### PR TITLE
Neighborhood graph on the note view

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "highlight.js": "^11.11.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-force-graph-2d": "^1.29.1",
         "react-markdown": "^10.1.0",
         "react-router": "^7",
         "rehype-highlight": "^7.0.2",
@@ -304,6 +305,8 @@
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@25.0.0", "", {}, "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A=="],
+
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
@@ -356,6 +359,8 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
+    "accessor-fn": ["accessor-fn@1.5.3", "", {}, "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -372,6 +377,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ=="],
 
+    "bezier-js": ["bezier-js@6.1.4", "", {}, "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg=="],
+
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
@@ -379,6 +386,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
+
+    "canvas-color-tracker": ["canvas-color-tracker@1.3.2", "", { "dependencies": { "tinycolor2": "^1.6.0" } }, "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -409,6 +418,44 @@
     "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-binarytree": ["d3-binarytree@1.0.2", "", {}, "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-force-3d": ["d3-force-3d@3.0.6", "", { "dependencies": { "d3-binarytree": "1", "d3-dispatch": "1 - 3", "d3-octree": "1", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-octree": ["d3-octree@1.1.0", "", {}, "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
     "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
 
@@ -464,6 +511,10 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "float-tooltip": ["float-tooltip@1.7.5", "", { "dependencies": { "d3-selection": "2 - 3", "kapsule": "^1.16", "preact": "10" } }, "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg=="],
+
+    "force-graph": ["force-graph@1.51.4", "", { "dependencies": { "@tweenjs/tween.js": "18 - 25", "accessor-fn": "1", "bezier-js": "3 - 6", "canvas-color-tracker": "^1.3", "d3-array": "1 - 3", "d3-drag": "2 - 3", "d3-force-3d": "2 - 3", "d3-scale": "1 - 4", "d3-scale-chromatic": "1 - 3", "d3-selection": "2 - 3", "d3-zoom": "2 - 3", "float-tooltip": "^1.7", "index-array-by": "1", "kapsule": "^1.16", "lodash-es": "4" } }, "sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w=="],
+
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -508,7 +559,11 @@
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
+    "index-array-by": ["index-array-by@1.4.2", "", {}, "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -522,6 +577,8 @@
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
+    "jerrypick": ["jerrypick@1.1.2", "", {}, "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -531,6 +588,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "kapsule": ["kapsule@1.16.3", "", { "dependencies": { "lodash-es": "4" } }, "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -556,7 +615,11 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
@@ -672,6 +735,8 @@
 
     "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
@@ -686,7 +751,11 @@
 
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
+    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
+
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
@@ -696,7 +765,11 @@
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
+    "react-force-graph-2d": ["react-force-graph-2d@1.29.1", "", { "dependencies": { "force-graph": "^1.51", "prop-types": "15", "react-kapsule": "^2.5" }, "peerDependencies": { "react": "*" } }, "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ=="],
+
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-kapsule": ["react-kapsule@2.5.7", "", { "dependencies": { "jerrypick": "^1.1.1" }, "peerDependencies": { "react": ">=16.13.1" } }, "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
@@ -759,6 +832,8 @@
     "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
@@ -857,6 +932,8 @@
     "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "highlight.js": "^11.11.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-force-graph-2d": "^1.29.1",
     "react-markdown": "^10.1.0",
     "react-router": "^7",
     "rehype-highlight": "^7.0.2",

--- a/src/app/routes/NoteView.tsx
+++ b/src/app/routes/NoteView.tsx
@@ -1,5 +1,6 @@
 import { DeleteNoteButton } from "@/components/DeleteNoteButton";
 import { MarkdownView, buildWikilinkResolver } from "@/components/MarkdownView";
+import { NeighborhoodGraph } from "@/components/NeighborhoodGraph";
 import { relativeTime } from "@/lib/time";
 import { useActiveVaultClient, useNote, useVaultStore } from "@/lib/vault";
 import { VaultAuthError } from "@/lib/vault/client";
@@ -92,6 +93,8 @@ function NoteBody({ note }: { note: Note }) {
             </div>
           </section>
         ) : null}
+
+        <NeighborhoodGraph anchor={note} />
       </div>
 
       <aside className="space-y-6 text-sm lg:sticky lg:top-24 lg:self-start">

--- a/src/components/NeighborhoodGraph.test.tsx
+++ b/src/components/NeighborhoodGraph.test.tsx
@@ -1,0 +1,216 @@
+import { NeighborhoodGraph } from "@/components/NeighborhoodGraph";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the force graph lib — jsdom has no canvas, and we only care about
+// the data/click wiring, not the actual rendering.
+interface MockGraphData {
+  nodes: Array<{ id: string; isAnchor?: boolean }>;
+  links: Array<{ source: string; target: string; rel?: string }>;
+}
+
+vi.mock("react-force-graph-2d", () => ({
+  default: (props: {
+    graphData: MockGraphData;
+    onNodeClick: (n: { id: string }) => void;
+  }) => (
+    <div data-testid="mock-force-graph">
+      <span data-testid="node-count">{props.graphData.nodes.length}</span>
+      <span data-testid="link-count">{props.graphData.links.length}</span>
+      <ul>
+        {props.graphData.nodes.map((n) => (
+          <li key={n.id}>
+            <button type="button" onClick={() => props.onNodeClick(n)}>
+              {n.id}
+              {n.isAnchor ? " (anchor)" : ""}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+
+// jsdom doesn't implement ResizeObserver.
+beforeEach(() => {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+    class MockResizeObserver {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    } as unknown as typeof ResizeObserver;
+});
+
+function seedActiveVault() {
+  useVaultStore.setState({
+    vaults: {
+      v1: {
+        id: "v1",
+        url: "http://localhost:1940",
+        name: "default",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v1",
+  });
+  // Minimal fake token so useActiveVaultClient returns a client.
+  localStorage.setItem(
+    "lens:token:v1",
+    JSON.stringify({ accessToken: "t", scope: "full", vault: "default" }),
+  );
+}
+
+function Wrap({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <MemoryRouter initialEntries={["/notes/A"]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/notes/A" element={children} />
+          <Route path="/notes/:id" element={<div data-testid="note-route" />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function mockFetchReturning(byId: Record<string, unknown>) {
+  const impl = vi.fn<typeof fetch>(async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const params = new URL(url).searchParams;
+    const id = params.get("id") ?? "";
+    const body = byId[id] ?? [];
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => "",
+    } as Response;
+  });
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
+
+describe("NeighborhoodGraph", () => {
+  beforeEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+
+  const anchor = {
+    id: "A",
+    path: "notes/A",
+    createdAt: "2026-04-18T00:00:00.000Z",
+    links: [
+      { sourceId: "A", targetId: "B", relationship: "wikilink" },
+      { sourceId: "C", targetId: "A", relationship: "wikilink" },
+    ],
+  };
+
+  it("renders the graph with anchor and neighbors at depth 2", async () => {
+    seedActiveVault();
+    mockFetchReturning({
+      B: { id: "B", path: "notes/B", createdAt: "2026-04-18T00:00:00.000Z" },
+      C: { id: "C", path: "notes/C", createdAt: "2026-04-18T00:00:00.000Z" },
+    });
+    render(
+      <Wrap>
+        <NeighborhoodGraph anchor={anchor} />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("node-count").textContent).toBe("3"));
+    expect(screen.getByTestId("link-count").textContent).toBe("2");
+    expect(screen.getByRole("button", { name: /A \(anchor\)/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^B$/ })).toBeInTheDocument();
+  });
+
+  it("shows the empty state when the note has no neighbors", async () => {
+    seedActiveVault();
+    mockFetchReturning({});
+    render(
+      <Wrap>
+        <NeighborhoodGraph anchor={{ ...anchor, links: [] }} />
+      </Wrap>,
+    );
+    await waitFor(() => expect(screen.getByText(/no neighbors yet/i)).toBeInTheDocument());
+    expect(screen.queryByTestId("mock-force-graph")).not.toBeInTheDocument();
+  });
+
+  it("clicking a node navigates to that note", async () => {
+    seedActiveVault();
+    mockFetchReturning({
+      B: { id: "B", path: "notes/B", createdAt: "2026-04-18T00:00:00.000Z" },
+      C: { id: "C", path: "notes/C", createdAt: "2026-04-18T00:00:00.000Z" },
+    });
+    render(
+      <Wrap>
+        <NeighborhoodGraph anchor={anchor} />
+      </Wrap>,
+    );
+    const btn = await screen.findByRole("button", { name: /^B$/ });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+    await waitFor(() => expect(screen.getByTestId("note-route")).toBeInTheDocument());
+  });
+
+  it("depth=1 does not fetch any neighbors", async () => {
+    seedActiveVault();
+    const fetchImpl = mockFetchReturning({
+      B: { id: "B", path: "notes/B", createdAt: "2026-04-18T00:00:00.000Z" },
+      C: { id: "C", path: "notes/C", createdAt: "2026-04-18T00:00:00.000Z" },
+    });
+    render(
+      <Wrap>
+        <NeighborhoodGraph anchor={anchor} />
+      </Wrap>,
+    );
+    // Settle depth 2 default first (renders with 3 nodes).
+    await waitFor(() => expect(screen.getByTestId("node-count").textContent).toBe("3"));
+    fetchImpl.mockClear();
+
+    const depth1 = screen.getByRole("button", { name: "1" });
+    await act(async () => {
+      fireEvent.click(depth1);
+    });
+
+    await waitFor(() => expect(screen.getByText(/no neighbors yet/i)).toBeInTheDocument());
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("collapses and re-expands via the header toggle", async () => {
+    seedActiveVault();
+    mockFetchReturning({
+      B: { id: "B", path: "notes/B", createdAt: "2026-04-18T00:00:00.000Z" },
+      C: { id: "C", path: "notes/C", createdAt: "2026-04-18T00:00:00.000Z" },
+    });
+    render(
+      <Wrap>
+        <NeighborhoodGraph anchor={anchor} />
+      </Wrap>,
+    );
+    await screen.findByTestId("mock-force-graph");
+    const toggle = screen.getByRole("button", { name: /Neighborhood/ });
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    expect(screen.queryByTestId("mock-force-graph")).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /graph depth/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/NeighborhoodGraph.tsx
+++ b/src/components/NeighborhoodGraph.tsx
@@ -1,0 +1,163 @@
+import { useActiveVaultClient } from "@/lib/vault";
+import {
+  DEFAULT_DEPTH,
+  type GraphNode,
+  MAX_DEPTH,
+  MIN_DEPTH,
+  type NeighborhoodGraphData,
+  useNeighborhood,
+} from "@/lib/vault/neighborhood";
+import type { Note } from "@/lib/vault/types";
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+
+const ForceGraph2D = lazy(() => import("react-force-graph-2d"));
+
+interface Props {
+  anchor: Note;
+}
+
+export function NeighborhoodGraph({ anchor }: Props) {
+  const [open, setOpen] = useState(true);
+  const [depth, setDepth] = useState(DEFAULT_DEPTH);
+  const client = useActiveVaultClient();
+  const { data, isLoading } = useNeighborhood(client, open ? anchor : undefined, depth);
+
+  return (
+    <section className="mt-10 border-t border-border pt-6">
+      <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            aria-expanded={open}
+            className="font-serif text-xl text-fg hover:text-accent"
+          >
+            {open ? "▾" : "▸"} Neighborhood
+          </button>
+          {open && data ? (
+            <span className="text-xs text-fg-dim">
+              {data.nodes.length} {data.nodes.length === 1 ? "note" : "notes"}
+            </span>
+          ) : null}
+        </div>
+        {open ? <DepthControl depth={depth} onChange={setDepth} /> : null}
+      </header>
+
+      {open ? <Body data={data} isLoading={isLoading} /> : null}
+    </section>
+  );
+}
+
+function DepthControl({ depth, onChange }: { depth: number; onChange: (d: number) => void }) {
+  const options: number[] = [];
+  for (let i = MIN_DEPTH; i <= MAX_DEPTH; i++) options.push(i);
+  return (
+    <fieldset className="flex items-center gap-1 text-xs text-fg-dim">
+      <legend className="mr-1 inline-block">Depth</legend>
+      {options.map((d) => (
+        <button
+          key={d}
+          type="button"
+          aria-pressed={d === depth}
+          onClick={() => onChange(d)}
+          className={
+            d === depth
+              ? "rounded border border-accent bg-accent/10 px-2 py-0.5 text-accent"
+              : "rounded border border-border bg-card px-2 py-0.5 hover:text-accent"
+          }
+        >
+          {d}
+        </button>
+      ))}
+    </fieldset>
+  );
+}
+
+function Body({ data, isLoading }: { data: NeighborhoodGraphData | null; isLoading: boolean }) {
+  if (!data && isLoading) {
+    return <GraphSkeleton />;
+  }
+  if (!data) return null;
+  if (data.nodes.length <= 1) {
+    return (
+      <div className="rounded-md border border-border bg-card p-6 text-center text-sm text-fg-dim">
+        This note has no neighbors yet.
+      </div>
+    );
+  }
+  return <GraphCanvas data={data} />;
+}
+
+function GraphSkeleton() {
+  return (
+    <div
+      aria-busy="true"
+      className="h-[24rem] w-full animate-pulse rounded-md border border-border bg-card"
+    />
+  );
+}
+
+function GraphCanvas({ data }: { data: NeighborhoodGraphData }) {
+  const navigate = useNavigate();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState<{ w: number; h: number }>({ w: 600, h: 384 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      setSize({ w: Math.max(320, Math.floor(rect.width)), h: 384 });
+    };
+    update();
+    const obs = new ResizeObserver(update);
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  const graphData = useMemo(
+    () => ({
+      nodes: data.nodes.map((n) => ({ ...n })),
+      links: data.edges.map((e) => ({ source: e.source, target: e.target, rel: e.relationship })),
+    }),
+    [data],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="neighborhood-graph-canvas"
+      className="overflow-hidden rounded-md border border-border bg-card"
+    >
+      <Suspense fallback={<GraphSkeleton />}>
+        <ForceGraph2D
+          graphData={graphData}
+          width={size.w}
+          height={size.h}
+          nodeLabel={(n) => nodeTooltip(n as unknown as GraphNode)}
+          nodeVal={(n) => {
+            const node = n as unknown as GraphNode;
+            return node.isAnchor ? 8 : 3 + Math.min(node.linkCount, 8);
+          }}
+          nodeColor={(n) => ((n as unknown as GraphNode).isAnchor ? "#c9b170" : "#8a9a7a")}
+          linkColor={() => "rgba(160, 160, 160, 0.4)"}
+          linkDirectionalArrowLength={3}
+          linkDirectionalArrowRelPos={1}
+          cooldownTicks={80}
+          onNodeClick={(n) => {
+            const node = n as unknown as GraphNode;
+            navigate(`/notes/${encodeURIComponent(node.id)}`);
+          }}
+        />
+      </Suspense>
+    </div>
+  );
+}
+
+function nodeTooltip(n: GraphNode): string {
+  const lines = [n.path ?? n.id];
+  if (n.tags && n.tags.length > 0) lines.push(`tags: ${n.tags.join(", ")}`);
+  if (n.summary) lines.push(n.summary);
+  return lines.join("\n");
+}

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -1,5 +1,6 @@
 export * from "./client";
 export * from "./discovery";
+export * from "./neighborhood";
 export * from "./note-query";
 export * from "./oauth";
 export * from "./pkce";

--- a/src/lib/vault/neighborhood.test.ts
+++ b/src/lib/vault/neighborhood.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { buildNeighborhoodGraph, expandNeighborhood } from "./neighborhood";
+import type { Note } from "./types";
+
+function note(id: string, links: Array<[string, string]> = [], extras: Partial<Note> = {}): Note {
+  return {
+    id,
+    path: `notes/${id}`,
+    createdAt: "2026-04-18T00:00:00.000Z",
+    metadata: { summary: `summary for ${id}` },
+    tags: ["t"],
+    links: links.map(([source, target]) => ({
+      sourceId: source,
+      targetId: target,
+      relationship: "wikilink",
+    })),
+    ...extras,
+  };
+}
+
+describe("buildNeighborhoodGraph", () => {
+  it("marks the anchor and dedupes edges", () => {
+    const anchor = note("A", [
+      ["A", "B"],
+      ["A", "B"],
+      ["C", "A"],
+    ]);
+    const b = note("B", [["A", "B"]]);
+    const c = note("C", [["C", "A"]]);
+    const notes = new Map([
+      ["A", anchor],
+      ["B", b],
+      ["C", c],
+    ]);
+
+    const graph = buildNeighborhoodGraph("A", notes);
+
+    expect(graph.nodes).toHaveLength(3);
+    expect(graph.nodes.find((n) => n.id === "A")?.isAnchor).toBe(true);
+    expect(graph.nodes.find((n) => n.id === "B")?.isAnchor).toBe(false);
+    expect(graph.edges).toHaveLength(2);
+    expect(graph.edges).toContainEqual({ source: "A", target: "B", relationship: "wikilink" });
+    expect(graph.edges).toContainEqual({ source: "C", target: "A", relationship: "wikilink" });
+  });
+
+  it("skips edges where an endpoint is not in the notes map", () => {
+    const anchor = note("A", [
+      ["A", "B"],
+      ["A", "Z"], // Z is out of neighborhood
+    ]);
+    const b = note("B");
+    const notes = new Map([
+      ["A", anchor],
+      ["B", b],
+    ]);
+    const graph = buildNeighborhoodGraph("A", notes);
+    expect(graph.nodes.map((n) => n.id).sort()).toEqual(["A", "B"]);
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.edges[0]).toEqual({ source: "A", target: "B", relationship: "wikilink" });
+  });
+
+  it("counts links per node for sizing", () => {
+    const a = note("A", [
+      ["A", "B"],
+      ["A", "C"],
+    ]);
+    const b = note("B");
+    const c = note("C");
+    const graph = buildNeighborhoodGraph(
+      "A",
+      new Map([
+        ["A", a],
+        ["B", b],
+        ["C", c],
+      ]),
+    );
+    expect(graph.nodes.find((n) => n.id === "A")?.linkCount).toBe(2);
+    expect(graph.nodes.find((n) => n.id === "B")?.linkCount).toBe(1);
+    expect(graph.nodes.find((n) => n.id === "C")?.linkCount).toBe(1);
+  });
+
+  it("exposes summary and tags for tooltip use", () => {
+    const a = note("A", [], { metadata: { summary: "about A" }, tags: ["x", "y"] });
+    const graph = buildNeighborhoodGraph("A", new Map([["A", a]]));
+    const node = graph.nodes[0];
+    expect(node.summary).toBe("about A");
+    expect(node.tags).toEqual(["x", "y"]);
+  });
+});
+
+describe("expandNeighborhood", () => {
+  it("returns just the anchor at depth 1", async () => {
+    const anchor = note("A", [["A", "B"]]);
+    const fetched: string[] = [];
+    const result = await expandNeighborhood(anchor, 1, async (id) => {
+      fetched.push(id);
+      return null;
+    });
+    expect(fetched).toEqual([]);
+    expect([...result.keys()]).toEqual(["A"]);
+  });
+
+  it("fetches 1-hop neighbors at depth 2", async () => {
+    const anchor = note("A", [
+      ["A", "B"],
+      ["C", "A"],
+    ]);
+    const fetched: string[] = [];
+    const fetchNote = async (id: string): Promise<Note | null> => {
+      fetched.push(id);
+      return note(id);
+    };
+    const result = await expandNeighborhood(anchor, 2, fetchNote);
+    expect(fetched.sort()).toEqual(["B", "C"]);
+    expect([...result.keys()].sort()).toEqual(["A", "B", "C"]);
+  });
+
+  it("fetches 2-hop neighbors at depth 3", async () => {
+    const anchor = note("A", [["A", "B"]]);
+    const neighbors = new Map<string, Note>([
+      ["B", note("B", [["B", "C"]])],
+      ["C", note("C")],
+    ]);
+    const fetched: string[] = [];
+    const fetchNote = async (id: string) => {
+      fetched.push(id);
+      return neighbors.get(id) ?? null;
+    };
+    const result = await expandNeighborhood(anchor, 3, fetchNote);
+    expect(fetched).toEqual(["B", "C"]);
+    expect([...result.keys()].sort()).toEqual(["A", "B", "C"]);
+  });
+
+  it("stops early if a layer has no new ids to fetch", async () => {
+    const anchor = note("A", [["A", "A"]]);
+    const fetchNote = async () => null;
+    const result = await expandNeighborhood(anchor, 3, fetchNote);
+    expect([...result.keys()]).toEqual(["A"]);
+  });
+
+  it("swallows per-node fetch errors and keeps the others", async () => {
+    const anchor = note("A", [
+      ["A", "B"],
+      ["A", "C"],
+    ]);
+    const fetchNote = async (id: string) => {
+      if (id === "B") throw new Error("boom");
+      return note(id);
+    };
+    const result = await expandNeighborhood(anchor, 2, fetchNote);
+    expect([...result.keys()].sort()).toEqual(["A", "C"]);
+  });
+
+  it("abandons a layer's fetched notes when cancellation is observed", async () => {
+    const anchor = note("A", [["A", "B"]]);
+    const signal = { cancelled: false };
+    const fetchNote = async (id: string) => {
+      if (id === "B") {
+        signal.cancelled = true;
+        return note(id);
+      }
+      return note(id);
+    };
+    const result = await expandNeighborhood(anchor, 3, fetchNote, signal);
+    // Cancellation observed after layer 1's Promise.all — B is discarded.
+    expect([...result.keys()]).toEqual(["A"]);
+  });
+});

--- a/src/lib/vault/neighborhood.ts
+++ b/src/lib/vault/neighborhood.ts
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import type { VaultClient } from "./client";
+import type { Note } from "./types";
+
+export interface GraphNode {
+  id: string;
+  path?: string;
+  tags?: string[];
+  summary?: string;
+  isAnchor: boolean;
+  linkCount: number;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  relationship: string;
+}
+
+export interface NeighborhoodGraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export const MIN_DEPTH = 1;
+export const MAX_DEPTH = 3;
+export const DEFAULT_DEPTH = 2;
+
+export function buildNeighborhoodGraph(
+  anchorId: string,
+  notesById: Map<string, Note>,
+): NeighborhoodGraphData {
+  const edges = new Map<string, GraphEdge>();
+  const linkCount = new Map<string, number>();
+
+  for (const note of notesById.values()) {
+    for (const l of note.links ?? []) {
+      if (l.sourceId === l.targetId) continue;
+      if (!notesById.has(l.sourceId) || !notesById.has(l.targetId)) continue;
+      const key = `${l.sourceId}|${l.targetId}|${l.relationship}`;
+      if (edges.has(key)) continue;
+      edges.set(key, {
+        source: l.sourceId,
+        target: l.targetId,
+        relationship: l.relationship,
+      });
+      linkCount.set(l.sourceId, (linkCount.get(l.sourceId) ?? 0) + 1);
+      linkCount.set(l.targetId, (linkCount.get(l.targetId) ?? 0) + 1);
+    }
+  }
+
+  const nodes: GraphNode[] = [...notesById.values()].map((n) => ({
+    id: n.id,
+    path: n.path,
+    tags: n.tags,
+    summary: typeof n.metadata?.summary === "string" ? n.metadata.summary : undefined,
+    isAnchor: n.id === anchorId,
+    linkCount: linkCount.get(n.id) ?? 0,
+  }));
+
+  return { nodes, edges: [...edges.values()] };
+}
+
+export async function expandNeighborhood(
+  anchor: Note,
+  depth: number,
+  fetchNote: (id: string) => Promise<Note | null>,
+  signal?: { cancelled: boolean },
+): Promise<Map<string, Note>> {
+  const notes = new Map<string, Note>();
+  notes.set(anchor.id, anchor);
+
+  let frontier: Note[] = [anchor];
+  for (let layer = 1; layer < depth; layer++) {
+    const toFetch = new Set<string>();
+    for (const note of frontier) {
+      for (const l of note.links ?? []) {
+        const peerId = l.sourceId === note.id ? l.targetId : l.sourceId;
+        if (peerId === note.id) continue;
+        if (!notes.has(peerId)) toFetch.add(peerId);
+      }
+    }
+    if (toFetch.size === 0) break;
+    const fetched = await Promise.all([...toFetch].map((id) => fetchNote(id).catch(() => null)));
+    if (signal?.cancelled) return notes;
+    const next: Note[] = [];
+    for (const n of fetched) {
+      if (n && !notes.has(n.id)) {
+        notes.set(n.id, n);
+        next.push(n);
+      }
+    }
+    frontier = next;
+  }
+  return notes;
+}
+
+export function useNeighborhood(
+  client: VaultClient | null,
+  anchor: Note | undefined,
+  depth: number,
+): { data: NeighborhoodGraphData | null; isLoading: boolean } {
+  const [data, setData] = useState<NeighborhoodGraphData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!client || !anchor) {
+      setData(null);
+      setIsLoading(false);
+      return;
+    }
+    const signal = { cancelled: false };
+    setIsLoading(true);
+    expandNeighborhood(anchor, depth, (id) => client.getNote(id, { includeLinks: true }), signal)
+      .then((notes) => {
+        if (signal.cancelled) return;
+        setData(buildNeighborhoodGraph(anchor.id, notes));
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (signal.cancelled) return;
+        setIsLoading(false);
+      });
+    return () => {
+      signal.cancelled = true;
+    };
+  }, [client, anchor, depth]);
+
+  return { data, isLoading };
+}


### PR DESCRIPTION
## Summary

Renders a neighborhood graph on `/notes/:id`. Makes the note view feel like a vault, not a page.

- **Pure data-transform** in `src/lib/vault/neighborhood.ts` — `buildNeighborhoodGraph()` builds `{nodes, edges}` from a map of notes, and `expandNeighborhood()` does a layered BFS up to depth N with cancellation support. The vault's native `near` query returned empty for a non-trivial anchor in my spot-checks, so I went with the team-lead-suggested fallback: two passes of `include_links: true` on discovered notes. Works reliably.
- **Component** in `src/components/NeighborhoodGraph.tsx` — `react-force-graph-2d` behind `React.lazy` so it only loads when the panel is open. Default collapsed-open state; click the header to hide. Anchor node highlighted, node size by link-count, clicking a node navigates.
- **Depth control** — buttons for 1/2/3, default 2, as scoped. `depth=1` renders just the anchor (empty state).
- **Empty state** when a note has no neighbors: "This note has no neighbors yet."
- **Mounted** in the left (main) column below the attachment section on NoteView.

## Bundle

The force-graph library lazy-chunks to **188KB raw / 60KB gzipped**, separate from the main bundle. You only pay for it when you open a note's panel. Initial bundle is unchanged.

## Files

- `src/lib/vault/neighborhood.ts` (new) — data module + hook
- `src/lib/vault/neighborhood.test.ts` (new) — 10 tests (build-graph + BFS)
- `src/components/NeighborhoodGraph.tsx` (new) — UI
- `src/components/NeighborhoodGraph.test.tsx` (new) — 5 tests (render, empty, click-navigates, depth=1 skips fetches, collapse)
- `src/app/routes/NoteView.tsx` — mount point
- `src/lib/vault/index.ts` — re-export
- `package.json`, `bun.lock` — add react-force-graph-2d

## Out of scope (later PRs)

- Full-vault graph (PR #14)
- Tag-based filtering
- 3D variant
- Styling edges by relationship type
- Pinning the anchor at center (force-graph's built-in center-on-mount is good enough for v1)

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 141 pass (15 new)
- [x] `bun run build` — force-graph lazy-chunked
- [ ] Manual: load a note with ≥1 wikilink, expand the panel, verify anchor renders with neighbors; click a neighbor and confirm navigation; switch depth 1/2/3; collapse/re-expand
- [ ] Manual: load a note with no links — verify empty state instead of empty canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)