### PR TITLE
v1 polish: /tags route + theme toggle + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lens is a static single-page app that speaks directly to your vault over its HTT
 
 ## Status
 
-Pre-alpha, in active development toward launch with Parachute Vault.
+v1, in active use. Launching alongside Parachute Vault.
 
 ## Quick start
 
@@ -22,11 +22,12 @@ Open the dev URL, paste your vault URL, connect.
 - Multi-vault support — switch between vaults, tokens stored per vault
 - Note list with search, tag and path filters
 - Note view with rendered markdown, metadata, resolved `[[wikilinks]]`
-- Markdown editor with live preview
+- Markdown editor with live preview, attachments (drag, drop, paste)
 - Create and delete notes
+- Tag index at `/tags` — browse and click through to filtered note lists
 - Neighborhood graph on each note (via the vault's `near` query)
-- Full-vault graph view
-- Theme matched to Parachute's visual language
+- Full-vault graph at `/graph` with search and tag filters
+- Theme matched to Parachute's visual language — system, light, or dark; toggle in the header
 
 ## Build from source
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,16 @@
       content="Parachute Lens — a lightweight web UI for any Parachute Vault."
     />
     <title>Parachute Lens</title>
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem("lens:theme");
+          if (t === "dark" || t === "light") {
+            document.documentElement.setAttribute("data-theme", t);
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import { NoteNew } from "./routes/NoteNew";
 import { NoteView } from "./routes/NoteView";
 import { Notes } from "./routes/Notes";
 import { OAuthCallback } from "./routes/OAuthCallback";
+import { Tags } from "./routes/Tags";
 import { VaultGraph } from "./routes/VaultGraph";
 import { Vaults } from "./routes/Vaults";
 
@@ -23,6 +24,7 @@ export function App() {
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/notes" element={<Notes />} />
+              <Route path="/tags" element={<Tags />} />
               <Route path="/new" element={<NoteNew />} />
               <Route path="/graph" element={<VaultGraph />} />
               <Route path="/notes/:id" element={<NoteView />} />

--- a/src/app/routes/Tags.test.tsx
+++ b/src/app/routes/Tags.test.tsx
@@ -1,0 +1,174 @@
+import { Tags } from "@/app/routes/Tags";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FetchState {
+  tags: unknown[];
+}
+
+function installFetch(state: FetchState) {
+  const impl = vi.fn<typeof fetch>(async () => {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => state.tags,
+      text: async () => "",
+    } as Response;
+  });
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      v1: {
+        id: "v1",
+        url: "http://localhost:1940",
+        name: "default",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v1",
+  });
+  localStorage.setItem(
+    "lens:token:v1",
+    JSON.stringify({ accessToken: "t", scope: "full", vault: "default" }),
+  );
+}
+
+function LocationSpy() {
+  const loc = useLocation();
+  return <div data-testid="location">{`${loc.pathname}${loc.search}`}</div>;
+}
+
+function Wrap({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return (
+    <MemoryRouter initialEntries={["/tags"]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/tags" element={children} />
+          <Route path="/notes" element={<LocationSpy />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("Tags route", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+
+  it("renders tag chips sorted by count desc", async () => {
+    installFetch({
+      tags: [
+        { name: "daily", count: 2 },
+        { name: "canon", count: 9 },
+        { name: "idea", count: 5 },
+      ],
+    });
+    render(
+      <Wrap>
+        <Tags />
+      </Wrap>,
+    );
+    const list = await screen.findByRole("list", { name: /tag list/i });
+    const items = within(list).getAllByRole("listitem");
+    expect(items.map((el) => el.textContent ?? "")).toEqual(["canon9", "idea5", "daily2"]);
+  });
+
+  it("filters tags by the search input", async () => {
+    installFetch({
+      tags: [
+        { name: "canon", count: 1 },
+        { name: "journal", count: 2 },
+        { name: "uni", count: 3 },
+      ],
+    });
+    render(
+      <Wrap>
+        <Tags />
+      </Wrap>,
+    );
+    await screen.findByRole("link", { name: /canon/i });
+    fireEvent.change(screen.getByLabelText(/filter tags/i), { target: { value: "jour" } });
+    expect(screen.queryByRole("link", { name: /canon/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /journal/i })).toBeInTheDocument();
+    expect(screen.getByText(/1 \/ 3 tags/i)).toBeInTheDocument();
+  });
+
+  it("toggling sort switches to alphabetical order", async () => {
+    installFetch({
+      tags: [
+        { name: "zebra", count: 9 },
+        { name: "apple", count: 1 },
+      ],
+    });
+    render(
+      <Wrap>
+        <Tags />
+      </Wrap>,
+    );
+    // Default: count desc — zebra first.
+    let links = await screen.findAllByRole("link");
+    expect(links[0]).toHaveTextContent("zebra");
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle tag sort/i }));
+    links = await screen.findAllByRole("link");
+    expect(links[0]).toHaveTextContent("apple");
+  });
+
+  it("clicking a tag navigates to /notes?tag=<name>", async () => {
+    installFetch({ tags: [{ name: "daily", count: 3 }] });
+    render(
+      <Wrap>
+        <Tags />
+      </Wrap>,
+    );
+    const link = await screen.findByRole("link", { name: /daily/i });
+    fireEvent.click(link);
+    await waitFor(() =>
+      expect(screen.getByTestId("location").textContent).toBe("/notes?tag=daily"),
+    );
+  });
+
+  it("shows the empty state when there are no tags", async () => {
+    installFetch({ tags: [] });
+    render(
+      <Wrap>
+        <Tags />
+      </Wrap>,
+    );
+    expect(await screen.findByText(/no tags in this vault yet/i)).toBeInTheDocument();
+  });
+
+  it("shows the filtered-empty state when filter matches nothing", async () => {
+    installFetch({ tags: [{ name: "canon", count: 1 }] });
+    render(
+      <Wrap>
+        <Tags />
+      </Wrap>,
+    );
+    await screen.findByRole("link", { name: /canon/i });
+    fireEvent.change(screen.getByLabelText(/filter tags/i), { target: { value: "zzz" } });
+    expect(await screen.findByText(/no tags match your filter/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/routes/Tags.tsx
+++ b/src/app/routes/Tags.tsx
@@ -1,0 +1,143 @@
+import { useTags, useVaultStore } from "@/lib/vault";
+import { VaultAuthError } from "@/lib/vault/client";
+import type { TagSummary } from "@/lib/vault/types";
+import { useMemo, useState } from "react";
+import { Link, Navigate } from "react-router";
+
+type SortMode = "count" | "alpha";
+
+export function Tags() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const tags = useTags();
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortMode>("count");
+
+  const visible = useMemo(
+    () => filterAndSort(tags.data ?? [], search, sort),
+    [tags.data, search, sort],
+  );
+
+  if (!activeVault) return <Navigate to="/" replace />;
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-6 flex items-baseline justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-fg-dim">{activeVault.name}</p>
+          <h1 className="font-serif text-3xl tracking-tight">Tags</h1>
+        </div>
+        <button
+          type="button"
+          onClick={() => setSort((s) => (s === "count" ? "alpha" : "count"))}
+          className="text-sm text-fg-muted hover:text-accent"
+          aria-label="Toggle tag sort"
+        >
+          Sort: {sort === "count" ? "most used" : "A–Z"}
+        </button>
+      </header>
+
+      <input
+        type="search"
+        placeholder="Filter tags…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        aria-label="Filter tags"
+        className="mb-6 w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-fg focus:border-accent focus:outline-none"
+      />
+
+      {tags.isPending ? (
+        <SkeletonChips />
+      ) : tags.isError ? (
+        <ErrorBlock error={tags.error} />
+      ) : visible.length === 0 ? (
+        <EmptyBlock filtering={search.trim().length > 0} hasAny={(tags.data ?? []).length > 0} />
+      ) : (
+        <ul className="flex flex-wrap gap-2" aria-label="Tag list">
+          {visible.map((t) => (
+            <li key={t.name}>
+              <Link
+                to={`/notes?tag=${encodeURIComponent(t.name)}`}
+                className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-sm text-fg hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-accent"
+              >
+                <span>{t.name}</span>
+                <span className="text-xs text-fg-dim">{t.count}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {tags.data && tags.data.length > 0 ? (
+        <p className="mt-6 text-xs text-fg-dim">
+          {visible.length} / {tags.data.length} tag{tags.data.length === 1 ? "" : "s"}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function filterAndSort(tags: TagSummary[], search: string, sort: SortMode): TagSummary[] {
+  const needle = search.trim().toLowerCase();
+  const filtered = needle ? tags.filter((t) => t.name.toLowerCase().includes(needle)) : tags;
+  const sorted = [...filtered];
+  if (sort === "alpha") {
+    sorted.sort((a, b) => a.name.localeCompare(b.name));
+  } else {
+    sorted.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  }
+  return sorted;
+}
+
+function SkeletonChips() {
+  return (
+    <div className="flex flex-wrap gap-2" aria-busy="true">
+      {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
+        <div
+          key={i}
+          className="h-8 w-24 animate-pulse rounded-full border border-border bg-card/60"
+        />
+      ))}
+    </div>
+  );
+}
+
+function ErrorBlock({ error }: { error: Error }) {
+  const isAuth = error instanceof VaultAuthError;
+  return (
+    <div className="rounded-md border border-red-500/30 bg-red-500/5 p-6">
+      <p className="mb-2 font-medium text-red-400">
+        {isAuth ? "Session expired" : "Could not load tags"}
+      </p>
+      <p className="mb-4 text-sm text-fg-muted">{error.message}</p>
+      {isAuth ? (
+        <Link
+          to="/add"
+          className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Reconnect vault
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+function EmptyBlock({ filtering, hasAny }: { filtering: boolean; hasAny: boolean }) {
+  if (filtering && hasAny) {
+    return (
+      <div className="rounded-md border border-border bg-card p-10 text-center">
+        <p className="text-fg-muted">No tags match your filter.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-md border border-border bg-card p-10 text-center">
+      <p className="mb-3 text-fg-muted">No tags in this vault yet.</p>
+      <Link
+        to="/new"
+        className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+      >
+        Create a note
+      </Link>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { type VaultRecord, useVaultStore } from "@/lib/vault";
 import { Link, useNavigate } from "react-router";
 
@@ -33,6 +34,9 @@ export function Header() {
               <Link to="/notes" className="text-sm text-fg-muted hover:text-accent">
                 Notes
               </Link>
+              <Link to="/tags" className="text-sm text-fg-muted hover:text-accent">
+                Tags
+              </Link>
               <Link to="/graph" className="text-sm text-fg-muted hover:text-accent">
                 Graph
               </Link>
@@ -58,9 +62,13 @@ export function Header() {
               >
                 Manage
               </button>
+              <ThemeToggle />
             </>
           ) : (
-            <span className="text-sm text-fg-dim">No vault connected</span>
+            <>
+              <span className="text-sm text-fg-dim">No vault connected</span>
+              <ThemeToggle />
+            </>
           )}
         </div>
       </nav>

--- a/src/components/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,52 @@
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { THEME_STORAGE_KEY } from "@/lib/theme";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("starts from stored preference on mount", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    render(<ThemeToggle />);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(screen.getByRole("button", { name: /dark/i })).toBeInTheDocument();
+  });
+
+  it("cycles system → light → dark → system on click", () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByRole("button");
+
+    // Initial state: system (no stored pref, no attribute)
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    expect(btn).toHaveAccessibleName(/system/i);
+
+    act(() => {
+      fireEvent.click(btn);
+    });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+    expect(btn).toHaveAccessibleName(/light/i);
+
+    act(() => {
+      fireEvent.click(btn);
+    });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(btn).toHaveAccessibleName(/dark/i);
+
+    act(() => {
+      fireEvent.click(btn);
+    });
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    expect(btn).toHaveAccessibleName(/system/i);
+  });
+});

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,79 @@
+import {
+  type Theme,
+  applyTheme,
+  nextTheme,
+  readStoredTheme,
+  themeLabel,
+  writeStoredTheme,
+} from "@/lib/theme";
+import { useEffect, useState } from "react";
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("system");
+
+  useEffect(() => {
+    const stored = readStoredTheme();
+    setTheme(stored);
+    applyTheme(stored);
+  }, []);
+
+  const cycle = () => {
+    const next = nextTheme(theme);
+    setTheme(next);
+    writeStoredTheme(next);
+    applyTheme(next);
+  };
+
+  const label = themeLabel(theme);
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      aria-label={`Theme: ${label}. Click to cycle.`}
+      title={`Theme: ${label}`}
+      className="rounded-md border border-border bg-card px-2 py-1.5 text-sm text-fg-muted hover:text-accent focus-visible:outline-2 focus-visible:outline-accent"
+    >
+      <ThemeIcon theme={theme} />
+    </button>
+  );
+}
+
+function ThemeIcon({ theme }: { theme: Theme }) {
+  if (theme === "light") {
+    return (
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 20 20"
+        className="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      >
+        <circle cx="10" cy="10" r="3.5" />
+        <path d="M10 2v2M10 16v2M2 10h2M16 10h2M4.2 4.2l1.4 1.4M14.4 14.4l1.4 1.4M4.2 15.8l1.4-1.4M14.4 5.6l1.4-1.4" />
+      </svg>
+    );
+  }
+  if (theme === "dark") {
+    return (
+      <svg aria-hidden="true" viewBox="0 0 20 20" className="h-4 w-4" fill="currentColor">
+        <path d="M15.5 11.8a6 6 0 0 1-7.3-7.3 6 6 0 1 0 7.3 7.3z" />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+    >
+      <circle cx="10" cy="10" r="6" />
+      <path d="M10 4v12" fill="currentColor" stroke="none" />
+      <path d="M10 4a6 6 0 0 1 0 12" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  THEME_STORAGE_KEY,
+  applyTheme,
+  nextTheme,
+  readStoredTheme,
+  themeLabel,
+  writeStoredTheme,
+} from "./theme";
+
+describe("theme", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("nextTheme cycles system → light → dark → system", () => {
+    expect(nextTheme("system")).toBe("light");
+    expect(nextTheme("light")).toBe("dark");
+    expect(nextTheme("dark")).toBe("system");
+  });
+
+  it("readStoredTheme defaults to system when unset or invalid", () => {
+    expect(readStoredTheme()).toBe("system");
+    localStorage.setItem(THEME_STORAGE_KEY, "nonsense");
+    expect(readStoredTheme()).toBe("system");
+  });
+
+  it("writeStoredTheme round-trips and removes key for system", () => {
+    writeStoredTheme("dark");
+    expect(readStoredTheme()).toBe("dark");
+    writeStoredTheme("light");
+    expect(readStoredTheme()).toBe("light");
+    writeStoredTheme("system");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    expect(readStoredTheme()).toBe("system");
+  });
+
+  it("applyTheme sets or removes the data-theme attribute", () => {
+    applyTheme("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    applyTheme("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    applyTheme("system");
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+
+  it("themeLabel returns a display-friendly label", () => {
+    expect(themeLabel("system")).toBe("System");
+    expect(themeLabel("light")).toBe("Light");
+    expect(themeLabel("dark")).toBe("Dark");
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,42 @@
+export type Theme = "system" | "light" | "dark";
+
+export const THEME_STORAGE_KEY = "lens:theme";
+export const THEMES: Theme[] = ["system", "light", "dark"];
+
+function isTheme(v: unknown): v is Theme {
+  return v === "system" || v === "light" || v === "dark";
+}
+
+export function readStoredTheme(): Theme {
+  try {
+    const v = localStorage.getItem(THEME_STORAGE_KEY);
+    return isTheme(v) ? v : "system";
+  } catch {
+    return "system";
+  }
+}
+
+export function writeStoredTheme(theme: Theme): void {
+  try {
+    if (theme === "system") localStorage.removeItem(THEME_STORAGE_KEY);
+    else localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // storage unavailable — caller still applies visually
+  }
+}
+
+export function applyTheme(theme: Theme, root: HTMLElement = document.documentElement): void {
+  if (theme === "system") root.removeAttribute("data-theme");
+  else root.setAttribute("data-theme", theme);
+}
+
+export function nextTheme(current: Theme): Theme {
+  const idx = THEMES.indexOf(current);
+  return THEMES[(idx + 1) % THEMES.length];
+}
+
+export function themeLabel(theme: Theme): string {
+  if (theme === "light") return "Light";
+  if (theme === "dark") return "Dark";
+  return "System";
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -22,8 +22,9 @@
   --color-card-hover: #fefdfb;
 }
 
+/* System dark — only when the user hasn't picked explicitly. */
 @media (prefers-color-scheme: dark) {
-  @theme {
+  :root:not([data-theme="light"]) {
     --color-bg: #1a1917;
     --color-bg-soft: #23221f;
     --color-fg: #e8e5de;
@@ -38,6 +39,23 @@
     --color-card: #23221f;
     --color-card-hover: #2a2926;
   }
+}
+
+/* Explicit dark — wins over system. */
+:root[data-theme="dark"] {
+  --color-bg: #1a1917;
+  --color-bg-soft: #23221f;
+  --color-fg: #e8e5de;
+  --color-fg-muted: #a8a49b;
+  --color-fg-dim: #706c64;
+  --color-accent: #7ab087;
+  --color-accent-hover: #8bc098;
+  --color-accent-light: #5b8c6a;
+  --color-sky: #7fb3cc;
+  --color-border: #33312d;
+  --color-border-light: #2a2926;
+  --color-card: #23221f;
+  --color-card-hover: #2a2926;
 }
 
 html,
@@ -157,13 +175,23 @@ body {
 }
 
 @media (prefers-color-scheme: dark) {
-  .prose-note code,
-  .prose-note pre {
+  :root:not([data-theme="light"]) .prose-note code,
+  :root:not([data-theme="light"]) .prose-note pre {
     background: #1f1e1b;
     border-color: var(--color-border);
   }
-  .prose-note .hljs {
+  :root:not([data-theme="light"]) .prose-note .hljs {
     background: #1f1e1b !important;
     color: var(--color-fg);
   }
+}
+
+:root[data-theme="dark"] .prose-note code,
+:root[data-theme="dark"] .prose-note pre {
+  background: #1f1e1b;
+  border-color: var(--color-border);
+}
+:root[data-theme="dark"] .prose-note .hljs {
+  background: #1f1e1b !important;
+  color: var(--color-fg);
 }


### PR DESCRIPTION
## Summary
- **`/tags` route** — browse every tag with its count. Sort toggles between "most used" and "A–Z". Search filter at top. Click a chip → `/notes?tag=<name>` (the Notes route already reads `tag` query params, so the round-trip works today).
- **Explicit dark-mode toggle** in the header, cycling `system → light → dark`. Persists to `localStorage` as `lens:theme`. An inline script in `index.html` applies the stored `data-theme` attribute before React mounts, so dark-mode users don't see a white flash on load.
- **Theme tokens** — explicit choice overrides `prefers-color-scheme` via `:root[data-theme]` selectors. System is the default (no attribute); that's also what the `@media (prefers-color-scheme: dark)` block targets, guarded so an explicit light choice on a dark OS isn't overridden.
- **README** bumped to v1. Feature list updated to mention the tag index and theme toggle.

## Housekeeping
- No stray `console.log` / `TODO` / `FIXME` in `src/**/*.{ts,tsx}`.
- Ad-hoc hex codes audit: only in `src/styles/index.css` where the color tokens are defined and a single `#1f1e1b` for code-block dark backgrounds.

## Tests (+12 added, 172/172 total)
- `src/lib/theme.test.ts` — `nextTheme` cycle, `readStoredTheme` / `writeStoredTheme` round-trip, `applyTheme` sets/removes the attribute, label formatter.
- `src/components/ThemeToggle.test.tsx` — starts from stored preference, cycles on click with `data-theme` applied and `localStorage` persisted.
- `src/app/routes/Tags.test.tsx` — count-desc default ordering, search filters, alpha-sort toggle, click navigates to `/notes?tag=<name>`, empty-vault fallback, filtered-empty state.

## Gates
- ✅ lint
- ✅ typecheck
- ✅ test — 172/172
- ✅ build
- ✅ dev-server smoke — `curl -s http://localhost:5173` serves HTML with the inline theme script inlined

## Test plan
- [ ] Visit `/tags` on a populated vault — see chips with counts; toggle sort; filter reduces count in footer.
- [ ] Click a chip → Notes opens already filtered.
- [ ] Click the theme button in the header — icon cycles sun/moon/half; page re-themes immediately; refresh preserves choice.
- [ ] Open in a fresh private window with system dark — loads dark with no white flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)