### PR TITLE
Note view with rendered markdown, wikilinks, and attachments

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,13 @@
       "name": "@openparachute/lens",
       "dependencies": {
         "@tanstack/react-query": "^5",
+        "highlight.js": "^11.11.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-markdown": "^10.1.0",
         "react-router": "^7",
+        "rehype-highlight": "^7.0.2",
+        "remark-gfm": "^4.0.1",
         "zustand": "^5",
       },
       "devDependencies": {
@@ -22,8 +26,11 @@
         "@types/react-dom": "^19.1.0",
         "@vitejs/plugin-react": "^4.3.0",
         "jsdom": "^25.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
         "tailwindcss": "^4.1.0",
         "typescript": "~5.6.0",
+        "unified": "^11.0.5",
         "vite": "^6.0.0",
         "vitest": "^3",
       },
@@ -268,15 +275,29 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -306,6 +327,8 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
@@ -316,11 +339,23 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -338,6 +373,8 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
@@ -345,6 +382,8 @@
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
@@ -370,9 +409,15 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -398,7 +443,19 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
+
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -407,6 +464,18 @@
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
+    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
@@ -444,7 +513,11 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lowlight": ["lowlight@3.3.0", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.0.0", "highlight.js": "~11.11.0" } }, "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -452,7 +525,95 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -468,6 +629,8 @@
 
     "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
 
+    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
@@ -482,6 +645,8 @@
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
@@ -490,11 +655,23 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
     "react-router": ["react-router@7.14.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "rehype-highlight": ["rehype-highlight@7.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-text": "^4.0.0", "lowlight": "^3.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
@@ -514,13 +691,21 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
@@ -548,11 +733,33 @@
 
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
     "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-find-after": ["unist-util-find-after@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
@@ -582,6 +789,8 @@
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
@@ -599,6 +808,8 @@
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,13 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5",
+    "highlight.js": "^11.11.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-markdown": "^10.1.0",
     "react-router": "^7",
+    "rehype-highlight": "^7.0.2",
+    "remark-gfm": "^4.0.1",
     "zustand": "^5"
   },
   "devDependencies": {
@@ -38,8 +42,11 @@
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.0",
     "jsdom": "^25.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
     "tailwindcss": "^4.1.0",
     "typescript": "~5.6.0",
+    "unified": "^11.0.5",
     "vite": "^6.0.0",
     "vitest": "^3"
   }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,6 +3,7 @@ import { QueryProvider } from "@/providers/QueryProvider";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { AddVault } from "./routes/AddVault";
 import { Home } from "./routes/Home";
+import { NoteView } from "./routes/NoteView";
 import { Notes } from "./routes/Notes";
 import { OAuthCallback } from "./routes/OAuthCallback";
 import { Vaults } from "./routes/Vaults";
@@ -17,6 +18,7 @@ export function App() {
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/notes" element={<Notes />} />
+              <Route path="/notes/:id" element={<NoteView />} />
               <Route path="/add" element={<AddVault />} />
               <Route path="/oauth/callback" element={<OAuthCallback />} />
               <Route path="/vaults" element={<Vaults />} />

--- a/src/app/routes/NoteView.test.tsx
+++ b/src/app/routes/NoteView.test.tsx
@@ -1,0 +1,265 @@
+import { NoteView } from "@/app/routes/NoteView";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FetchMap {
+  [urlMatcher: string]: { status?: number; body: unknown };
+}
+
+function installFetch(map: FetchMap) {
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    for (const matcher of Object.keys(map)) {
+      if (url.includes(matcher)) {
+        const entry = map[matcher];
+        return {
+          ok: (entry.status ?? 200) < 400,
+          status: entry.status ?? 200,
+          json: async () => entry.body,
+          text: async () => "",
+          blob: async () => new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" }),
+        } as Response;
+      }
+    }
+    return {
+      ok: false,
+      status: 404,
+      json: async () => null,
+      text: async () => "",
+    } as Response;
+  });
+  vi.stubGlobal("fetch", fetchImpl);
+  return fetchImpl;
+}
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      dev: {
+        id: "dev",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "client-test",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "dev",
+  });
+  localStorage.setItem(
+    "lens:token:dev",
+    JSON.stringify({ accessToken: "pvt_abc", scope: "full", vault: "default" }),
+  );
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/notes/:id" element={<NoteView />} />
+        <Route path="/notes" element={<div>NotesListPage</div>} />
+        <Route path="/add" element={<div>AddVaultPage</div>} />
+        <Route path="*" element={<div>Other</div>} />
+      </Routes>
+    </MemoryRouter>,
+    { wrapper: Wrapper },
+  );
+}
+
+describe("NoteView route", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders markdown content, metadata, tags, and back link", async () => {
+    installFetch({
+      "/api/notes": {
+        body: {
+          id: "abc-123",
+          path: "Canon/Aaron",
+          createdAt: "2026-04-16T04:30:54.177Z",
+          updatedAt: "2026-04-17T00:05:07.721Z",
+          content: "# Aaron Gabriel\n\nTeacher and builder.",
+          metadata: { summary: "Canon note on Aaron." },
+          tags: ["canon"],
+          links: [],
+          attachments: [],
+        },
+      },
+    });
+
+    renderAt("/notes/abc-123");
+
+    expect(await screen.findByText("Aaron Gabriel")).toBeInTheDocument();
+    expect(screen.getByText("Teacher and builder.")).toBeInTheDocument();
+    expect(screen.getByText("Canon note on Aaron.")).toBeInTheDocument();
+    // Tag chip links to the filtered list
+    const tagChip = screen.getByRole("link", { name: "canon" });
+    expect(tagChip).toHaveAttribute("href", "/notes?tag=canon");
+    // Back link to /notes is present
+    expect(screen.getByRole("link", { name: /all notes/i })).toBeInTheDocument();
+    // Edit placeholder routes to the edit route (PR #5)
+    expect(screen.getByRole("link", { name: /edit/i })).toHaveAttribute(
+      "href",
+      "/notes/abc-123/edit",
+    );
+  });
+
+  it("resolves [[wikilinks]] via the outbound links table and renders as a /notes/<id> link", async () => {
+    installFetch({
+      "/api/notes": {
+        body: {
+          id: "me",
+          path: "Canon/Aaron",
+          createdAt: "2026-04-16T00:00:00Z",
+          content: "See [[Canon/Uni]] for more. Also [[Missing/Note]].",
+          tags: [],
+          links: [
+            {
+              sourceId: "me",
+              targetId: "uni-id",
+              relationship: "wikilink",
+              targetNote: { id: "uni-id", path: "Canon/Uni" },
+            },
+          ],
+          attachments: [],
+        },
+      },
+    });
+
+    const { container } = renderAt("/notes/me");
+
+    // Prefer the in-body wikilink (not the sidebar) via container scoping.
+    await screen.findByText(/See/);
+    const body = container.querySelector(".prose-note");
+    expect(body).not.toBeNull();
+    const resolvedLinks = Array.from(
+      body!.querySelectorAll<HTMLAnchorElement>("a.wikilink-resolved"),
+    );
+    expect(resolvedLinks).toHaveLength(1);
+    expect(resolvedLinks[0]).toHaveAttribute("href", "/notes/uni-id");
+    expect(resolvedLinks[0]?.textContent).toBe("Canon/Uni");
+
+    const unresolvedLinks = Array.from(
+      body!.querySelectorAll<HTMLAnchorElement>("a.wikilink-unresolved"),
+    );
+    expect(unresolvedLinks).toHaveLength(1);
+    expect(unresolvedLinks[0]).toHaveAttribute("href", "/notes/Missing%2FNote");
+    expect(unresolvedLinks[0]?.textContent).toBe("Missing/Note");
+  });
+
+  it("renders inbound and outbound link panels with peer paths", async () => {
+    installFetch({
+      "/api/notes": {
+        body: {
+          id: "center",
+          path: "hub",
+          createdAt: "2026-04-16T00:00:00Z",
+          content: "Hub.",
+          tags: [],
+          links: [
+            {
+              sourceId: "center",
+              targetId: "out-1",
+              relationship: "wikilink",
+              targetNote: { id: "out-1", path: "Outbound/One" },
+            },
+            {
+              sourceId: "in-1",
+              targetId: "center",
+              relationship: "wikilink",
+              sourceNote: { id: "in-1", path: "Inbound/One" },
+            },
+          ],
+          attachments: [],
+        },
+      },
+    });
+
+    renderAt("/notes/center");
+
+    expect(await screen.findByRole("heading", { name: /Outbound \(1\)/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Inbound \(1\)/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Outbound\/One/ })).toHaveAttribute(
+      "href",
+      "/notes/out-1",
+    );
+    expect(screen.getByRole("link", { name: /Inbound\/One/ })).toHaveAttribute(
+      "href",
+      "/notes/in-1",
+    );
+  });
+
+  it("renders an inline image attachment (blob-fetched through VaultClient)", async () => {
+    installFetch({
+      "/api/notes": {
+        body: {
+          id: "with-img",
+          path: "media",
+          createdAt: "2026-04-16T00:00:00Z",
+          content: "pic",
+          tags: [],
+          links: [],
+          attachments: [
+            {
+              id: "att-1",
+              filename: "hero.png",
+              mimeType: "image/png",
+              url: "/attachments/att-1",
+              size: 2048,
+            },
+          ],
+        },
+      },
+      "/attachments/att-1": { body: null },
+    });
+    const origCreate = URL.createObjectURL;
+    URL.createObjectURL = vi.fn(() => "blob:fake-url");
+    URL.revokeObjectURL = vi.fn();
+
+    renderAt("/notes/with-img");
+
+    const img = (await screen.findByAltText("hero.png")) as HTMLImageElement;
+    await waitFor(() => {
+      expect(img.src).toContain("blob:fake-url");
+    });
+    URL.createObjectURL = origCreate;
+  });
+
+  it("shows a 404 block when the vault returns no note for the id", async () => {
+    installFetch({
+      "/api/notes": { body: [] },
+    });
+    renderAt("/notes/nonexistent");
+    expect(await screen.findByText(/note not found/i)).toBeInTheDocument();
+  });
+
+  it("routes through Reconnect on 401", async () => {
+    installFetch({
+      "/api/notes": { status: 401, body: null },
+    });
+    renderAt("/notes/any");
+    expect(await screen.findByText(/session expired/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /reconnect/i })).toHaveAttribute("href", "/add");
+  });
+});

--- a/src/app/routes/NoteView.tsx
+++ b/src/app/routes/NoteView.tsx
@@ -1,0 +1,472 @@
+import { type WikilinkResolver, remarkWikilinks } from "@/lib/markdown/remark-wikilinks";
+import { relativeTime } from "@/lib/time";
+import { useActiveVaultClient, useNote, useVaultStore } from "@/lib/vault";
+import { VaultAuthError } from "@/lib/vault/client";
+import type { Note, NoteAttachment, NoteLink } from "@/lib/vault/types";
+import { useEffect, useMemo, useState } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import { Link, Navigate, useParams } from "react-router";
+import rehypeHighlight from "rehype-highlight";
+import remarkGfm from "remark-gfm";
+
+export function NoteView() {
+  const { id } = useParams<{ id: string }>();
+  const decodedId = id ? decodeURIComponent(id) : undefined;
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const note = useNote(decodedId);
+
+  if (!activeVault) return <Navigate to="/" replace />;
+
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-10">
+      <nav className="mb-6 text-sm text-fg-dim">
+        <Link to="/notes" className="hover:text-accent">
+          ← All notes
+        </Link>
+      </nav>
+
+      {note.isPending ? (
+        <NoteSkeleton />
+      ) : note.isError ? (
+        <ErrorBlock error={note.error} />
+      ) : !note.data ? (
+        <NotFoundBlock id={decodedId ?? ""} />
+      ) : (
+        <NoteBody note={note.data} />
+      )}
+    </div>
+  );
+}
+
+function NoteBody({ note }: { note: Note }) {
+  const resolver = useMemo(() => buildWikilinkResolver(note), [note]);
+  const label = note.path ?? note.id;
+  const summary = typeof note.metadata?.summary === "string" ? note.metadata.summary : null;
+  const inbound = useMemo(
+    () =>
+      (note.links ?? []).filter(
+        (l) => l.targetId === note.id && l.sourceId !== note.id && l.sourceNote,
+      ),
+    [note],
+  );
+  const outbound = useMemo(() => {
+    const seen = new Set<string>();
+    const out: NoteLink[] = [];
+    for (const l of note.links ?? []) {
+      if (l.sourceId !== note.id || l.targetId === note.id) continue;
+      if (!l.targetNote) continue;
+      if (seen.has(l.targetId)) continue;
+      seen.add(l.targetId);
+      out.push(l);
+    }
+    return out;
+  }, [note]);
+
+  return (
+    <article className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem]">
+      <div className="min-w-0">
+        <header className="mb-6 border-b border-border pb-4">
+          <p className="font-mono text-xs text-fg-dim break-all">{label}</p>
+          <h1 className="mt-1 font-serif text-3xl tracking-tight">
+            {note.path ? pathTitle(note.path) : note.id}
+          </h1>
+          {summary ? <p className="mt-3 text-fg-muted">{summary}</p> : null}
+          <div className="mt-4 flex items-center gap-2">
+            <Link
+              to={`/notes/${encodeURIComponent(note.id)}/edit`}
+              className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-fg-muted hover:text-accent"
+            >
+              Edit
+            </Link>
+            <button
+              type="button"
+              disabled
+              className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-fg-dim opacity-50"
+              title="Delete lands in PR #6"
+            >
+              Delete
+            </button>
+          </div>
+        </header>
+
+        <MarkdownView content={note.content ?? ""} resolve={resolver} />
+
+        {note.attachments && note.attachments.length > 0 ? (
+          <section className="mt-10 border-t border-border pt-6">
+            <h2 className="mb-3 font-serif text-xl">Attachments</h2>
+            <div className="space-y-6">
+              {note.attachments.map((a) => (
+                <AttachmentView key={a.id} attachment={a} />
+              ))}
+            </div>
+          </section>
+        ) : null}
+      </div>
+
+      <aside className="space-y-6 text-sm lg:sticky lg:top-24 lg:self-start">
+        <MetadataPanel note={note} />
+        {note.tags && note.tags.length > 0 ? <TagsPanel tags={note.tags} /> : null}
+        {outbound.length > 0 ? (
+          <LinksPanel title="Outbound" links={outbound} peer="target" />
+        ) : null}
+        {inbound.length > 0 ? <LinksPanel title="Inbound" links={inbound} peer="source" /> : null}
+      </aside>
+    </article>
+  );
+}
+
+function pathTitle(path: string): string {
+  const last = path.split("/").pop() ?? path;
+  return last.replace(/\.md$/i, "");
+}
+
+function buildWikilinkResolver(note: Note): WikilinkResolver {
+  const map = new Map<string, string>();
+  for (const l of note.links ?? []) {
+    if (l.sourceId !== note.id || !l.targetNote) continue;
+    if (l.targetNote.path) map.set(l.targetNote.path, l.targetNote.id);
+    map.set(l.targetNote.id, l.targetNote.id);
+  }
+  return (target) => {
+    const id = map.get(target);
+    return id ? { id } : null;
+  };
+}
+
+const MARKDOWN_COMPONENTS: Components = {
+  a({ node: _node, href, className, children, ...rest }) {
+    const classes = className ?? "";
+    if (classes.includes("wikilink")) {
+      const styleCls = classes.includes("wikilink-resolved")
+        ? "text-accent hover:underline"
+        : "text-fg-dim underline decoration-dashed underline-offset-4 hover:text-fg";
+      return (
+        <Link
+          to={href ?? "#"}
+          className={`${classes} ${styleCls}`}
+          {...(rest as Record<string, unknown>)}
+        >
+          {children}
+        </Link>
+      );
+    }
+    if (href && (href.startsWith("/") || href.startsWith("#"))) {
+      return (
+        <Link to={href} className="text-accent hover:underline">
+          {children}
+        </Link>
+      );
+    }
+    return (
+      <a
+        href={href}
+        className="text-accent hover:underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {children}
+      </a>
+    );
+  },
+};
+
+function MarkdownView({ content, resolve }: { content: string; resolve: WikilinkResolver }) {
+  return (
+    <div className="prose-note">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, [remarkWikilinks, { resolve }]]}
+        rehypePlugins={[rehypeHighlight]}
+        components={MARKDOWN_COMPONENTS}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+function MetadataPanel({ note }: { note: Note }) {
+  const created = note.createdAt;
+  const updated = note.updatedAt;
+  const metaEntries = Object.entries(note.metadata ?? {}).filter(([key]) => key !== "summary");
+
+  return (
+    <section className="rounded-md border border-border bg-card p-4">
+      <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">Metadata</h2>
+      <dl className="space-y-1.5 text-sm">
+        {note.path ? (
+          <Row
+            label="Path"
+            value={<span className="font-mono text-xs break-all">{note.path}</span>}
+          />
+        ) : null}
+        <Row label="ID" value={<span className="font-mono text-xs break-all">{note.id}</span>} />
+        <Row label="Created" value={<time title={created}>{relativeTime(created)}</time>} />
+        {updated ? (
+          <Row label="Updated" value={<time title={updated}>{relativeTime(updated)}</time>} />
+        ) : null}
+        {metaEntries.map(([key, value]) => (
+          <Row
+            key={key}
+            label={key}
+            value={<span className="break-all text-fg-muted">{String(value)}</span>}
+          />
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-xs uppercase tracking-wider text-fg-dim">{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function TagsPanel({ tags }: { tags: string[] }) {
+  return (
+    <section className="rounded-md border border-border bg-card p-4">
+      <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">Tags</h2>
+      <div className="flex flex-wrap gap-1.5">
+        {tags.map((t) => (
+          <Link
+            key={t}
+            to={`/notes?tag=${encodeURIComponent(t)}`}
+            className="rounded-full border border-border bg-bg/60 px-2 py-0.5 text-xs text-fg-dim hover:text-accent"
+          >
+            {t}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function LinksPanel({
+  title,
+  links,
+  peer,
+}: {
+  title: string;
+  links: NoteLink[];
+  peer: "source" | "target";
+}) {
+  return (
+    <section className="rounded-md border border-border bg-card p-4">
+      <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">
+        {title} ({links.length})
+      </h2>
+      <ul className="space-y-1.5">
+        {links.map((l) => {
+          const peerNote = peer === "source" ? l.sourceNote : l.targetNote;
+          if (!peerNote) return null;
+          const label = peerNote.path ?? peerNote.id;
+          const summary =
+            typeof peerNote.metadata?.summary === "string" ? peerNote.metadata.summary : null;
+          return (
+            <li key={`${l.sourceId}->${l.targetId}:${l.relationship}`}>
+              <Link
+                to={`/notes/${encodeURIComponent(peerNote.id)}`}
+                className="block rounded px-1 py-0.5 hover:bg-bg/50"
+              >
+                <div className="truncate font-mono text-xs text-fg-muted hover:text-accent">
+                  {label}
+                </div>
+                {summary ? (
+                  <div className="mt-0.5 line-clamp-2 text-xs text-fg-dim">{summary}</div>
+                ) : null}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function AttachmentView({ attachment }: { attachment: NoteAttachment }) {
+  const mime = (attachment.mimeType ?? "").toLowerCase();
+  const filename = attachment.filename ?? attachment.id;
+
+  return (
+    <figure className="rounded-md border border-border bg-card p-3">
+      <figcaption className="mb-2 flex items-baseline justify-between gap-3">
+        <span className="truncate font-mono text-xs text-fg-muted">{filename}</span>
+        {typeof attachment.size === "number" ? (
+          <span className="shrink-0 text-xs text-fg-dim">{formatBytes(attachment.size)}</span>
+        ) : null}
+      </figcaption>
+      <AttachmentBody attachment={attachment} mime={mime} filename={filename} />
+    </figure>
+  );
+}
+
+function AttachmentBody({
+  attachment,
+  mime,
+  filename,
+}: {
+  attachment: NoteAttachment;
+  mime: string;
+  filename: string;
+}) {
+  const client = useActiveVaultClient();
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const kind = attachmentKind(mime, filename);
+  const needsBlob = kind !== "other";
+  const src = attachment.url;
+
+  useEffect(() => {
+    if (!needsBlob || !src || !client) return;
+    let cancelled = false;
+    let createdUrl: string | null = null;
+    setError(null);
+    client
+      .fetchAttachmentBlob(src)
+      .then((blob) => {
+        if (cancelled) return;
+        createdUrl = URL.createObjectURL(blob);
+        setBlobUrl(createdUrl);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load attachment");
+      });
+    return () => {
+      cancelled = true;
+      if (createdUrl) URL.revokeObjectURL(createdUrl);
+    };
+  }, [needsBlob, src, client]);
+
+  if (!src) {
+    return <p className="text-sm text-fg-dim">(no URL)</p>;
+  }
+  if (error) {
+    return <p className="text-sm text-red-400">{error}</p>;
+  }
+  if (needsBlob && !blobUrl) {
+    return <div className="h-32 animate-pulse rounded bg-border/40" aria-busy="true" />;
+  }
+
+  const displayUrl = blobUrl ?? src;
+  if (kind === "image") {
+    return <img src={displayUrl} alt={filename} className="max-h-[32rem] rounded" />;
+  }
+  if (kind === "audio") {
+    // biome-ignore lint/a11y/useMediaCaption: vault attachments don't carry caption tracks
+    return <audio controls src={displayUrl} className="w-full" />;
+  }
+  if (kind === "video") {
+    // biome-ignore lint/a11y/useMediaCaption: vault attachments don't carry caption tracks
+    return <video controls src={displayUrl} className="w-full rounded" />;
+  }
+  if (kind === "pdf") {
+    return (
+      <>
+        <iframe
+          src={displayUrl}
+          title={filename}
+          className="h-[40rem] w-full rounded border border-border"
+        />
+        <a
+          href={displayUrl}
+          download={filename}
+          className="mt-2 inline-block text-sm text-accent hover:underline"
+        >
+          Download {filename}
+        </a>
+      </>
+    );
+  }
+  return (
+    <a href={displayUrl} download={filename} className="text-sm text-accent hover:underline">
+      Download {filename}
+    </a>
+  );
+}
+
+function attachmentKind(
+  mime: string,
+  filename: string,
+): "image" | "audio" | "video" | "pdf" | "other" {
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("audio/")) return "audio";
+  if (mime.startsWith("video/")) return "video";
+  if (mime === "application/pdf") return "pdf";
+  const ext = filename.toLowerCase().split(".").pop() ?? "";
+  if (["png", "jpg", "jpeg", "gif", "webp", "svg"].includes(ext)) return "image";
+  if (["mp3", "wav", "ogg", "m4a", "flac"].includes(ext)) return "audio";
+  if (["mp4", "webm", "mov"].includes(ext)) return "video";
+  if (ext === "pdf") return "pdf";
+  return "other";
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function NoteSkeleton() {
+  return (
+    <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem]" aria-busy="true">
+      <div className="min-w-0 space-y-3">
+        <div className="h-3 w-32 animate-pulse rounded bg-border/40" />
+        <div className="h-8 w-2/3 animate-pulse rounded bg-border/60" />
+        <div className="h-4 w-full animate-pulse rounded bg-border/30" />
+        <div className="mt-6 space-y-2">
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <div
+              key={i}
+              className="h-3 animate-pulse rounded bg-border/30"
+              style={{ width: `${70 + ((i * 13) % 25)}%` }}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="space-y-4">
+        <div className="h-32 animate-pulse rounded bg-border/30" />
+        <div className="h-24 animate-pulse rounded bg-border/30" />
+      </div>
+    </div>
+  );
+}
+
+function NotFoundBlock({ id }: { id: string }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-10 text-center">
+      <p className="mb-2 font-serif text-xl">Note not found</p>
+      <p className="mb-4 text-sm text-fg-muted">
+        No note with id <span className="font-mono">{id}</span> in this vault.
+      </p>
+      <Link to="/notes" className="text-sm text-accent hover:underline">
+        Back to all notes
+      </Link>
+    </div>
+  );
+}
+
+function ErrorBlock({ error }: { error: Error }) {
+  const isAuth = error instanceof VaultAuthError;
+  return (
+    <div className="rounded-md border border-red-500/30 bg-red-500/5 p-6">
+      <p className="mb-2 font-medium text-red-400">
+        {isAuth ? "Session expired" : "Could not load note"}
+      </p>
+      <p className="mb-4 text-sm text-fg-muted">{error.message}</p>
+      {isAuth ? (
+        <Link
+          to="/add"
+          className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Reconnect vault
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -12,14 +12,16 @@ import {
 import { VaultAuthError } from "@/lib/vault/client";
 import type { Note, TagSummary } from "@/lib/vault/types";
 import { useEffect, useMemo, useState } from "react";
-import { Link, Navigate } from "react-router";
+import { Link, Navigate, useSearchParams } from "react-router";
 
 export function Notes() {
   const activeVault = useVaultStore((s) => s.getActiveVault());
+  const [searchParams] = useSearchParams();
 
   const [search, setSearch] = useState("");
   const [pathPrefix, setPathPrefix] = useState("");
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const initialTags = useMemo(() => searchParams.getAll("tag"), [searchParams]);
+  const [selectedTags, setSelectedTags] = useState<string[]>(initialTags);
   const [tagMatch, setTagMatch] = useState<"any" | "all">("any");
   const [sort, setSort] = useState<"asc" | "desc">("desc");
   const [offset, setOffset] = useState(0);

--- a/src/lib/markdown/remark-wikilinks.test.ts
+++ b/src/lib/markdown/remark-wikilinks.test.ts
@@ -1,0 +1,94 @@
+import type { Root } from "mdast";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import { type WikilinkResolver, remarkWikilinks } from "./remark-wikilinks";
+
+function makeResolver(map: Record<string, string>): WikilinkResolver {
+  return (target) => (map[target] ? { id: map[target] } : null);
+}
+
+function processToTree(md: string, resolve: WikilinkResolver): Root {
+  const tree = unified().use(remarkParse).use(remarkWikilinks, { resolve }).parse(md);
+  return unified().use(remarkWikilinks, { resolve }).runSync(tree) as Root;
+}
+
+interface LinkLike {
+  type: string;
+  url?: string;
+  data?: { hProperties?: Record<string, unknown> };
+  children?: LinkLike[];
+  value?: string;
+}
+
+function flattenLinks(node: LinkLike, acc: LinkLike[] = []): LinkLike[] {
+  if (node.type === "link") acc.push(node);
+  for (const child of node.children ?? []) flattenLinks(child, acc);
+  return acc;
+}
+
+describe("remarkWikilinks", () => {
+  it("replaces [[target]] with a resolved link node when target is in the map", () => {
+    const tree = processToTree(
+      "See [[Canon/Uni]] for more.",
+      makeResolver({ "Canon/Uni": "abc-123" }),
+    );
+    const links = flattenLinks(tree as unknown as LinkLike);
+    expect(links).toHaveLength(1);
+    expect(links[0]?.url).toBe("/notes/abc-123");
+    const cls = links[0]?.data?.hProperties?.className as string;
+    expect(cls).toContain("wikilink-resolved");
+    expect(links[0]?.children?.[0]?.value).toBe("Canon/Uni");
+  });
+
+  it("marks unresolved wikilinks with a distinct class", () => {
+    const tree = processToTree("Orphan [[Missing/Note]].", makeResolver({}));
+    const links = flattenLinks(tree as unknown as LinkLike);
+    expect(links).toHaveLength(1);
+    const cls = links[0]?.data?.hProperties?.className as string;
+    expect(cls).toContain("wikilink-unresolved");
+    expect(links[0]?.url).toBe("/notes/Missing%2FNote");
+  });
+
+  it("honors the display text form [[target|Display]]", () => {
+    const tree = processToTree(
+      "Read [[Canon/Uni|the Uni canon]].",
+      makeResolver({ "Canon/Uni": "uni-id" }),
+    );
+    const links = flattenLinks(tree as unknown as LinkLike);
+    expect(links[0]?.children?.[0]?.value).toBe("the Uni canon");
+  });
+
+  it("does not touch [[target]] inside fenced code blocks", async () => {
+    const md = "```\n[[Canon/Uni]]\n```\n";
+    const out = await unified()
+      .use(remarkParse)
+      .use(remarkWikilinks, { resolve: makeResolver({ "Canon/Uni": "x" }) })
+      .use(remarkStringify)
+      .process(md);
+    expect(String(out)).toContain("[[Canon/Uni]]");
+  });
+
+  it("does not touch [[target]] inside inline code", async () => {
+    const md = "This is literal: `[[Canon/Uni]]`.";
+    const out = await unified()
+      .use(remarkParse)
+      .use(remarkWikilinks, { resolve: makeResolver({ "Canon/Uni": "x" }) })
+      .use(remarkStringify)
+      .process(md);
+    expect(String(out)).toContain("`[[Canon/Uni]]`");
+  });
+
+  it("handles multiple wikilinks in a single paragraph", () => {
+    const tree = processToTree(
+      "Links: [[A]], [[B]], and [[C]].",
+      makeResolver({ A: "a-id", C: "c-id" }),
+    );
+    const links = flattenLinks(tree as unknown as LinkLike);
+    expect(links).toHaveLength(3);
+    expect(links[0]?.url).toBe("/notes/a-id");
+    expect(links[1]?.url).toBe("/notes/B");
+    expect(links[2]?.url).toBe("/notes/c-id");
+  });
+});

--- a/src/lib/markdown/remark-wikilinks.ts
+++ b/src/lib/markdown/remark-wikilinks.ts
@@ -1,0 +1,70 @@
+import type { Root, RootContent, Text } from "mdast";
+import type { Plugin } from "unified";
+
+export type WikilinkResolver = (target: string) => { id: string } | null;
+
+const WIKILINK_RE = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+
+interface ParentWithChildren {
+  children: RootContent[];
+}
+
+function splitTextNode(text: string, resolve: WikilinkResolver): RootContent[] {
+  const out: RootContent[] = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(WIKILINK_RE)) {
+    const matchIndex = match.index ?? 0;
+    if (matchIndex > lastIndex) {
+      out.push({ type: "text", value: text.slice(lastIndex, matchIndex) });
+    }
+    const target = match[1]?.trim() ?? "";
+    const display = (match[2]?.trim() || target).trim();
+    const resolved = resolve(target);
+    const href = resolved
+      ? `/notes/${encodeURIComponent(resolved.id)}`
+      : `/notes/${encodeURIComponent(target)}`;
+    out.push({
+      type: "link",
+      url: href,
+      title: null,
+      children: [{ type: "text", value: display }],
+      data: {
+        hProperties: {
+          className: resolved ? "wikilink wikilink-resolved" : "wikilink wikilink-unresolved",
+          "data-wikilink-target": target,
+          "data-wikilink-resolved": resolved ? "true" : "false",
+        },
+      },
+    });
+    lastIndex = matchIndex + match[0].length;
+  }
+  if (lastIndex === 0) return [{ type: "text", value: text }];
+  if (lastIndex < text.length) out.push({ type: "text", value: text.slice(lastIndex) });
+  return out;
+}
+
+function transformChildren(node: ParentWithChildren, resolve: WikilinkResolver): void {
+  const next: RootContent[] = [];
+  for (const child of node.children) {
+    if (child.type === "text") {
+      const pieces = splitTextNode((child as Text).value, resolve);
+      next.push(...pieces);
+      continue;
+    }
+    if (child.type === "code" || child.type === "inlineCode") {
+      next.push(child);
+      continue;
+    }
+    if ("children" in child && Array.isArray((child as { children?: unknown[] }).children)) {
+      transformChildren(child as unknown as ParentWithChildren, resolve);
+    }
+    next.push(child);
+  }
+  node.children = next;
+}
+
+export const remarkWikilinks: Plugin<[{ resolve: WikilinkResolver }], Root> = ({ resolve }) => {
+  return (tree) => {
+    transformChildren(tree as unknown as ParentWithChildren, resolve);
+  };
+};

--- a/src/lib/vault/client.test.ts
+++ b/src/lib/vault/client.test.ts
@@ -88,6 +88,61 @@ describe("VaultClient", () => {
     expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/notes");
   });
 
+  it("getNote passes id, include_content, include_links, include_attachments", async () => {
+    const fetchImpl = mockFetch({
+      json: {
+        id: "abc",
+        path: "Canon/Aaron",
+        createdAt: "2026-04-16T00:00:00Z",
+        content: "# hi",
+        tags: ["canon"],
+        links: [],
+        attachments: [],
+      },
+    });
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+
+    const note = await client.getNote("Canon/Aaron", {
+      includeLinks: true,
+      includeAttachments: true,
+    });
+    expect(note?.id).toBe("abc");
+
+    const url = fetchImpl.mock.calls[0]?.[0] as string;
+    expect(url).toContain("id=Canon%2FAaron");
+    expect(url).toContain("include_content=true");
+    expect(url).toContain("include_links=true");
+    expect(url).toContain("include_attachments=true");
+  });
+
+  it("getNote unwraps an array response to a single note", async () => {
+    const fetchImpl = mockFetch({
+      json: [{ id: "a", createdAt: "2026-04-18T00:00:00Z" }],
+    });
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+    const note = await client.getNote("a");
+    expect(note?.id).toBe("a");
+  });
+
+  it("getNote returns null when the vault returns an empty array", async () => {
+    const fetchImpl = mockFetch({ json: [] });
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+    const note = await client.getNote("missing");
+    expect(note).toBeNull();
+  });
+
   it("listTags hits /api/tags and returns the summary array", async () => {
     const fetchImpl = mockFetch({
       json: [

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -55,7 +55,36 @@ export class VaultClient {
     return this.request<Note[]>(`/api/notes${qs ? `?${qs}` : ""}`);
   }
 
+  async getNote(
+    id: string,
+    opts: { includeLinks?: boolean; includeAttachments?: boolean } = {},
+  ): Promise<Note | null> {
+    const params = new URLSearchParams({ id, include_content: "true" });
+    if (opts.includeLinks) params.set("include_links", "true");
+    if (opts.includeAttachments) params.set("include_attachments", "true");
+    const rows = await this.request<Note[] | Note>(`/api/notes?${params.toString()}`);
+    // The vault may return either a single note (when id is passed) or an array.
+    if (Array.isArray(rows)) return rows[0] ?? null;
+    return rows ?? null;
+  }
+
   async listTags(): Promise<TagSummary[]> {
     return this.request<TagSummary[]>("/api/tags");
+  }
+
+  async fetchAttachmentBlob(url: string): Promise<Blob> {
+    const target = url.startsWith("http")
+      ? url
+      : `${this.baseUrl}${url.startsWith("/") ? "" : "/"}${url}`;
+    const res = await this.fetchImpl(target, {
+      headers: { Authorization: `Bearer ${this.token}` },
+    });
+    if (res.status === 401 || res.status === 403) {
+      throw new VaultAuthError(`Vault rejected the token (${res.status})`);
+    }
+    if (!res.ok) {
+      throw new Error(`GET ${url} failed (${res.status})`);
+    }
+    return res.blob();
   }
 }

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -52,3 +52,15 @@ export function useTags() {
     staleTime: 60_000,
   });
 }
+
+export function useNote(id: string | undefined) {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+
+  return useQuery({
+    queryKey: ["note", activeId, id],
+    enabled: !!client && !!id,
+    queryFn: () => client!.getNote(id!, { includeLinks: true, includeAttachments: true }),
+    staleTime: 10_000,
+  });
+}

--- a/src/lib/vault/types.ts
+++ b/src/lib/vault/types.ts
@@ -62,6 +62,35 @@ export interface Note {
   preview?: string;
   byteSize?: number;
   content?: string;
+  links?: NoteLink[];
+  attachments?: NoteAttachment[];
+}
+
+export interface NoteSummary {
+  id: string;
+  path?: string;
+  tags?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface NoteLink {
+  sourceId: string;
+  targetId: string;
+  relationship: string;
+  createdAt?: string;
+  sourceNote?: NoteSummary;
+  targetNote?: NoteSummary;
+}
+
+export interface NoteAttachment {
+  id: string;
+  filename?: string;
+  mimeType?: string;
+  url?: string;
+  size?: number;
+  [key: string]: unknown;
 }
 
 export interface TagSummary {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,5 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,300;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap");
 @import "tailwindcss";
+@import "highlight.js/styles/github.css";
 
 @theme {
   --font-sans: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif;
@@ -45,4 +46,124 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   line-height: 1.65;
+}
+
+.prose-note {
+  color: var(--color-fg);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+.prose-note h1,
+.prose-note h2,
+.prose-note h3,
+.prose-note h4 {
+  font-family: var(--font-serif);
+  color: var(--color-fg);
+  letter-spacing: -0.015em;
+  margin-top: 1.75em;
+  margin-bottom: 0.5em;
+  line-height: 1.25;
+}
+.prose-note h1 {
+  font-size: 1.875rem;
+}
+.prose-note h2 {
+  font-size: 1.5rem;
+}
+.prose-note h3 {
+  font-size: 1.25rem;
+}
+.prose-note h4 {
+  font-size: 1.1rem;
+}
+.prose-note p {
+  margin: 0.75em 0;
+}
+.prose-note ul,
+.prose-note ol {
+  margin: 0.75em 0;
+  padding-left: 1.5rem;
+}
+.prose-note ul {
+  list-style: disc;
+}
+.prose-note ol {
+  list-style: decimal;
+}
+.prose-note li {
+  margin: 0.25em 0;
+}
+.prose-note li > p {
+  margin: 0.25em 0;
+}
+.prose-note blockquote {
+  border-left: 3px solid var(--color-border);
+  padding-left: 1rem;
+  margin: 1em 0;
+  color: var(--color-fg-muted);
+  font-style: italic;
+}
+.prose-note code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background: var(--color-bg-soft);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+}
+.prose-note pre {
+  background: var(--color-bg-soft);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.9rem 1rem;
+  margin: 1em 0;
+  overflow-x: auto;
+  font-size: 0.875em;
+  line-height: 1.5;
+}
+.prose-note pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+.prose-note table {
+  border-collapse: collapse;
+  margin: 1em 0;
+  width: 100%;
+  font-size: 0.9em;
+}
+.prose-note th,
+.prose-note td {
+  border: 1px solid var(--color-border);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+.prose-note th {
+  background: var(--color-bg-soft);
+  font-weight: 500;
+}
+.prose-note hr {
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: 1.5em 0;
+}
+.prose-note img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+}
+.prose-note input[type="checkbox"] {
+  margin-right: 0.4em;
+}
+
+@media (prefers-color-scheme: dark) {
+  .prose-note code,
+  .prose-note pre {
+    background: #1f1e1b;
+    border-color: var(--color-border);
+  }
+  .prose-note .hljs {
+    background: #1f1e1b !important;
+    color: var(--color-fg);
+  }
 }


### PR DESCRIPTION
## Summary
- New `/notes/:id` route with two-column layout: rendered markdown on the left, metadata / tags / outbound / inbound panels on the right. Clicking into a note from the list just works.
- `[[wikilinks]]` resolve via the vault's outbound-links table (populated by `include_links: true`): resolved targets render as accent-colored router links, unresolved ones stay clickable with dashed-underline muted styling. Implemented as a standalone `remark-wikilinks` plugin so it composes with `remarkGfm` and skips content inside fenced or inline code.
- GitHub-flavored markdown (tables, strikethrough, task lists, autolinks) via `remark-gfm`; code blocks get syntax highlighting via `rehype-highlight` (lighter than shiki, synchronous).
- Inline rendering for image / audio / video / PDF attachments — auth-gated blob fetch through `VaultClient.fetchAttachmentBlob`, object URL created on mount and revoked on unmount. Non-media attachments render as a download link. This was in scope because the note view is broken without it (someone pastes an image and expects to see it).
- Tag chips are clickable — each goes to `/notes?tag=<tag>`, and `Notes.tsx` now seeds its `selectedTags` state from `searchParams.getAll("tag")`. URL-based over router-state because it's shareable.
- 404 / 401 are distinct: missing note shows a "not found" block with a back link; token rejection reuses the list view's Reconnect-through-`/add` flow so auth recovery stays one consistent path.
- Edit and Delete buttons are placeholders for PR #5 / #6 (Edit routes to `/notes/:id/edit`; Delete is disabled).

## Bundle size
Went from ~295KB to ~642KB JS (~198KB gzip). Mostly `highlight.js` bundling all languages. Acceptable for the core reading surface. If it starts to hurt, the obvious next levers are route-level code-splitting on `/notes/:id` or swapping to `highlight.js/lib/common`.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` — 70/70 pass (6 wikilinks plugin, 6 NoteView, 3 new client tests, 55 carried)
- [x] `bun run build` succeeds
- [x] `bun run dev` serves `/notes/:id` at 200
- [ ] Manual: point at a real vault, verify a note with wikilinks, a note with inbound+outbound links, a note with an image attachment, and a non-existent id for the 404 path
- [ ] Manual: expire a token and confirm Reconnect still routes correctly
- [ ] Manual: click a tag chip from a note, confirm `/notes` pre-filters

## Out of scope
- Editing (PR #5), create/delete (PR #6)
- Graph badges / neighborhood visualization (later)
- Attachment upload (PR #7) — rendering only here

🤖 Generated with [Claude Code](https://claude.com/claude-code)