### PR TITLE
Hotfix: bind fetch to globalThis to avoid 'Illegal invocation'

### DIFF
--- a/src/lib/vault/client.test.ts
+++ b/src/lib/vault/client.test.ts
@@ -499,3 +499,36 @@ describe("VaultClient", () => {
     expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/tags");
   });
 });
+
+describe("VaultClient default fetch binding", () => {
+  // Regression for "TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation".
+  // Browser's native `fetch` requires its `this` receiver to be the global (Window).
+  // Storing `fetch` as a bare reference on an instance field loses that binding; at
+  // call-time `this` becomes the VaultClient instance and the browser throws.
+  // jsdom's fetch is permissive and doesn't enforce this invariant, so we install a
+  // this-aware shim here that mimics the browser check. This test exists to catch
+  // regressions in the default-path binding only — don't add one per endpoint.
+  it("does not throw 'Illegal invocation' when no fetchImpl is provided", async () => {
+    const shim = vi.fn(function (this: unknown, _url: string, _init?: RequestInit) {
+      if (this !== globalThis) {
+        throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation");
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ name: "default", description: "" }),
+        text: async () => "",
+      } as Response);
+    });
+    vi.stubGlobal("fetch", shim);
+    try {
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+      });
+      await expect(client.vaultInfo(false)).resolves.toBeDefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -87,7 +87,7 @@ export class VaultClient {
   constructor(opts: VaultClientOptions) {
     this.baseUrl = opts.vaultUrl.replace(/\/$/, "");
     this.token = opts.accessToken;
-    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
     this.xhrFactory = opts.xhrFactory ?? (() => new XMLHttpRequest());
   }
 

--- a/src/lib/vault/discovery.ts
+++ b/src/lib/vault/discovery.ts
@@ -13,7 +13,7 @@ const REQUIRED_FIELDS: (keyof AuthorizationServerMetadata)[] = [
  */
 export async function discoverAuthServer(
   vaultUrl: string,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<AuthorizationServerMetadata> {
   const metadataUrl = `${vaultUrl.replace(/\/$/, "")}/.well-known/oauth-authorization-server`;
 
@@ -49,7 +49,7 @@ export async function discoverAuthServer(
 export async function registerClient(
   registrationEndpoint: string,
   redirectUri: string,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<ClientRegistration> {
   const res = await fetchImpl(registrationEndpoint, {
     method: "POST",

--- a/src/lib/vault/oauth.ts
+++ b/src/lib/vault/oauth.ts
@@ -21,7 +21,7 @@ export function redirectUriForOrigin(origin: string = window.location.origin): s
 export async function beginOAuth(
   rawUrl: string,
   scope: TokenScope = "full",
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<{ authorizeUrl: string; pending: PendingOAuthState }> {
   const vaultUrl = normalizeVaultUrl(rawUrl);
   const redirectUri = redirectUriForOrigin();
@@ -65,7 +65,7 @@ export async function beginOAuth(
 export async function completeOAuth(
   code: string,
   state: string,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<{ pending: PendingOAuthState; token: TokenResponse }> {
   const pending = loadPendingOAuth();
   if (!pending) {


### PR DESCRIPTION
## Summary
- Browser's native `fetch` requires `this === Window`. Storing a bare `fetch` reference on `VaultClient.fetchImpl` (or as a default param in oauth/discovery helpers) loses that binding — at call-time `this` is the VaultClient instance and the browser throws `TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation`.
- jsdom's `fetch` is permissive and didn't enforce the invariant, so existing tests passed while the browser broke.
- Fix: `fetch.bind(globalThis)` in all four default paths — `VaultClient` constructor, `discoverAuthServer`, `registerClient`, `beginOAuth`, `completeOAuth`.
- Regression test installs a this-aware fetch shim that throws "Illegal invocation" when `this !== globalThis`, instantiates `VaultClient` without an explicit `fetchImpl`, and asserts `vaultInfo()` resolves. Verified it fails without the fix.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` — 101 tests pass (new regression included)
- [x] `bun run build` succeeds
- [x] Reverted fix + re-ran regression test → failed with the exact browser error, confirming coverage
- [ ] Aaron verifies in browser that vault sign-in completes without "Illegal invocation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)