### PR TITLE
Hotfix: header label fallback + VITE_EXPOSE gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ bun run test        # vitest run
 bun run build       # tsc -b && vite build
 ```
 
+By default the dev server binds to localhost and rejects Host headers it
+doesn't recognize. Set `VITE_EXPOSE=true` to bind to all interfaces and accept
+any Host — useful when reaching the dev server from another device on your
+tailnet:
+
+```sh
+VITE_EXPOSE=true bun run dev
+```
+
 ## License
 
 AGPL-3.0 — same as Parachute Vault.

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,0 +1,65 @@
+import { Header } from "@/components/Header";
+import { useVaultStore } from "@/lib/vault/store";
+import type { VaultRecord } from "@/lib/vault/types";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+function makeVault(partial: Partial<VaultRecord> & Pick<VaultRecord, "id" | "url">): VaultRecord {
+  return {
+    name: "",
+    issuer: partial.url,
+    clientId: "client-test",
+    scope: "full",
+    addedAt: "2026-04-18T00:00:00.000Z",
+    lastUsedAt: "2026-04-18T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+function renderHeader() {
+  return render(
+    <MemoryRouter>
+      <Header />
+    </MemoryRouter>,
+  );
+}
+
+describe("Header vault label fallback", () => {
+  beforeEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+
+  it("renders the vault name when present", () => {
+    useVaultStore.setState({
+      vaults: { a: makeVault({ id: "a", url: "http://localhost:1940", name: "default" }) },
+      activeVaultId: "a",
+    });
+    renderHeader();
+    expect(screen.getByRole("combobox", { name: /active vault/i })).toHaveTextContent("default");
+  });
+
+  it("falls back to the URL host when name is empty", () => {
+    useVaultStore.setState({
+      vaults: { a: makeVault({ id: "a", url: "https://vault.example.com:8443/api", name: "" }) },
+      activeVaultId: "a",
+    });
+    renderHeader();
+    expect(screen.getByRole("combobox", { name: /active vault/i })).toHaveTextContent(
+      "vault.example.com:8443",
+    );
+  });
+
+  it("falls back to the raw URL when both name and URL are unparseable", () => {
+    useVaultStore.setState({
+      vaults: { a: makeVault({ id: "a", url: "not a url", name: "" }) },
+      activeVaultId: "a",
+    });
+    renderHeader();
+    expect(screen.getByRole("combobox", { name: /active vault/i })).toHaveTextContent("not a url");
+  });
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useVaultStore } from "@/lib/vault";
+import { type VaultRecord, useVaultStore } from "@/lib/vault";
 import { Link, useNavigate } from "react-router";
 
 export function Header() {
@@ -7,7 +7,17 @@ export function Header() {
   const activeVaultId = useVaultStore((s) => s.activeVaultId);
   const setActiveVault = useVaultStore((s) => s.setActiveVault);
 
-  const vaultList = Object.values(vaults).sort((a, b) => a.name.localeCompare(b.name));
+  const vaultLabel = (v: VaultRecord): string => {
+    if (v.name) return v.name;
+    try {
+      return new URL(v.url).host;
+    } catch {
+      return v.url;
+    }
+  };
+  const vaultList = Object.values(vaults).sort((a, b) =>
+    vaultLabel(a).localeCompare(vaultLabel(b)),
+  );
   const hasVaults = vaultList.length > 0;
 
   return (
@@ -31,7 +41,7 @@ export function Header() {
               >
                 {vaultList.map((v) => (
                   <option key={v.id} value={v.id}>
-                    {v.name}
+                    {vaultLabel(v)}
                   </option>
                 ))}
               </select>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,11 +3,19 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+// Set VITE_EXPOSE=true to bind the dev server to all interfaces and accept any
+// Host header — useful when reaching the dev server over a tailnet. Off by default.
+const devExposure = process.env.VITE_EXPOSE === "true";
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+  },
+  server: {
+    host: devExposure ? "0.0.0.0" : undefined,
+    allowedHosts: devExposure ? true : undefined,
   },
 });


### PR DESCRIPTION
Two follow-on fixes from the fetch-binding hotfix (PR #9, already merged), per team-lead direction.

## Summary

### 1. Header: fall back to URL host when vault name is empty
Aaron hit a blank `<option>` next to the Manage button. Root cause: the unscoped OAuth token response (`/oauth/authorize` vs `/vaults/<name>/oauth/authorize`) returns an empty `vault` field, so `VaultRecord.name` is blank for default-vault connections.

`src/components/Header.tsx` now uses `name || new URL(v.url).host || v.url` and sorts by the computed label. Three tests cover the full fallback chain.

### 2. vite.config.ts: gate exposed dev server behind VITE_EXPOSE=true
Aaron needs the dev server reachable over his tailnet, but permissive binding shouldn't be the committed default. Gate `host: "0.0.0.0"` and `allowedHosts: true` on `process.env.VITE_EXPOSE === "true"`. README documents the flag under Development.

## Follow-up (non-blocking, tracked separately)
The vault's unscoped OAuth token response returns an empty `vault` field — either it should include the default vault's actual name or omit the field entirely. Will file an issue on `parachute-vault`.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` — 104 tests pass (3 new Header tests)
- [x] `bun run build` succeeds
- [ ] Aaron verifies the vault dropdown shows a label for default-vault connections
- [ ] Aaron verifies `VITE_EXPOSE=true bun run dev` accepts his tailnet host; `bun run dev` (default) does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)