### PR TITLE
Note list with filters, search, and sort

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,6 +3,7 @@ import { QueryProvider } from "@/providers/QueryProvider";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { AddVault } from "./routes/AddVault";
 import { Home } from "./routes/Home";
+import { Notes } from "./routes/Notes";
 import { OAuthCallback } from "./routes/OAuthCallback";
 import { Vaults } from "./routes/Vaults";
 
@@ -15,6 +16,7 @@ export function App() {
           <main>
             <Routes>
               <Route path="/" element={<Home />} />
+              <Route path="/notes" element={<Notes />} />
               <Route path="/add" element={<AddVault />} />
               <Route path="/oauth/callback" element={<OAuthCallback />} />
               <Route path="/vaults" element={<Vaults />} />

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -1,70 +1,29 @@
-import { useVaultInfo, useVaultStore } from "@/lib/vault";
-import { Link } from "react-router";
+import { useVaultStore } from "@/lib/vault";
+import { Link, Navigate } from "react-router";
 
 export function Home() {
   const activeVault = useVaultStore((s) => s.getActiveVault());
-  const info = useVaultInfo();
 
-  if (!activeVault) {
-    return (
-      <div className="mx-auto max-w-2xl px-6 py-20 text-center">
-        <p className="mb-8 font-serif text-xl italic text-fg-muted">
-          A lens onto any Parachute Vault.
-        </p>
-        <h1 className="mb-4 font-serif text-5xl tracking-tight">Lens</h1>
-        <p className="mb-10 text-fg-dim tracking-wide">
-          Point it at a vault. Sign in. Browse, edit, visualize.
-        </p>
-
-        <Link
-          to="/add"
-          className="inline-block rounded-md bg-accent px-6 py-3 text-sm font-medium text-white hover:bg-accent-hover"
-        >
-          Connect a vault
-        </Link>
-      </div>
-    );
+  if (activeVault) {
+    return <Navigate to="/notes" replace />;
   }
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-16">
-      <p className="mb-2 text-sm uppercase tracking-wider text-fg-dim">Connected vault</p>
-      <h1 className="mb-2 font-serif text-4xl tracking-tight">{activeVault.name}</h1>
-      <p className="mb-10 font-mono text-sm text-fg-muted">{activeVault.url}</p>
-
-      <div className="rounded-xl border border-border bg-card p-8 shadow-sm">
-        {info.isPending ? (
-          <p className="text-fg-muted">Loading vault info…</p>
-        ) : info.isError ? (
-          <div>
-            <p className="mb-1 font-medium text-red-400">Could not load vault info</p>
-            <p className="text-sm text-fg-muted">{info.error.message}</p>
-          </div>
-        ) : info.data ? (
-          <dl className="grid grid-cols-3 gap-8 text-center">
-            <div>
-              <dt className="text-xs uppercase tracking-wider text-fg-dim">Notes</dt>
-              <dd className="mt-2 font-serif text-3xl text-fg">
-                {info.data.stats?.noteCount ?? 0}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs uppercase tracking-wider text-fg-dim">Tags</dt>
-              <dd className="mt-2 font-serif text-3xl text-fg">{info.data.stats?.tagCount ?? 0}</dd>
-            </div>
-            <div>
-              <dt className="text-xs uppercase tracking-wider text-fg-dim">Links</dt>
-              <dd className="mt-2 font-serif text-3xl text-fg">
-                {info.data.stats?.linkCount ?? 0}
-              </dd>
-            </div>
-          </dl>
-        ) : null}
-      </div>
-
-      <p className="mt-8 text-sm text-fg-dim">
-        Note list and editor land in the next PRs. This page confirms the vault handshake works.
+    <div className="mx-auto max-w-2xl px-6 py-20 text-center">
+      <p className="mb-8 font-serif text-xl italic text-fg-muted">
+        A lens onto any Parachute Vault.
       </p>
+      <h1 className="mb-4 font-serif text-5xl tracking-tight">Lens</h1>
+      <p className="mb-10 text-fg-dim tracking-wide">
+        Point it at a vault. Sign in. Browse, edit, visualize.
+      </p>
+
+      <Link
+        to="/add"
+        className="inline-block rounded-md bg-accent px-6 py-3 text-sm font-medium text-white hover:bg-accent-hover"
+      >
+        Connect a vault
+      </Link>
     </div>
   );
 }

--- a/src/app/routes/Notes.test.tsx
+++ b/src/app/routes/Notes.test.tsx
@@ -1,0 +1,169 @@
+import { Notes } from "@/app/routes/Notes";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { BrowserRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FetchState {
+  notes: unknown[];
+  tags: unknown[];
+}
+
+function installFetch(state: FetchState) {
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = url.includes("/api/tags") ? state.tags : state.notes;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => "",
+    } as Response;
+  });
+  vi.stubGlobal("fetch", fetchImpl);
+  return fetchImpl;
+}
+
+function seedStore() {
+  // Directly mutate zustand state so we don't touch localStorage.
+  useVaultStore.setState({
+    vaults: {
+      dev: {
+        id: "dev",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "client-test",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "dev",
+  });
+  localStorage.setItem(
+    "lens:token:dev",
+    JSON.stringify({ accessToken: "pvt_abc", scope: "full", vault: "default" }),
+  );
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <BrowserRouter>{children}</BrowserRouter>
+    </QueryClientProvider>
+  );
+}
+
+function lastNotesUrl(fetchImpl: ReturnType<typeof installFetch>): string {
+  const calls = fetchImpl.mock.calls.map((c) => String(c[0]));
+  const noteCalls = calls.filter((u) => u.includes("/api/notes"));
+  return noteCalls[noteCalls.length - 1] ?? "";
+}
+
+describe("Notes route", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("renders fetched notes with path, preview, tags, and relative time", async () => {
+    installFetch({
+      notes: [
+        {
+          id: "n1",
+          path: "Projects/lens/README",
+          preview: "A lens onto any Parachute Vault.",
+          tags: ["project"],
+          createdAt: "2026-04-18T10:00:00.000Z",
+          updatedAt: "2026-04-18T11:00:00.000Z",
+        },
+      ],
+      tags: [{ name: "project", count: 1 }],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    const pathLink = await screen.findByText("Projects/lens/README");
+    expect(pathLink).toBeInTheDocument();
+    expect(screen.getByText(/A lens onto any Parachute Vault\./)).toBeInTheDocument();
+    // Tag chip should live inside the same row as the path.
+    const row = pathLink.closest("li");
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toContain("project");
+  });
+
+  it("debounces the search input and sends the search param after 300ms", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const fetchImpl = installFetch({ notes: [], tags: [] });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(fetchImpl.mock.calls.some((c) => String(c[0]).includes("/api/notes"))).toBe(true);
+    });
+
+    const input = screen.getByLabelText(/search notes/i);
+    fireEvent.change(input, { target: { value: "hello" } });
+
+    // Debounce: no search= yet right after typing.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(lastNotesUrl(fetchImpl)).not.toContain("search=hello");
+
+    // After the full debounce window, the search param lands on the URL.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    await waitFor(() => {
+      expect(lastNotesUrl(fetchImpl)).toContain("search=hello");
+    });
+  });
+
+  it("toggles sort direction via the header button", async () => {
+    const fetchImpl = installFetch({ notes: [], tags: [] });
+    render(<Notes />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(lastNotesUrl(fetchImpl)).toContain("sort=desc");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle sort/i }));
+
+    await waitFor(() => {
+      expect(lastNotesUrl(fetchImpl)).toContain("sort=asc");
+    });
+  });
+
+  it("shows empty state when no notes and no active filters", async () => {
+    installFetch({ notes: [], tags: [] });
+    render(<Notes />, { wrapper: Wrapper });
+    expect(await screen.findByText(/this vault has no notes yet/i)).toBeInTheDocument();
+  });
+
+  it("shows filtered-empty state and hides the zero-vault copy", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    installFetch({ notes: [], tags: [] });
+    render(<Notes />, { wrapper: Wrapper });
+
+    fireEvent.change(screen.getByLabelText(/search notes/i), { target: { value: "xyz" } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(await screen.findByText(/no notes match these filters/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -1,0 +1,310 @@
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { relativeTime } from "@/lib/time";
+import {
+  DEFAULT_NOTE_QUERY,
+  DEFAULT_PAGE_SIZE,
+  type NoteQueryState,
+  isFilteringActive,
+  useNotes,
+  useTags,
+  useVaultStore,
+} from "@/lib/vault";
+import { VaultAuthError } from "@/lib/vault/client";
+import type { Note, TagSummary } from "@/lib/vault/types";
+import { useEffect, useMemo, useState } from "react";
+import { Link, Navigate } from "react-router";
+
+export function Notes() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+
+  const [search, setSearch] = useState("");
+  const [pathPrefix, setPathPrefix] = useState("");
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagMatch, setTagMatch] = useState<"any" | "all">("any");
+  const [sort, setSort] = useState<"asc" | "desc">("desc");
+  const [offset, setOffset] = useState(0);
+
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const debouncedPrefix = useDebouncedValue(pathPrefix, 300);
+
+  // Any filter change resets pagination.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: offset is the target, not a trigger
+  useEffect(() => {
+    setOffset(0);
+  }, [debouncedSearch, debouncedPrefix, selectedTags, tagMatch, sort]);
+
+  const queryState: NoteQueryState = useMemo(
+    () => ({
+      ...DEFAULT_NOTE_QUERY,
+      search: debouncedSearch,
+      pathPrefix: debouncedPrefix,
+      tags: selectedTags,
+      tagMatch,
+      sort,
+      offset,
+    }),
+    [debouncedSearch, debouncedPrefix, selectedTags, tagMatch, sort, offset],
+  );
+
+  const notes = useNotes(queryState);
+  const tags = useTags();
+
+  if (!activeVault) return <Navigate to="/" replace />;
+
+  const pageFirst = offset + 1;
+  const pageLast = offset + (notes.data?.length ?? 0);
+  const hasPrev = offset > 0;
+  const hasNext = (notes.data?.length ?? 0) === DEFAULT_PAGE_SIZE;
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-6 flex items-baseline justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-fg-dim">{activeVault.name}</p>
+          <h1 className="font-serif text-3xl tracking-tight">Notes</h1>
+        </div>
+        <button
+          type="button"
+          onClick={() => setSort((s) => (s === "desc" ? "asc" : "desc"))}
+          className="text-sm text-fg-muted hover:text-accent"
+          aria-label="Toggle sort direction"
+        >
+          Sort: {sort === "desc" ? "newest" : "oldest"} first
+        </button>
+      </header>
+
+      <div className="mb-6 space-y-3">
+        <input
+          type="search"
+          placeholder="Search…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-fg focus:border-accent focus:outline-none"
+          aria-label="Search notes"
+        />
+        <div className="flex flex-wrap items-start gap-3">
+          <input
+            type="text"
+            placeholder="Path starts with…"
+            value={pathPrefix}
+            onChange={(e) => setPathPrefix(e.target.value)}
+            className="flex-1 min-w-48 rounded-md border border-border bg-card px-3 py-2 font-mono text-sm text-fg focus:border-accent focus:outline-none"
+            aria-label="Filter by path prefix"
+          />
+          <TagFilter
+            tags={tags.data ?? []}
+            selected={selectedTags}
+            onToggle={(name) =>
+              setSelectedTags((cur) =>
+                cur.includes(name) ? cur.filter((t) => t !== name) : [...cur, name],
+              )
+            }
+            tagMatch={tagMatch}
+            onTagMatchChange={setTagMatch}
+            onClear={() => setSelectedTags([])}
+          />
+        </div>
+      </div>
+
+      {notes.isPending ? (
+        <SkeletonRows />
+      ) : notes.isError ? (
+        <ErrorBlock error={notes.error} />
+      ) : notes.data && notes.data.length > 0 ? (
+        <ol className="divide-y divide-border rounded-md border border-border bg-card">
+          {notes.data.map((n) => (
+            <NoteRow key={n.id} note={n} />
+          ))}
+        </ol>
+      ) : (
+        <EmptyBlock filtering={isFilteringActive(queryState)} />
+      )}
+
+      <div className="mt-6 flex items-center justify-between text-sm text-fg-dim">
+        <span>
+          {notes.data && notes.data.length > 0
+            ? `Showing ${pageFirst}–${pageLast}`
+            : notes.isFetching
+              ? "Loading…"
+              : ""}
+        </span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={!hasPrev}
+            onClick={() => setOffset((o) => Math.max(0, o - DEFAULT_PAGE_SIZE))}
+            className="rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted enabled:hover:text-accent disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            disabled={!hasNext}
+            onClick={() => setOffset((o) => o + DEFAULT_PAGE_SIZE)}
+            className="rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted enabled:hover:text-accent disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NoteRow({ note }: { note: Note }) {
+  const label = note.path ?? note.id;
+  const stamp = note.updatedAt ?? note.createdAt;
+  return (
+    <li>
+      <Link
+        to={`/notes/${encodeURIComponent(note.id)}`}
+        className="block px-4 py-3 hover:bg-bg/60 focus:bg-bg/60 focus:outline-none"
+      >
+        <div className="flex items-baseline justify-between gap-4">
+          <span className="truncate font-mono text-sm text-fg">{label}</span>
+          <span className="shrink-0 text-xs text-fg-dim">{relativeTime(stamp)}</span>
+        </div>
+        {note.preview ? (
+          <p className="mt-1 truncate text-sm text-fg-muted">{note.preview}</p>
+        ) : null}
+        {note.tags && note.tags.length > 0 ? (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {note.tags.map((t) => (
+              <span
+                key={t}
+                className="rounded-full border border-border bg-bg/60 px-2 py-0.5 text-xs text-fg-dim"
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </Link>
+    </li>
+  );
+}
+
+function TagFilter({
+  tags,
+  selected,
+  onToggle,
+  tagMatch,
+  onTagMatchChange,
+  onClear,
+}: {
+  tags: TagSummary[];
+  selected: string[];
+  onToggle: (name: string) => void;
+  tagMatch: "any" | "all";
+  onTagMatchChange: (mode: "any" | "all") => void;
+  onClear: () => void;
+}) {
+  return (
+    <details className="rounded-md border border-border bg-card text-sm">
+      <summary className="cursor-pointer list-none px-3 py-2 text-fg-muted hover:text-accent">
+        Tags{selected.length > 0 ? ` (${selected.length})` : ""}
+      </summary>
+      <div className="border-t border-border p-3">
+        {selected.length > 1 ? (
+          <fieldset className="mb-3 flex items-center gap-3 text-xs">
+            <legend className="sr-only">Match mode</legend>
+            <label className="flex items-center gap-1.5">
+              <input
+                type="radio"
+                name="tag-match"
+                value="any"
+                checked={tagMatch === "any"}
+                onChange={() => onTagMatchChange("any")}
+              />
+              Any
+            </label>
+            <label className="flex items-center gap-1.5">
+              <input
+                type="radio"
+                name="tag-match"
+                value="all"
+                checked={tagMatch === "all"}
+                onChange={() => onTagMatchChange("all")}
+              />
+              All
+            </label>
+            <button
+              type="button"
+              onClick={onClear}
+              className="ml-auto text-xs text-fg-dim hover:text-accent"
+            >
+              Clear
+            </button>
+          </fieldset>
+        ) : null}
+        {tags.length === 0 ? (
+          <p className="text-xs text-fg-dim">No tags in this vault.</p>
+        ) : (
+          <ul className="max-h-56 space-y-1 overflow-y-auto pr-1">
+            {tags.map((t) => (
+              <li key={t.name}>
+                <label className="flex items-center gap-2 text-sm text-fg hover:text-accent">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(t.name)}
+                    onChange={() => onToggle(t.name)}
+                  />
+                  <span className="flex-1 truncate">{t.name}</span>
+                  <span className="text-xs text-fg-dim">{t.count}</span>
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function SkeletonRows() {
+  return (
+    <ol className="divide-y divide-border rounded-md border border-border bg-card" aria-busy="true">
+      {[0, 1, 2, 3, 4].map((i) => (
+        <li key={i} className="px-4 py-3">
+          <div className="h-4 w-1/3 animate-pulse rounded bg-border/60" />
+          <div className="mt-2 h-3 w-2/3 animate-pulse rounded bg-border/40" />
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function ErrorBlock({ error }: { error: Error }) {
+  const isAuth = error instanceof VaultAuthError;
+  return (
+    <div className="rounded-md border border-red-500/30 bg-red-500/5 p-6">
+      <p className="mb-2 font-medium text-red-400">
+        {isAuth ? "Session expired" : "Could not load notes"}
+      </p>
+      <p className="mb-4 text-sm text-fg-muted">{error.message}</p>
+      {isAuth ? (
+        <Link
+          to="/add"
+          className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Reconnect vault
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+function EmptyBlock({ filtering }: { filtering: boolean }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-10 text-center">
+      {filtering ? (
+        <p className="text-fg-muted">No notes match these filters.</p>
+      ) : (
+        <>
+          <p className="mb-1 text-fg-muted">This vault has no notes yet.</p>
+          <p className="text-sm text-fg-dim">Creating notes lands in a later PR.</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/src/lib/time.test.ts
+++ b/src/lib/time.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { relativeTime } from "./time";
+
+const NOW = new Date("2026-04-18T12:00:00.000Z");
+
+describe("relativeTime", () => {
+  it("returns empty string for undefined or invalid dates", () => {
+    expect(relativeTime(undefined, NOW)).toBe("");
+    expect(relativeTime("not a date", NOW)).toBe("");
+  });
+
+  it("says 'just now' under one minute", () => {
+    expect(relativeTime("2026-04-18T11:59:30.000Z", NOW)).toBe("just now");
+  });
+
+  it("formats minutes, hours, days, weeks, months, years", () => {
+    expect(relativeTime("2026-04-18T11:55:00.000Z", NOW)).toBe("5m ago");
+    expect(relativeTime("2026-04-18T09:00:00.000Z", NOW)).toBe("3h ago");
+    expect(relativeTime("2026-04-16T12:00:00.000Z", NOW)).toBe("2d ago");
+    expect(relativeTime("2026-04-04T12:00:00.000Z", NOW)).toBe("2w ago");
+    expect(relativeTime("2026-01-18T12:00:00.000Z", NOW)).toBe("3mo ago");
+    expect(relativeTime("2024-04-18T12:00:00.000Z", NOW)).toBe("2y ago");
+  });
+
+  it("handles future dates with 'in' prefix", () => {
+    expect(relativeTime("2026-04-20T12:00:00.000Z", NOW)).toBe("in 2d");
+  });
+});

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,24 @@
+const UNITS: Array<[string, number]> = [
+  ["y", 365 * 24 * 60 * 60 * 1000],
+  ["mo", 30 * 24 * 60 * 60 * 1000],
+  ["w", 7 * 24 * 60 * 60 * 1000],
+  ["d", 24 * 60 * 60 * 1000],
+  ["h", 60 * 60 * 1000],
+  ["m", 60 * 1000],
+];
+
+export function relativeTime(iso: string | undefined, now: Date = new Date()): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  const t = date.getTime();
+  if (Number.isNaN(t)) return "";
+  const diff = now.getTime() - t;
+  const abs = Math.abs(diff);
+  for (const [label, ms] of UNITS) {
+    if (abs >= ms) {
+      const n = Math.floor(abs / ms);
+      return diff >= 0 ? `${n}${label} ago` : `in ${n}${label}`;
+    }
+  }
+  return "just now";
+}

--- a/src/lib/vault/client.test.ts
+++ b/src/lib/vault/client.test.ts
@@ -57,4 +57,52 @@ describe("VaultClient", () => {
     await client.vaultInfo(false);
     expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/vault");
   });
+
+  it("queryNotes passes URLSearchParams to /api/notes and parses the array", async () => {
+    const fetchImpl = mockFetch({
+      json: [{ id: "a", createdAt: "2026-04-18T00:00:00Z", tags: ["daily"] }],
+    });
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+
+    const params = new URLSearchParams({ search: "hello", sort: "desc", limit: "50" });
+    const rows = await client.queryNotes(params);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.tags).toEqual(["daily"]);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+      "http://localhost:1940/api/notes?search=hello&sort=desc&limit=50",
+    );
+  });
+
+  it("queryNotes omits the querystring entirely when params are empty", async () => {
+    const fetchImpl = mockFetch({ json: [] });
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+    await client.queryNotes(new URLSearchParams());
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/notes");
+  });
+
+  it("listTags hits /api/tags and returns the summary array", async () => {
+    const fetchImpl = mockFetch({
+      json: [
+        { name: "daily", count: 42 },
+        { name: "work", count: 7 },
+      ],
+    });
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+    const tags = await client.listTags();
+    expect(tags).toHaveLength(2);
+    expect(tags[0]).toEqual({ name: "daily", count: 42 });
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/tags");
+  });
 });

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -1,4 +1,4 @@
-import type { VaultInfo } from "./types";
+import type { Note, TagSummary, VaultInfo } from "./types";
 
 export interface VaultClientOptions {
   vaultUrl: string;
@@ -48,5 +48,14 @@ export class VaultClient {
   async vaultInfo(includeStats = true): Promise<VaultInfo> {
     const query = includeStats ? "?include_stats=true" : "";
     return this.request<VaultInfo>(`/api/vault${query}`);
+  }
+
+  async queryNotes(params: URLSearchParams): Promise<Note[]> {
+    const qs = params.toString();
+    return this.request<Note[]>(`/api/notes${qs ? `?${qs}` : ""}`);
+  }
+
+  async listTags(): Promise<TagSummary[]> {
+    return this.request<TagSummary[]>("/api/tags");
   }
 }

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -1,5 +1,6 @@
 export * from "./client";
 export * from "./discovery";
+export * from "./note-query";
 export * from "./oauth";
 export * from "./pkce";
 export * from "./queries";

--- a/src/lib/vault/note-query.test.ts
+++ b/src/lib/vault/note-query.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_NOTE_QUERY,
+  type NoteQueryState,
+  buildNoteQueryParams,
+  isFilteringActive,
+} from "./note-query";
+
+function state(overrides: Partial<NoteQueryState> = {}): NoteQueryState {
+  return { ...DEFAULT_NOTE_QUERY, ...overrides };
+}
+
+describe("buildNoteQueryParams", () => {
+  it("emits sort and limit even with no filters", () => {
+    const params = buildNoteQueryParams(state());
+    expect(params.get("sort")).toBe("desc");
+    expect(params.get("limit")).toBe("50");
+    expect(params.get("search")).toBeNull();
+    expect(params.get("tag")).toBeNull();
+    expect(params.get("offset")).toBeNull();
+  });
+
+  it("omits offset when zero, emits when positive", () => {
+    expect(buildNoteQueryParams(state({ offset: 0 })).get("offset")).toBeNull();
+    expect(buildNoteQueryParams(state({ offset: 50 })).get("offset")).toBe("50");
+  });
+
+  it("trims whitespace from search and drops when blank", () => {
+    expect(buildNoteQueryParams(state({ search: "   " })).get("search")).toBeNull();
+    expect(buildNoteQueryParams(state({ search: "  hello  " })).get("search")).toBe("hello");
+  });
+
+  it("joins tags comma-separated", () => {
+    const params = buildNoteQueryParams(state({ tags: ["daily", "work"] }));
+    expect(params.get("tag")).toBe("daily,work");
+  });
+
+  it("includes tag_match only when 2+ tags are selected", () => {
+    expect(
+      buildNoteQueryParams(state({ tags: ["daily"], tagMatch: "all" })).get("tag_match"),
+    ).toBeNull();
+    expect(
+      buildNoteQueryParams(state({ tags: ["daily", "work"], tagMatch: "all" })).get("tag_match"),
+    ).toBe("all");
+    expect(
+      buildNoteQueryParams(state({ tags: ["daily", "work"], tagMatch: "any" })).get("tag_match"),
+    ).toBe("any");
+  });
+
+  it("passes path_prefix when present, trims blanks", () => {
+    expect(buildNoteQueryParams(state({ pathPrefix: "   " })).get("path_prefix")).toBeNull();
+    expect(buildNoteQueryParams(state({ pathPrefix: " Projects/" })).get("path_prefix")).toBe(
+      "Projects/",
+    );
+  });
+
+  it("respects explicit sort direction", () => {
+    expect(buildNoteQueryParams(state({ sort: "asc" })).get("sort")).toBe("asc");
+  });
+});
+
+describe("isFilteringActive", () => {
+  it("is false by default", () => {
+    expect(isFilteringActive(state())).toBe(false);
+  });
+
+  it("is true when any filter is set", () => {
+    expect(isFilteringActive(state({ search: "foo" }))).toBe(true);
+    expect(isFilteringActive(state({ tags: ["daily"] }))).toBe(true);
+    expect(isFilteringActive(state({ pathPrefix: "Projects/" }))).toBe(true);
+  });
+
+  it("ignores trivially-blank search/prefix", () => {
+    expect(isFilteringActive(state({ search: "   " }))).toBe(false);
+    expect(isFilteringActive(state({ pathPrefix: "   " }))).toBe(false);
+  });
+});

--- a/src/lib/vault/note-query.ts
+++ b/src/lib/vault/note-query.ts
@@ -1,0 +1,47 @@
+export interface NoteQueryState {
+  search: string;
+  tags: string[];
+  tagMatch: "any" | "all";
+  pathPrefix: string;
+  sort: "asc" | "desc";
+  limit: number;
+  offset: number;
+}
+
+export const DEFAULT_PAGE_SIZE = 50;
+
+export const DEFAULT_NOTE_QUERY: NoteQueryState = {
+  search: "",
+  tags: [],
+  tagMatch: "any",
+  pathPrefix: "",
+  sort: "desc",
+  limit: DEFAULT_PAGE_SIZE,
+  offset: 0,
+};
+
+export function buildNoteQueryParams(state: NoteQueryState): URLSearchParams {
+  const params = new URLSearchParams();
+  const search = state.search.trim();
+  if (search) params.set("search", search);
+
+  if (state.tags.length > 0) {
+    params.set("tag", state.tags.join(","));
+    if (state.tags.length > 1) params.set("tag_match", state.tagMatch);
+  }
+
+  const prefix = state.pathPrefix.trim();
+  if (prefix) params.set("path_prefix", prefix);
+
+  params.set("sort", state.sort);
+  params.set("limit", String(state.limit));
+  if (state.offset > 0) params.set("offset", String(state.offset));
+
+  return params;
+}
+
+export function isFilteringActive(state: NoteQueryState): boolean {
+  return (
+    state.search.trim().length > 0 || state.tags.length > 0 || state.pathPrefix.trim().length > 0
+  );
+}

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -1,12 +1,19 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { VaultClient } from "./client";
+import { type NoteQueryState, buildNoteQueryParams } from "./note-query";
+import { loadToken } from "./storage";
 import { useVaultStore } from "./store";
 
 export function useActiveVaultClient(): VaultClient | null {
   const vault = useVaultStore((s) => s.getActiveVault());
-  const token = useVaultStore((s) => s.getActiveToken());
-  if (!vault || !token) return null;
-  return new VaultClient({ vaultUrl: vault.url, accessToken: token.accessToken });
+  const activeId = useVaultStore((s) => s.activeVaultId);
+  return useMemo(() => {
+    if (!vault || !activeId) return null;
+    const token = loadToken(activeId);
+    if (!token) return null;
+    return new VaultClient({ vaultUrl: vault.url, accessToken: token.accessToken });
+  }, [vault, activeId]);
 }
 
 export function useVaultInfo() {
@@ -18,5 +25,30 @@ export function useVaultInfo() {
     enabled: !!client,
     queryFn: () => client!.vaultInfo(true),
     staleTime: 30_000,
+  });
+}
+
+export function useNotes(queryState: NoteQueryState) {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+
+  return useQuery({
+    queryKey: ["notes", activeId, queryState],
+    enabled: !!client,
+    queryFn: () => client!.queryNotes(buildNoteQueryParams(queryState)),
+    staleTime: 10_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useTags() {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+
+  return useQuery({
+    queryKey: ["tags", activeId],
+    enabled: !!client,
+    queryFn: () => client!.listTags(),
+    staleTime: 60_000,
   });
 }

--- a/src/lib/vault/types.ts
+++ b/src/lib/vault/types.ts
@@ -52,6 +52,23 @@ export interface VaultInfo {
   };
 }
 
+export interface Note {
+  id: string;
+  path?: string;
+  createdAt: string;
+  updatedAt?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  preview?: string;
+  byteSize?: number;
+  content?: string;
+}
+
+export interface TagSummary {
+  name: string;
+  count: number;
+}
+
 export interface PendingOAuthState {
   vaultUrl: string;
   issuer: string;


### PR DESCRIPTION
## Summary
- New `/notes` route is the default landing for a connected vault (`/` redirects when a vault is active). Filter surface: full-text search, multi-select tag filter with any/all match toggle, path prefix, and createdAt asc/desc sort.
- Search and path prefix inputs are debounced 300ms via a `useDebouncedValue` hook so each keystroke doesn't fire a request. Pagination is server-side `limit=50` + `offset`; Next disables when a page returns fewer than `limit` rows.
- Row layout shows path (or `id` fallback), `preview`, tag chips, and a relative-time stamp derived from `updatedAt ?? createdAt`.
- Extended `VaultClient` with `queryNotes(params)` and `listTags()`. Added pure `buildNoteQueryParams(state)` helper and `isFilteringActive(state)` — together those are the testable query-layer core.
- Empty state distinguishes "no notes yet" from "no notes match these filters". `VaultAuthError` routes through to a Reconnect button that sends the user to `/add`; skeleton rows on initial load; `keepPreviousData` keeps the previous page visible during refetch.

## Latent bug squashed in passing
`useActiveVaultClient()` used a zustand selector that called `loadToken()`, which `JSON.parse`s on every invocation and returns a new object identity each render. With no vault present (PR #1/#2 tests) this was harmless — the path returned `null`. With a token in the store, it pushed consumers into an infinite re-render loop. Moved the token lookup into `useMemo` keyed on `activeVaultId`.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` — 55/55 pass (10 query-builder, 4 relative-time, 6 client, 5 Notes route, 30 pre-existing)
- [x] `bun run build` succeeds (295 KB JS / 93 KB gzip)
- [x] `bun run dev` serves `/notes` at 200
- [ ] Manual: point at a real vault and verify filter combinations, pagination, and the skeleton/empty/error states
- [ ] Manual: expire a token and confirm the Reconnect flow

## Out of scope
- Note view at `/notes/:id` (PR #4) — list rows link there as placeholders
- Create/edit/delete (PR #5/#6)
- Graph badges on rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)