### PR TITLE
PR #8.5: attachment remove button

### DIFF
--- a/src/app/routes/NoteEditor.tsx
+++ b/src/app/routes/NoteEditor.tsx
@@ -5,6 +5,7 @@ import type { CodeMirrorEditorHandle } from "@/components/CodeMirrorEditor";
 import { CodeMirrorEditor } from "@/components/CodeMirrorEditor";
 import { DeleteNoteButton } from "@/components/DeleteNoteButton";
 import { MarkdownView, buildWikilinkResolver } from "@/components/MarkdownView";
+import { RemoveAttachmentButton } from "@/components/RemoveAttachmentButton";
 import { TagEditor, normalizeTag } from "@/components/TagEditor";
 import { useAttachmentUploader } from "@/components/useAttachmentUploader";
 import { relativeTime } from "@/lib/time";
@@ -287,6 +288,7 @@ function EditorSurface({ note }: { note: Note }) {
       </div>
 
       <AttachmentsSection
+        noteId={note.id}
         attachments={note.attachments ?? []}
         uploads={uploader.uploads}
         onPickFiles={uploader.start}
@@ -312,12 +314,14 @@ const ALLOWLIST_HINT = (
 );
 
 function AttachmentsSection({
+  noteId,
   attachments,
   uploads,
   onPickFiles,
   onCancel,
   onDismiss,
 }: {
+  noteId: string;
   attachments: NoteAttachment[];
   uploads: ReturnType<typeof useAttachmentUploader>["uploads"];
   onPickFiles: (files: File[]) => void;
@@ -344,7 +348,10 @@ function AttachmentsSection({
               <span className="truncate" title={a.path ?? a.id}>
                 {a.filename ?? a.path ?? a.id}
               </span>
-              {a.mimeType ? <span className="shrink-0 text-fg-dim">{a.mimeType}</span> : null}
+              <div className="flex shrink-0 items-center gap-2">
+                {a.mimeType ? <span className="text-fg-dim">{a.mimeType}</span> : null}
+                <RemoveAttachmentButton noteId={noteId} attachment={a} />
+              </div>
             </li>
           ))}
         </ul>

--- a/src/components/RemoveAttachmentButton.test.tsx
+++ b/src/components/RemoveAttachmentButton.test.tsx
@@ -1,0 +1,210 @@
+import { RemoveAttachmentButton } from "@/components/RemoveAttachmentButton";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault/store";
+import type { NoteAttachment } from "@/lib/vault/types";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FetchEntry {
+  status?: number;
+  body?: unknown;
+}
+type FetchMap = Record<string, FetchEntry>;
+
+function installFetch(map: FetchMap) {
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    for (const matcher of Object.keys(map)) {
+      const [wantMethod, wantFragment] = matcher.includes(" ")
+        ? matcher.split(" ", 2)
+        : ["GET", matcher];
+      if (method !== wantMethod) continue;
+      if (!url.includes(wantFragment!)) continue;
+      const entry = map[matcher]!;
+      return {
+        ok: (entry.status ?? 200) < 400,
+        status: entry.status ?? 200,
+        json: async () => entry.body ?? null,
+        text: async () => "",
+      } as Response;
+    }
+    return { ok: false, status: 404, json: async () => null, text: async () => "" } as Response;
+  });
+  vi.stubGlobal("fetch", fetchImpl);
+  return fetchImpl;
+}
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      dev: {
+        id: "dev",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "client-test",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "dev",
+  });
+  localStorage.setItem(
+    "lens:token:dev",
+    JSON.stringify({ accessToken: "pvt_abc", scope: "full", vault: "default" }),
+  );
+}
+
+const attachment: NoteAttachment = {
+  id: "att-1",
+  filename: "screenshot.png",
+  mimeType: "image/png",
+  path: "2026-04-18/screenshot.png",
+};
+
+function Wrapper({ children, qc }: { children: ReactNode; qc: QueryClient }) {
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function renderButton() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return {
+    qc,
+    ...render(<RemoveAttachmentButton noteId="note-a" attachment={attachment} />, {
+      wrapper: ({ children }) => <Wrapper qc={qc}>{children}</Wrapper>,
+    }),
+  };
+}
+
+// The component arms the Remove button after a short delay to prevent double-click
+// accidents. Real timers + small sleep is simpler than mocking time, especially
+// because TanStack Query mutations schedule real microtasks that fake timers stall.
+const waitForArm = () => new Promise<void>((r) => setTimeout(r, 300));
+
+describe("RemoveAttachmentButton", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useToastStore.setState({ toasts: [] });
+    seedStore();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("opens a confirm dialog before calling DELETE", async () => {
+    const fetchImpl = installFetch({
+      "DELETE /api/notes/note-a/attachments/att-1": { status: 204 },
+    });
+    const { qc } = renderButton();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    fireEvent.click(screen.getByRole("button", { name: /remove attachment screenshot\.png/i }));
+    expect(await screen.findByText(/remove attachment\?/i)).toBeInTheDocument();
+
+    const removeBtn = screen.getByRole("button", { name: /^remove$/i });
+    expect(removeBtn).toBeDisabled();
+    await waitForArm();
+    expect(removeBtn).not.toBeDisabled();
+
+    fireEvent.click(removeBtn);
+
+    await waitFor(() =>
+      expect(fetchImpl).toHaveBeenCalledWith(
+        "http://localhost:1940/api/notes/note-a/attachments/att-1",
+        expect.objectContaining({ method: "DELETE" }),
+      ),
+    );
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["note", "dev", "note-a"] }),
+    );
+    await waitFor(() =>
+      expect(useToastStore.getState().toasts.at(-1)?.message).toMatch(/removed screenshot\.png/i),
+    );
+  });
+
+  it("Cancel closes the dialog without calling DELETE", async () => {
+    const fetchImpl = installFetch({
+      "DELETE /api/notes/note-a/attachments/att-1": { status: 204 },
+    });
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: /remove attachment screenshot\.png/i }));
+    await waitForArm();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.queryByText(/remove attachment\?/i)).not.toBeInTheDocument();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("treats 404 as already-removed: toasts and closes", async () => {
+    installFetch({
+      "DELETE /api/notes/note-a/attachments/att-1": { status: 404 },
+    });
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: /remove attachment screenshot\.png/i }));
+    await waitForArm();
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+    await waitFor(() =>
+      expect(useToastStore.getState().toasts.at(-1)?.message).toMatch(
+        /already removed screenshot\.png/i,
+      ),
+    );
+    expect(screen.queryByText(/remove attachment\?/i)).not.toBeInTheDocument();
+  });
+
+  it("surfaces 401 as a reconnect prompt without closing the dialog", async () => {
+    installFetch({
+      "DELETE /api/notes/note-a/attachments/att-1": { status: 401 },
+    });
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: /remove attachment screenshot\.png/i }));
+    await waitForArm();
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/session expired/i);
+    expect(screen.getByText(/remove attachment\?/i)).toBeInTheDocument();
+  });
+
+  it("a second remove after the first lands returns 404 without crashing", async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        calls += 1;
+        return {
+          ok: calls === 1,
+          status: calls === 1 ? 204 : 404,
+          json: async () => null,
+          text: async () => "",
+        } as Response;
+      }),
+    );
+    renderButton();
+
+    const trigger = screen.getByRole("button", { name: /remove attachment screenshot\.png/i });
+    fireEvent.click(trigger);
+    await waitForArm();
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+    await waitFor(() =>
+      expect(useToastStore.getState().toasts.at(-1)?.message).toMatch(/^removed screenshot/i),
+    );
+
+    fireEvent.click(trigger);
+    await waitForArm();
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+    await waitFor(() =>
+      expect(useToastStore.getState().toasts.at(-1)?.message).toMatch(/already removed/i),
+    );
+    expect(calls).toBe(2);
+  });
+});

--- a/src/components/RemoveAttachmentButton.tsx
+++ b/src/components/RemoveAttachmentButton.tsx
@@ -1,0 +1,160 @@
+import { useToastStore } from "@/lib/toast/store";
+import { useDeleteAttachment } from "@/lib/vault";
+import { VaultAuthError, VaultNotFoundError } from "@/lib/vault/client";
+import type { NoteAttachment } from "@/lib/vault/types";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Props {
+  noteId: string;
+  attachment: NoteAttachment;
+}
+
+// Short delay before the Remove button becomes clickable. Prevents a double-click
+// on the trash icon from landing straight on Remove. 250ms is below the threshold
+// where users notice it as "slow" but above the ~100ms where accidental clicks land.
+const CONFIRM_ARM_DELAY_MS = 250;
+
+export function RemoveAttachmentButton({ noteId, attachment }: Props) {
+  const [open, setOpen] = useState(false);
+  const label = labelFor(attachment);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={`Remove attachment ${label}`}
+        className="shrink-0 rounded border border-transparent px-1.5 py-0.5 text-fg-dim hover:border-red-500/40 hover:text-red-400"
+      >
+        ✕
+      </button>
+      {open ? (
+        <ConfirmRemoveDialog
+          noteId={noteId}
+          attachment={attachment}
+          label={label}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function ConfirmRemoveDialog({
+  noteId,
+  attachment,
+  label,
+  onClose,
+}: {
+  noteId: string;
+  attachment: NoteAttachment;
+  label: string;
+  onClose(): void;
+}) {
+  const pushToast = useToastStore((s) => s.push);
+  const mutation = useDeleteAttachment();
+  const [armed, setArmed] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => setArmed(true), CONFIRM_ARM_DELAY_MS);
+    return () => clearTimeout(t);
+  }, []);
+
+  useEffect(() => {
+    cancelRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const handleConfirm = useCallback(() => {
+    if (!armed || mutation.isPending) return;
+    setErr(null);
+    mutation.mutate(
+      { noteId, attachmentId: attachment.id },
+      {
+        onSuccess: () => {
+          pushToast(`Removed ${label}`, "success");
+          onClose();
+        },
+        onError: (e) => {
+          if (e instanceof VaultAuthError) {
+            setErr("Session expired. Reconnect to remove attachments.");
+            return;
+          }
+          if (e instanceof VaultNotFoundError) {
+            // Already gone — the attachment list query is invalidated by the
+            // hook's onSuccess path, but for 404 we still want to refresh UI
+            // and let the user know.
+            pushToast(`Already removed ${label}`, "info");
+            onClose();
+            return;
+          }
+          setErr(e instanceof Error ? e.message : "Remove failed");
+        },
+      },
+    );
+  }, [armed, attachment.id, label, mutation, noteId, onClose, pushToast]);
+
+  return (
+    <dialog
+      open
+      aria-labelledby="confirm-remove-attachment-title"
+      className="fixed inset-0 z-40 m-0 flex h-full max-h-full w-full max-w-full items-center justify-center bg-black/60 p-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-md rounded-md border border-border bg-card p-6 shadow-xl">
+        <h2 id="confirm-remove-attachment-title" className="mb-2 font-serif text-lg text-red-400">
+          Remove attachment?
+        </h2>
+        <p className="mb-3 text-sm text-fg-muted">
+          <span className="rounded bg-bg/60 px-1 py-0.5 font-mono text-xs text-fg">{label}</span>{" "}
+          will be detached from this note. If no other note references the file, it will also be
+          deleted from storage. Markdown referencing it will show a broken link until you update it.
+        </p>
+        {err ? (
+          <p role="alert" className="mb-3 text-sm text-red-400">
+            {err}
+          </p>
+        ) : null}
+        <div className="flex justify-end gap-2">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-fg-muted hover:text-fg"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!armed || mutation.isPending}
+            className="rounded-md bg-red-500 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-40"
+          >
+            {mutation.isPending ? "Removing…" : "Remove"}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}
+
+function labelFor(a: NoteAttachment): string {
+  if (a.filename) return a.filename;
+  if (a.path) {
+    const last = a.path.split("/").pop();
+    if (last) return last;
+    return a.path;
+  }
+  return a.id;
+}

--- a/src/lib/vault/client.test.ts
+++ b/src/lib/vault/client.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { VaultAuthError, VaultClient, VaultConflictError, VaultUploadError } from "./client";
+import {
+  VaultAuthError,
+  VaultClient,
+  VaultConflictError,
+  VaultNotFoundError,
+  VaultUploadError,
+} from "./client";
 
 function mockFetch(response: { ok?: boolean; status?: number; json?: unknown; text?: string }) {
   return vi.fn<typeof fetch>(async () => {
@@ -479,6 +485,41 @@ describe("VaultClient", () => {
     await expect(
       client.linkAttachment("note-a", { path: "x", mimeType: "image/png" }),
     ).rejects.toBeInstanceOf(VaultAuthError);
+  });
+
+  it("deleteAttachment sends DELETE to /api/notes/:id/attachments/:attId and resolves void", async () => {
+    const fetchImpl = mockFetch({ status: 204 });
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+    await expect(client.deleteAttachment("note-a", "att-1")).resolves.toBeUndefined();
+    const call = fetchImpl.mock.calls[0];
+    expect(call?.[0]).toBe("http://localhost:1940/api/notes/note-a/attachments/att-1");
+    expect((call?.[1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("deleteAttachment throws VaultNotFoundError on 404 so callers can treat it as already-removed", async () => {
+    const fetchImpl = mockFetch({ ok: false, status: 404 });
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+    await expect(client.deleteAttachment("note-a", "att-1")).rejects.toBeInstanceOf(
+      VaultNotFoundError,
+    );
+  });
+
+  it("deleteAttachment propagates 401 as VaultAuthError", async () => {
+    const fetchImpl = mockFetch({ ok: false, status: 401 });
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+    await expect(client.deleteAttachment("note-a", "att-1")).rejects.toBeInstanceOf(VaultAuthError);
   });
 
   it("listTags hits /api/tags and returns the summary array", async () => {

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -48,6 +48,13 @@ export class VaultAuthError extends Error {
   }
 }
 
+export class VaultNotFoundError extends Error {
+  constructor(message = "Not found") {
+    super(message);
+    this.name = "VaultNotFoundError";
+  }
+}
+
 export class VaultConflictError extends Error {
   readonly currentUpdatedAt: string | null;
   readonly expectedUpdatedAt: string | null;
@@ -107,6 +114,9 @@ export class VaultClient {
 
     if (res.status === 401 || res.status === 403) {
       throw new VaultAuthError(`Vault rejected the token (${res.status})`);
+    }
+    if (res.status === 404) {
+      throw new VaultNotFoundError(`${init.method ?? "GET"} ${path} → 404`);
     }
     if (res.status === 409) {
       const body = (await res.json().catch(() => ({}))) as {
@@ -243,6 +253,13 @@ export class VaultClient {
   async listAttachments(noteIdOrPath: string): Promise<NoteAttachment[]> {
     return this.request<NoteAttachment[]>(
       `/api/notes/${encodeURIComponent(noteIdOrPath)}/attachments`,
+    );
+  }
+
+  async deleteAttachment(noteIdOrPath: string, attachmentId: string): Promise<void> {
+    await this.request<undefined>(
+      `/api/notes/${encodeURIComponent(noteIdOrPath)}/attachments/${encodeURIComponent(attachmentId)}`,
+      { method: "DELETE" },
     );
   }
 

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -149,6 +149,23 @@ export function useLinkAttachment() {
   });
 }
 
+export function useDeleteAttachment() {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (args: { noteId: string; attachmentId: string }) => {
+      if (!client) throw new Error("No active vault");
+      await client.deleteAttachment(args.noteId, args.attachmentId);
+      return args;
+    },
+    onSuccess: (args) => {
+      qc.invalidateQueries({ queryKey: ["note", activeId, args.noteId] });
+    },
+  });
+}
+
 export function useDeleteNote() {
   const client = useActiveVaultClient();
   const activeId = useVaultStore((s) => s.activeVaultId);


### PR DESCRIPTION
Wires the vault's `DELETE /api/notes/:id/attachments/:attId` endpoint (shipped in parachute-vault#128) into the editor's attachment sidebar.

## Summary

- **Client**: `VaultClient.deleteAttachment(noteId, attId)` returns void on 204.
- **Typed 404**: new `VaultNotFoundError` thrown from `request()` on 404 so callers can branch on it structurally instead of parsing message strings. No existing caller relies on 404 (getNote uses the list endpoint which returns `[]`); verified via full test suite.
- **Hook**: `useDeleteAttachment` invalidates the `["note", activeVaultId, noteId]` query on success so the sidebar refreshes.
- **UI**: `RemoveAttachmentButton` renders a small ✕ on each attachment row, opens a confirm dialog, and arms the Remove button after 250ms (prevents accidental double-click-through from the trigger). Cancel gets initial focus; Escape closes; click-outside closes.
- **Error handling**:
  - `401` → dialog stays open, "Session expired. Reconnect to remove attachments."
  - `404` → dialog closes, info toast "Already removed `<filename>`" (the attachment is gone either way)
  - Other → inline error message, dialog stays open

## Confirm pattern rationale
Team-lead suggested "click-to-confirm or type-to-confirm; typing the attachment filename is overkill for attachments." Chose click-to-confirm with a short arm delay. Typing the filename is the right gate for note deletion (catastrophic), but attachments are recoverable by re-upload and a delayed arm plus initial-focus-on-Cancel is enough friction.

## Out of scope
Markdown that references a now-deleted attachment will show a broken-image link until the markdown itself is edited. Fixing this needs either a vault-side "attachment gone" response or a client-side ghost-attachment index; worth a separate polish PR.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` — 112 tests pass (8 new)
  - Client: happy 204, 404 → VaultNotFoundError, 401 → VaultAuthError
  - Component: dialog open, arm delay enforced, Cancel skips DELETE, 404 closes with info toast, 401 stays open with alert, idempotent second delete doesn't crash
- [x] `bun run build` succeeds
- [ ] Aaron verifies in-browser: remove an attachment, sidebar updates, confirm 404 path when removing an already-removed attachment across tabs
- [ ] Aaron verifies markdown inline reference to removed attachment renders as broken-image (expected, out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)