### PR TITLE
Full-vault graph at /graph with search + tag filters

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import { NoteNew } from "./routes/NoteNew";
 import { NoteView } from "./routes/NoteView";
 import { Notes } from "./routes/Notes";
 import { OAuthCallback } from "./routes/OAuthCallback";
+import { VaultGraph } from "./routes/VaultGraph";
 import { Vaults } from "./routes/Vaults";
 
 export function App() {
@@ -23,6 +24,7 @@ export function App() {
               <Route path="/" element={<Home />} />
               <Route path="/notes" element={<Notes />} />
               <Route path="/new" element={<NoteNew />} />
+              <Route path="/graph" element={<VaultGraph />} />
               <Route path="/notes/:id" element={<NoteView />} />
               <Route path="/notes/:id/edit" element={<NoteEditor />} />
               <Route path="/add" element={<AddVault />} />

--- a/src/app/routes/VaultGraph.test.tsx
+++ b/src/app/routes/VaultGraph.test.tsx
@@ -1,0 +1,219 @@
+import { VaultGraph } from "@/app/routes/VaultGraph";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the force graph lib — jsdom has no canvas, and we only care about
+// the data/click wiring, not the actual rendering.
+interface MockGraphData {
+  nodes: Array<{ id: string; title: string }>;
+  links: Array<{ source: string; target: string; rel?: string }>;
+}
+
+vi.mock("react-force-graph-2d", () => ({
+  default: (props: {
+    graphData: MockGraphData;
+    onNodeClick: (n: { id: string }) => void;
+    nodeColor?: (n: { id: string }) => string;
+  }) => (
+    <div data-testid="mock-force-graph">
+      <span data-testid="node-count">{props.graphData.nodes.length}</span>
+      <span data-testid="link-count">{props.graphData.links.length}</span>
+      <ul>
+        {props.graphData.nodes.map((n) => (
+          <li key={n.id}>
+            <button
+              type="button"
+              onClick={() => props.onNodeClick(n)}
+              data-color={props.nodeColor?.(n) ?? ""}
+            >
+              {n.title}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+
+// jsdom doesn't implement ResizeObserver.
+beforeEach(() => {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+    class MockResizeObserver {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    } as unknown as typeof ResizeObserver;
+});
+
+function seedActiveVault() {
+  useVaultStore.setState({
+    vaults: {
+      v1: {
+        id: "v1",
+        url: "http://localhost:1940",
+        name: "default",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v1",
+  });
+  localStorage.setItem(
+    "lens:token:v1",
+    JSON.stringify({ accessToken: "t", scope: "full", vault: "default" }),
+  );
+}
+
+function Wrap({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return (
+    <MemoryRouter initialEntries={["/graph"]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/graph" element={children} />
+          <Route path="/notes/:id" element={<div data-testid="note-route" />} />
+          <Route path="/new" element={<div data-testid="new-route" />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function installFetch(notes: unknown[]) {
+  const impl = vi.fn<typeof fetch>(async () => {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => notes,
+      text: async () => "",
+    } as Response;
+  });
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
+
+describe("VaultGraph route", () => {
+  beforeEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+
+  const notes = [
+    {
+      id: "a",
+      path: "Projects/Lens.md",
+      createdAt: "2026-04-18T00:00:00.000Z",
+      tags: ["project"],
+      links: [{ sourceId: "a", targetId: "b", relationship: "wikilink" }],
+    },
+    {
+      id: "b",
+      path: "Canon/Uni.md",
+      createdAt: "2026-04-18T00:00:00.000Z",
+      tags: ["canon"],
+      links: [],
+    },
+    {
+      id: "c",
+      path: "Journal/2026-04-18.md",
+      createdAt: "2026-04-18T00:00:00.000Z",
+      tags: [],
+      links: [],
+    },
+  ];
+
+  it("renders nodes and edges from the fetched notes", async () => {
+    seedActiveVault();
+    installFetch(notes);
+    render(
+      <Wrap>
+        <VaultGraph />
+      </Wrap>,
+    );
+    await waitFor(() => expect(screen.getByTestId("node-count").textContent).toBe("3"));
+    expect(screen.getByTestId("link-count").textContent).toBe("1");
+    expect(screen.getByRole("button", { name: "Lens" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Uni" })).toBeInTheDocument();
+    expect(screen.getByText("3 / 3 notes")).toBeInTheDocument();
+  });
+
+  it("search input narrows the matched count", async () => {
+    seedActiveVault();
+    installFetch(notes);
+    render(
+      <Wrap>
+        <VaultGraph />
+      </Wrap>,
+    );
+    await screen.findByTestId("mock-force-graph");
+
+    fireEvent.change(screen.getByLabelText(/search graph nodes/i), {
+      target: { value: "Lens" },
+    });
+    await waitFor(() => expect(screen.getByText("1 / 3 notes")).toBeInTheDocument());
+  });
+
+  it("toggling a tag chip filters matches", async () => {
+    seedActiveVault();
+    installFetch(notes);
+    render(
+      <Wrap>
+        <VaultGraph />
+      </Wrap>,
+    );
+    await screen.findByTestId("mock-force-graph");
+
+    const canonChip = screen.getByRole("button", { name: "canon" });
+    await act(async () => {
+      fireEvent.click(canonChip);
+    });
+    expect(canonChip).toHaveAttribute("aria-pressed", "true");
+    await waitFor(() => expect(screen.getByText("1 / 3 notes")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /clear/i }));
+    });
+    await waitFor(() => expect(screen.getByText("3 / 3 notes")).toBeInTheDocument());
+  });
+
+  it("clicking a node navigates to that note", async () => {
+    seedActiveVault();
+    installFetch(notes);
+    render(
+      <Wrap>
+        <VaultGraph />
+      </Wrap>,
+    );
+    const btn = await screen.findByRole("button", { name: "Lens" });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+    await waitFor(() => expect(screen.getByTestId("note-route")).toBeInTheDocument());
+  });
+
+  it("shows the empty state when the vault has no notes", async () => {
+    seedActiveVault();
+    installFetch([]);
+    render(
+      <Wrap>
+        <VaultGraph />
+      </Wrap>,
+    );
+    await waitFor(() => expect(screen.getByText(/no notes yet/i)).toBeInTheDocument());
+    expect(screen.queryByTestId("mock-force-graph")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/routes/VaultGraph.tsx
+++ b/src/app/routes/VaultGraph.tsx
@@ -1,0 +1,298 @@
+import {
+  EMPTY_FILTER,
+  type VaultGraphFilter,
+  type VaultGraphNode,
+  type VaultGraph as VaultGraphType,
+  buildVaultGraph,
+  collectTopTags,
+  matchesFilter,
+  tagColor,
+  useAllNotesWithLinks,
+  useVaultStore,
+} from "@/lib/vault";
+import { VaultAuthError } from "@/lib/vault/client";
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
+import { Link, Navigate, useNavigate } from "react-router";
+
+const ForceGraph2D = lazy(() => import("react-force-graph-2d"));
+
+const MAX_TAG_CHIPS = 20;
+
+export function VaultGraph() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const query = useAllNotesWithLinks();
+  const [filter, setFilter] = useState<VaultGraphFilter>(EMPTY_FILTER);
+
+  const graph = useMemo(() => (query.data ? buildVaultGraph(query.data) : null), [query.data]);
+  const allTags = useMemo(() => (graph ? collectTopTags(graph.nodes) : []), [graph]);
+  const matched = useMemo(() => {
+    if (!graph) return new Set<string>();
+    return new Set(graph.nodes.filter((n) => matchesFilter(n, filter)).map((n) => n.id));
+  }, [graph, filter]);
+
+  if (!activeVault) return <Navigate to="/" replace />;
+
+  return (
+    <div className="flex h-[calc(100dvh-5rem)] flex-col">
+      <div className="border-b border-border bg-card/40 px-6 py-3">
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-4">
+          <input
+            type="search"
+            value={filter.search}
+            onChange={(e) => setFilter((f) => ({ ...f, search: e.target.value }))}
+            placeholder="Search nodes…"
+            aria-label="Search graph nodes"
+            className="min-w-48 rounded-md border border-border bg-card px-3 py-1.5 text-sm text-fg focus:border-accent focus:outline-none"
+          />
+          <TagFilter
+            allTags={allTags}
+            selected={filter.tags}
+            onChange={(tags) => setFilter((f) => ({ ...f, tags }))}
+          />
+          {graph ? (
+            <span className="text-xs text-fg-dim">
+              {matched.size} / {graph.nodes.length} notes
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        <Body query={query} graph={graph} matched={matched} />
+      </div>
+    </div>
+  );
+}
+
+function Body({
+  query,
+  graph,
+  matched,
+}: {
+  query: ReturnType<typeof useAllNotesWithLinks>;
+  graph: VaultGraphType | null;
+  matched: Set<string>;
+}) {
+  if (query.isPending) return <GraphSkeleton message="Loading vault…" />;
+  if (query.isError) {
+    return <ErrorBlock error={query.error} />;
+  }
+  if (!graph || graph.nodes.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-10">
+        <div className="max-w-sm rounded-md border border-border bg-card p-8 text-center">
+          <p className="mb-2 font-serif text-xl">No notes yet</p>
+          <p className="mb-4 text-sm text-fg-muted">
+            This vault is empty. Start by creating the first note.
+          </p>
+          <Link
+            to="/new"
+            className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+          >
+            Create a note
+          </Link>
+        </div>
+      </div>
+    );
+  }
+  return <GraphCanvas graph={graph} matched={matched} />;
+}
+
+function TagFilter({
+  allTags,
+  selected,
+  onChange,
+}: {
+  allTags: string[];
+  selected: string[];
+  onChange: (tags: string[]) => void;
+}) {
+  const visible = allTags.slice(0, MAX_TAG_CHIPS);
+  if (visible.length === 0) return null;
+  const toggle = (t: string) =>
+    onChange(selected.includes(t) ? selected.filter((x) => x !== t) : [...selected, t]);
+  return (
+    <fieldset
+      aria-label="Filter by tag"
+      className="flex flex-wrap items-center gap-1 text-xs text-fg-dim"
+    >
+      <legend className="mr-1 inline-block">Tags</legend>
+      {visible.map((t) => {
+        const active = selected.includes(t);
+        return (
+          <button
+            key={t}
+            type="button"
+            aria-pressed={active}
+            onClick={() => toggle(t)}
+            className={
+              active
+                ? "rounded-full border border-accent bg-accent/10 px-2 py-0.5 text-accent"
+                : "rounded-full border border-border bg-card px-2 py-0.5 hover:text-accent"
+            }
+          >
+            {t}
+          </button>
+        );
+      })}
+      {selected.length > 0 ? (
+        <button
+          type="button"
+          onClick={() => onChange([])}
+          className="ml-1 text-xs text-fg-dim hover:text-accent"
+        >
+          Clear
+        </button>
+      ) : null}
+    </fieldset>
+  );
+}
+
+function GraphSkeleton({ message }: { message: string }) {
+  return (
+    <div
+      aria-busy="true"
+      className="flex h-full animate-pulse items-center justify-center bg-card/30 text-sm text-fg-dim"
+    >
+      {message}
+    </div>
+  );
+}
+
+function GraphCanvas({
+  graph,
+  matched,
+}: {
+  graph: VaultGraphType;
+  matched: Set<string>;
+}) {
+  const navigate = useNavigate();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState<{ w: number; h: number }>({ w: 800, h: 600 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      setSize({
+        w: Math.max(320, Math.floor(rect.width)),
+        h: Math.max(320, Math.floor(rect.height)),
+      });
+    };
+    update();
+    const obs = new ResizeObserver(update);
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  const graphData = useMemo(
+    () => ({
+      nodes: graph.nodes.map((n) => ({ ...n })),
+      links: graph.edges.map((e) => ({
+        source: e.source,
+        target: e.target,
+        rel: e.relationship,
+      })),
+    }),
+    [graph],
+  );
+
+  const hasFilter = matched.size !== graph.nodes.length;
+  const nodeOpacity = (id: string) => (!hasFilter || matched.has(id) ? 1 : 0.15);
+
+  return (
+    <div ref={containerRef} data-testid="vault-graph-canvas" className="h-full w-full">
+      <Suspense fallback={<GraphSkeleton message="Rendering graph…" />}>
+        <ForceGraph2D
+          graphData={graphData}
+          width={size.w}
+          height={size.h}
+          backgroundColor="rgba(0,0,0,0)"
+          nodeLabel={(n) => nodeTooltip(n as unknown as VaultGraphNode)}
+          nodeVal={(n) => {
+            const node = n as unknown as VaultGraphNode;
+            return 2 + Math.min(node.degree, 12);
+          }}
+          nodeColor={(n) => {
+            const node = n as unknown as VaultGraphNode;
+            const base = tagColor(node.topTag);
+            return hasFilter && !matched.has(node.id) ? fade(base) : base;
+          }}
+          linkColor={(l) => {
+            const link = l as unknown as { source: unknown; target: unknown };
+            const srcId = resolveEndpointId(link.source);
+            const tgtId = resolveEndpointId(link.target);
+            const dim =
+              hasFilter && (!matched.has(srcId) || !matched.has(tgtId))
+                ? "rgba(160, 160, 160, 0.08)"
+                : "rgba(160, 160, 160, 0.35)";
+            return dim;
+          }}
+          linkDirectionalArrowLength={2.5}
+          linkDirectionalArrowRelPos={1}
+          cooldownTicks={100}
+          nodeCanvasObjectMode={() => "after"}
+          nodeCanvasObject={(n, ctx, globalScale) => {
+            const node = n as unknown as VaultGraphNode & { x?: number; y?: number };
+            if (node.x == null || node.y == null) return;
+            const opacity = nodeOpacity(node.id);
+            if (opacity < 0.5) return;
+            const fontSize = 10 / globalScale;
+            ctx.font = `${fontSize}px sans-serif`;
+            ctx.fillStyle = "rgba(220, 220, 220, 0.8)";
+            ctx.textAlign = "left";
+            ctx.textBaseline = "middle";
+            ctx.fillText(node.title, node.x + 6, node.y);
+          }}
+          onNodeClick={(n) => {
+            const node = n as unknown as VaultGraphNode;
+            navigate(`/notes/${encodeURIComponent(node.id)}`);
+          }}
+        />
+      </Suspense>
+    </div>
+  );
+}
+
+function nodeTooltip(n: VaultGraphNode): string {
+  const lines = [n.path ?? n.id, `${n.degree} link${n.degree === 1 ? "" : "s"}`];
+  if (n.tags.length > 0) lines.push(`tags: ${n.tags.join(", ")}`);
+  if (n.summary) lines.push(n.summary);
+  return lines.join("\n");
+}
+
+function fade(color: string): string {
+  if (color.startsWith("hsl(")) return color.replace("hsl(", "hsla(").replace(")", ", 0.2)");
+  return color;
+}
+
+function resolveEndpointId(endpoint: unknown): string {
+  if (typeof endpoint === "string") return endpoint;
+  if (endpoint && typeof endpoint === "object" && "id" in endpoint) {
+    return String((endpoint as { id: unknown }).id);
+  }
+  return "";
+}
+
+function ErrorBlock({ error }: { error: Error }) {
+  const isAuth = error instanceof VaultAuthError;
+  return (
+    <div className="flex h-full items-center justify-center p-10">
+      <div className="max-w-md rounded-md border border-red-500/30 bg-red-500/5 p-6">
+        <p className="mb-2 font-medium text-red-400">
+          {isAuth ? "Session expired" : "Could not load vault"}
+        </p>
+        <p className="mb-4 text-sm text-fg-muted">{error.message}</p>
+        {isAuth ? (
+          <Link
+            to="/add"
+            className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+          >
+            Reconnect vault
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,6 +30,12 @@ export function Header() {
         <div className="flex items-center gap-3">
           {hasVaults ? (
             <>
+              <Link to="/notes" className="text-sm text-fg-muted hover:text-accent">
+                Notes
+              </Link>
+              <Link to="/graph" className="text-sm text-fg-muted hover:text-accent">
+                Graph
+              </Link>
               <label htmlFor="vault-switcher" className="sr-only">
                 Active vault
               </label>

--- a/src/lib/vault/graph.test.ts
+++ b/src/lib/vault/graph.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { buildVaultGraph, collectTopTags, matchesFilter, tagColor, titleFor } from "./graph";
+import type { Note } from "./types";
+
+function n(id: string, opts: Partial<Note> = {}): Note {
+  return {
+    id,
+    path: `notes/${id}`,
+    createdAt: "2026-04-18T00:00:00.000Z",
+    tags: [],
+    ...opts,
+  };
+}
+
+describe("buildVaultGraph", () => {
+  it("produces one node per note and dedupes edges", () => {
+    const notes: Note[] = [
+      n("A", {
+        links: [
+          { sourceId: "A", targetId: "B", relationship: "wikilink" },
+          { sourceId: "A", targetId: "B", relationship: "wikilink" },
+        ],
+      }),
+      n("B", {
+        links: [{ sourceId: "A", targetId: "B", relationship: "wikilink" }],
+      }),
+    ];
+    const g = buildVaultGraph(notes);
+    expect(g.nodes.map((x) => x.id).sort()).toEqual(["A", "B"]);
+    expect(g.edges).toHaveLength(1);
+    expect(g.edges[0]).toEqual({ source: "A", target: "B", relationship: "wikilink" });
+  });
+
+  it("drops edges that point outside the fetched note set", () => {
+    const notes: Note[] = [
+      n("A", {
+        links: [
+          { sourceId: "A", targetId: "B", relationship: "wikilink" },
+          { sourceId: "A", targetId: "Z", relationship: "wikilink" },
+        ],
+      }),
+      n("B"),
+    ];
+    const g = buildVaultGraph(notes);
+    expect(g.nodes.map((x) => x.id).sort()).toEqual(["A", "B"]);
+    expect(g.edges).toHaveLength(1);
+  });
+
+  it("computes degree per node", () => {
+    const notes: Note[] = [
+      n("A", {
+        links: [
+          { sourceId: "A", targetId: "B", relationship: "wikilink" },
+          { sourceId: "A", targetId: "C", relationship: "wikilink" },
+        ],
+      }),
+      n("B", {
+        links: [{ sourceId: "B", targetId: "C", relationship: "wikilink" }],
+      }),
+      n("C"),
+    ];
+    const g = buildVaultGraph(notes);
+    const byId = Object.fromEntries(g.nodes.map((x) => [x.id, x]));
+    expect(byId.A.degree).toBe(2);
+    expect(byId.B.degree).toBe(2);
+    expect(byId.C.degree).toBe(2);
+  });
+
+  it("captures tags, top tag, and summary", () => {
+    const notes: Note[] = [
+      n("A", {
+        tags: ["canon", "uni"],
+        metadata: { summary: "anchor summary" },
+      }),
+    ];
+    const g = buildVaultGraph(notes);
+    expect(g.nodes[0].tags).toEqual(["canon", "uni"]);
+    expect(g.nodes[0].topTag).toBe("canon");
+    expect(g.nodes[0].summary).toBe("anchor summary");
+  });
+});
+
+describe("titleFor", () => {
+  it("strips .md and returns the path basename", () => {
+    expect(titleFor(n("A", { path: "Canon/Uni.md" }))).toBe("Uni");
+  });
+  it("falls back to id when path is missing", () => {
+    expect(titleFor(n("id-only", { path: undefined }))).toBe("id-only");
+  });
+});
+
+describe("matchesFilter", () => {
+  const node = {
+    id: "a-1",
+    path: "Projects/Lens.md",
+    title: "Lens",
+    tags: ["project", "active"],
+    degree: 3,
+  };
+
+  it("matches all nodes when filter is empty", () => {
+    expect(matchesFilter(node, { search: "", tags: [] })).toBe(true);
+  });
+
+  it("matches path substring case-insensitively", () => {
+    expect(matchesFilter(node, { search: "LENS", tags: [] })).toBe(true);
+    expect(matchesFilter(node, { search: "projects", tags: [] })).toBe(true);
+    expect(matchesFilter(node, { search: "xyz", tags: [] })).toBe(false);
+  });
+
+  it("matches any selected tag (OR semantics)", () => {
+    expect(matchesFilter(node, { search: "", tags: ["project"] })).toBe(true);
+    expect(matchesFilter(node, { search: "", tags: ["project", "canon"] })).toBe(true);
+    expect(matchesFilter(node, { search: "", tags: ["canon"] })).toBe(false);
+  });
+
+  it("combines search and tags with AND", () => {
+    expect(matchesFilter(node, { search: "Lens", tags: ["project"] })).toBe(true);
+    expect(matchesFilter(node, { search: "Lens", tags: ["canon"] })).toBe(false);
+    expect(matchesFilter(node, { search: "xyz", tags: ["project"] })).toBe(false);
+  });
+});
+
+describe("collectTopTags", () => {
+  it("orders by count desc, then alpha", () => {
+    const nodes = [
+      { id: "1", title: "1", tags: ["a", "b"], degree: 0 },
+      { id: "2", title: "2", tags: ["a"], degree: 0 },
+      { id: "3", title: "3", tags: ["c"], degree: 0 },
+    ];
+    expect(collectTopTags(nodes)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("tagColor", () => {
+  it("is stable for the same input", () => {
+    expect(tagColor("canon")).toBe(tagColor("canon"));
+  });
+  it("returns a default when tag is undefined", () => {
+    expect(tagColor(undefined)).toMatch(/^#/);
+  });
+});

--- a/src/lib/vault/graph.ts
+++ b/src/lib/vault/graph.ts
@@ -1,0 +1,108 @@
+import type { Note } from "./types";
+
+export interface VaultGraphNode {
+  id: string;
+  path?: string;
+  title: string;
+  tags: string[];
+  topTag?: string;
+  degree: number;
+  summary?: string;
+}
+
+export interface VaultGraphEdge {
+  source: string;
+  target: string;
+  relationship: string;
+}
+
+export interface VaultGraph {
+  nodes: VaultGraphNode[];
+  edges: VaultGraphEdge[];
+}
+
+export interface VaultGraphFilter {
+  search: string;
+  tags: string[];
+}
+
+export const EMPTY_FILTER: VaultGraphFilter = { search: "", tags: [] };
+
+export function buildVaultGraph(notes: Note[]): VaultGraph {
+  const notesById = new Map<string, Note>();
+  for (const n of notes) notesById.set(n.id, n);
+
+  const edgeMap = new Map<string, VaultGraphEdge>();
+  const degree = new Map<string, number>();
+
+  for (const note of notes) {
+    for (const l of note.links ?? []) {
+      if (l.sourceId === l.targetId) continue;
+      if (!notesById.has(l.sourceId) || !notesById.has(l.targetId)) continue;
+      const key = `${l.sourceId}|${l.targetId}|${l.relationship}`;
+      if (edgeMap.has(key)) continue;
+      edgeMap.set(key, {
+        source: l.sourceId,
+        target: l.targetId,
+        relationship: l.relationship,
+      });
+      degree.set(l.sourceId, (degree.get(l.sourceId) ?? 0) + 1);
+      degree.set(l.targetId, (degree.get(l.targetId) ?? 0) + 1);
+    }
+  }
+
+  const nodes: VaultGraphNode[] = notes.map((n) => {
+    const tags = n.tags ?? [];
+    return {
+      id: n.id,
+      path: n.path,
+      title: titleFor(n),
+      tags,
+      topTag: tags[0],
+      degree: degree.get(n.id) ?? 0,
+      summary: typeof n.metadata?.summary === "string" ? n.metadata.summary : undefined,
+    };
+  });
+
+  return { nodes, edges: [...edgeMap.values()] };
+}
+
+export function titleFor(note: Note): string {
+  if (note.path) {
+    const last = note.path.split("/").pop() ?? note.path;
+    return last.replace(/\.md$/i, "");
+  }
+  return note.id;
+}
+
+export function matchesFilter(node: VaultGraphNode, filter: VaultGraphFilter): boolean {
+  const q = filter.search.trim().toLowerCase();
+  if (q) {
+    const haystack = [node.path ?? "", node.title, node.id].join(" ").toLowerCase();
+    if (!haystack.includes(q)) return false;
+  }
+  if (filter.tags.length > 0) {
+    const hasAny = filter.tags.some((t) => node.tags.includes(t));
+    if (!hasAny) return false;
+  }
+  return true;
+}
+
+export function collectTopTags(nodes: VaultGraphNode[]): string[] {
+  const counts = new Map<string, number>();
+  for (const n of nodes) {
+    for (const t of n.tags) counts.set(t, (counts.get(t) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([t]) => t);
+}
+
+// Stable hue from tag name so the same tag keeps its color across sessions.
+export function tagColor(tag: string | undefined): string {
+  if (!tag) return "#8a9a7a";
+  let h = 0;
+  for (let i = 0; i < tag.length; i++) h = (h * 31 + tag.charCodeAt(i)) & 0xffffff;
+  const hue = h % 360;
+  return `hsl(${hue}, 40%, 55%)`;
+}

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -1,5 +1,6 @@
 export * from "./client";
 export * from "./discovery";
+export * from "./graph";
 export * from "./neighborhood";
 export * from "./note-query";
 export * from "./oauth";

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -48,6 +48,28 @@ export function useNotes(queryState: NoteQueryState) {
   });
 }
 
+// Cap on how many notes to pull back for the full-vault graph in v1.
+// If a vault grows beyond this, the graph page will show the first N —
+// pagination/sampling is a future PR.
+export const VAULT_GRAPH_NOTE_CAP = 5000;
+
+export function useAllNotesWithLinks() {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+
+  return useQuery({
+    queryKey: ["allNotesWithLinks", activeId],
+    enabled: !!client,
+    queryFn: () => {
+      const params = new URLSearchParams();
+      params.set("include_links", "true");
+      params.set("limit", String(VAULT_GRAPH_NOTE_CAP));
+      return client!.queryNotes(params);
+    },
+    staleTime: 60_000,
+  });
+}
+
 export function useTags() {
   const client = useActiveVaultClient();
   const activeId = useVaultStore((s) => s.activeVaultId);


### PR DESCRIPTION
## Summary
- New `/graph` route: fetches every note with `include_links: true` (capped at 5000 for v1), transforms into a vault-wide graph, renders via lazy-loaded `react-force-graph-2d`.
- Search + tag-chip filters **fade** non-matching nodes rather than removing them — spatial context is preserved, and the "X / Y notes" counter shows what the filter caught.
- Click a node → navigate to `/notes/:id`. Node size is driven by degree; color by stable hash of the top tag.
- Nav links added to the header (`Notes`, `Graph`) when a vault is connected.

## Scope notes
- Full fetch, no pagination or sampling. `VAULT_GRAPH_NOTE_CAP = 5000` — if a vault grows past that, the graph shows the first N. Pagination/sampling is a future PR.
- Edges that point outside the fetched set are dropped so dangling targets don't appear as ghost nodes.
- Force-graph lib stays in its own chunk (`react-force-graph-2d-*.js`, ~60 KB gzipped) via `React.lazy` + `Suspense`, same pattern as the neighborhood graph.
- Tag chips capped at 20 (by count desc, alpha tiebreak). Reasonable UX on wide tag vocabularies.

## Tests
- `src/lib/vault/graph.test.ts` — pure data: `buildVaultGraph` (dedupe edges, drop out-of-set, degree, tags/top tag), `titleFor`, `matchesFilter` (empty, search substring, tag OR, search+tag AND), `collectTopTags`, `tagColor` stability.
- `src/app/routes/VaultGraph.test.tsx` — smoke: renders nodes + edges from fetched notes, search narrows match count, tag chip toggles (aria-pressed, Clear resets), click-node navigates, empty-vault fallback.

## Gates
- ✅ lint
- ✅ typecheck
- ✅ test — 159/159
- ✅ build

## Test plan
- [ ] Visit `/graph` on a populated vault — see nodes + edges; hover for tooltip (path · degree · tags · summary).
- [ ] Type in search → non-matches fade, count updates; click a tag chip → same.
- [ ] Click a node → open note view.
- [ ] Connect an empty vault → see "No notes yet" + "Create a note" link.
- [ ] Expired token → see reconnect block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)