### PR TITLE
Add /capture voice memo route with offline-first enqueue

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { SyncProvider } from "@/providers/SyncProvider";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { AddVault } from "./routes/AddVault";
 import { Home } from "./routes/Home";
+import { MemoCapture } from "./routes/MemoCapture";
 import { NoteEditor } from "./routes/NoteEditor";
 import { NoteNew } from "./routes/NoteNew";
 import { NoteView } from "./routes/NoteView";
@@ -30,6 +31,7 @@ export function App() {
                 <Route path="/notes" element={<Notes />} />
                 <Route path="/tags" element={<Tags />} />
                 <Route path="/new" element={<NoteNew />} />
+                <Route path="/capture" element={<MemoCapture />} />
                 <Route path="/graph" element={<VaultGraph />} />
                 <Route path="/notes/:id" element={<NoteView />} />
                 <Route path="/notes/:id/edit" element={<NoteEditor />} />

--- a/src/app/routes/MemoCapture.test.tsx
+++ b/src/app/routes/MemoCapture.test.tsx
@@ -1,0 +1,273 @@
+import { MemoCapture } from "@/app/routes/MemoCapture";
+import { type LensDB, openLensDB } from "@/lib/sync/db";
+import { listPending } from "@/lib/sync/queue";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault/store";
+import { SyncProvider } from "@/providers/SyncProvider";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock just the parts of the recorder module that touch browser APIs. The
+// helpers (memoFilename, memoPath, memoNoteContent, pickMimeType) run for
+// real.
+interface FakeController {
+  start: () => void;
+  pause: () => void;
+  resume: () => void;
+  stop: () => Promise<{ data: ArrayBuffer; mimeType: string; durationMs: number }>;
+  cancel: () => void;
+  state: "idle" | "recording" | "paused" | "stopped";
+  mimeType: string;
+}
+
+const fakeState = {
+  controller: null as FakeController | null,
+  requestMic: vi.fn(async () => ({ getTracks: () => [] }) as unknown as MediaStream),
+  pickResult: "audio/webm;codecs=opus" as string | null,
+};
+
+vi.mock("@/lib/capture/recorder", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/capture/recorder")>("@/lib/capture/recorder");
+  return {
+    ...actual,
+    pickMimeType: () => fakeState.pickResult,
+    requestMic: () => fakeState.requestMic(),
+    createRecorder: (opts: { mimeType: string }) => {
+      const c: FakeController = {
+        state: "idle",
+        mimeType: opts.mimeType,
+        start() {
+          this.state = "recording";
+        },
+        pause() {
+          this.state = "paused";
+        },
+        resume() {
+          this.state = "recording";
+        },
+        async stop() {
+          this.state = "stopped";
+          return {
+            data: new Uint8Array([10, 20, 30]).buffer,
+            mimeType: opts.mimeType,
+            durationMs: 4_200,
+          };
+        },
+        cancel() {
+          this.state = "stopped";
+        },
+      };
+      fakeState.controller = c;
+      return c;
+    },
+  };
+});
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      dev: {
+        id: "dev",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "client-test",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "dev",
+  });
+  localStorage.setItem(
+    "lens:token:dev",
+    JSON.stringify({ accessToken: "pvt_abc", scope: "full", vault: "default" }),
+  );
+}
+
+async function freshDb(): Promise<LensDB> {
+  indexedDB.deleteDatabase("parachute-lens");
+  return openLensDB();
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return (
+    <QueryClientProvider client={client}>
+      <SyncProvider>{children}</SyncProvider>
+    </QueryClientProvider>
+  );
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/capture" element={<MemoCapture />} />
+        <Route path="/notes" element={<div>NotesListPage</div>} />
+      </Routes>
+    </MemoryRouter>,
+    { wrapper: Wrapper },
+  );
+}
+
+describe("MemoCapture route", () => {
+  let restoreOnline: (() => void) | null = null;
+
+  beforeEach(async () => {
+    const db = await freshDb();
+    db.close();
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useToastStore.setState({ toasts: [] });
+    seedStore();
+    fakeState.controller = null;
+    fakeState.pickResult = "audio/webm;codecs=opus";
+    fakeState.requestMic = vi.fn(async () => ({ getTracks: () => [] }) as unknown as MediaStream);
+    // URL.createObjectURL / revokeObjectURL don't exist in jsdom.
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => "blob:fake"),
+        revokeObjectURL: vi.fn(),
+      }),
+    );
+    // Pin navigator.onLine=false so the SyncEngine no-ops — we're verifying
+    // the enqueue path, not the drain path.
+    const desc = Object.getOwnPropertyDescriptor(Navigator.prototype, "onLine");
+    Object.defineProperty(navigator, "onLine", { configurable: true, get: () => false });
+    restoreOnline = () => {
+      if (desc) Object.defineProperty(navigator, "onLine", desc);
+    };
+  });
+
+  afterEach(() => {
+    restoreOnline?.();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the idle state with a Start recording button", async () => {
+    renderAt("/capture");
+    expect(screen.getByRole("button", { name: /start recording/i })).toBeInTheDocument();
+  });
+
+  it("permission denied shows the friendly retry affordance", async () => {
+    fakeState.requestMic = vi.fn(async () => {
+      const err = Object.assign(new Error("denied"), {
+        kind: "permission-denied",
+      });
+      throw err;
+    });
+    renderAt("/capture");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start recording/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/microphone access was denied/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("unsupported browser shows an error if no mimeType matches", async () => {
+    fakeState.pickResult = null;
+    renderAt("/capture");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start recording/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/can't record audio/i)).toBeInTheDocument();
+    });
+  });
+
+  it("record → stop → save enqueues create-note, upload-attachment, link-attachment", async () => {
+    renderAt("/capture");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start recording/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^stop$/i })).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^stop$/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save memo/i })).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save memo/i }));
+    });
+
+    // Lands on /notes with a toast and three queue rows.
+    await waitFor(() => {
+      expect(screen.getByText("NotesListPage")).toBeInTheDocument();
+    });
+    expect(useToastStore.getState().toasts[0]?.message).toContain("Memo saved");
+
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    const kinds = rows.map((r) => r.mutation.kind);
+    expect(kinds).toEqual(["create-note", "upload-attachment", "link-attachment"]);
+    // The link-attachment row should reference the blob of the upload row via blob:<id>.
+    const link = rows.find((r) => r.mutation.kind === "link-attachment")!;
+    const upload = rows.find((r) => r.mutation.kind === "upload-attachment")!;
+    if (link.mutation.kind !== "link-attachment" || upload.mutation.kind !== "upload-attachment") {
+      throw new Error("wrong mutation shape");
+    }
+    expect(link.mutation.pathRef).toBe(`blob:${upload.mutation.blobId}`);
+    expect(link.mutation.mimeType).toBe("audio/webm;codecs=opus");
+    if (rows[0].mutation.kind === "create-note") {
+      expect(rows[0].mutation.payload.path).toMatch(/^Memos\//);
+      expect(rows[0].mutation.payload.tags).toEqual(["memo"]);
+    }
+    db.close();
+  });
+
+  it("discard & re-record drops the review and returns to idle", async () => {
+    renderAt("/capture");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start recording/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^stop$/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save memo/i })).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /discard/i }));
+    });
+
+    expect(screen.getByRole("button", { name: /start recording/i })).toBeInTheDocument();
+  });
+
+  it("pause → resume keeps the recording going", async () => {
+    renderAt("/capture");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start recording/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^pause$/i })).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^pause$/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^resume$/i })).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^resume$/i }));
+    });
+    expect(screen.getByRole("button", { name: /^pause$/i })).toBeInTheDocument();
+  });
+});

--- a/src/app/routes/MemoCapture.tsx
+++ b/src/app/routes/MemoCapture.tsx
@@ -1,0 +1,413 @@
+import {
+  type PermissionError,
+  type RecorderController,
+  createRecorder,
+  memoFilename,
+  memoNoteContent,
+  memoPath,
+  pickMimeType,
+  requestMic,
+} from "@/lib/capture/recorder";
+import { blobRef, enqueue, newBlobId, newLocalId } from "@/lib/sync";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault";
+import { useSync } from "@/providers/SyncProvider";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, Navigate, useNavigate } from "react-router";
+
+type Phase =
+  | { kind: "idle" }
+  | { kind: "requesting" }
+  | { kind: "denied"; reason: string; message: string }
+  | { kind: "recording"; startedAt: number }
+  | { kind: "paused"; elapsedMs: number }
+  | { kind: "review"; data: ArrayBuffer; mimeType: string; url: string; durationMs: number }
+  | { kind: "saving" }
+  | { kind: "error"; message: string };
+
+function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const mm = Math.floor(total / 60);
+  const ss = total % 60;
+  return `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
+}
+
+export function MemoCapture() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const navigate = useNavigate();
+  const pushToast = useToastStore((s) => s.push);
+  const { db, blobStore, engine } = useSync();
+
+  const [phase, setPhase] = useState<Phase>({ kind: "idle" });
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const recorderRef = useRef<RecorderController | null>(null);
+  const previewUrlRef = useRef<string | null>(null);
+
+  // Tick the elapsed-time display while recording. Paused state holds the
+  // displayed elapsed steady at the accumulated value.
+  useEffect(() => {
+    if (phase.kind !== "recording") return;
+    const interval = setInterval(() => {
+      setElapsedMs(Date.now() - phase.startedAt);
+    }, 250);
+    return () => clearInterval(interval);
+  }, [phase]);
+
+  // Revoke any object URL we created for playback when the component unmounts
+  // or we move past review.
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    };
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    setPhase({ kind: "requesting" });
+    try {
+      const mimeType = pickMimeType();
+      if (!mimeType) {
+        setPhase({
+          kind: "error",
+          message: "This browser can't record audio in a format we can save.",
+        });
+        return;
+      }
+      const stream = await requestMic();
+      const rec = createRecorder({ stream, mimeType });
+      recorderRef.current = rec;
+      rec.start();
+      setElapsedMs(0);
+      setPhase({ kind: "recording", startedAt: Date.now() });
+    } catch (e) {
+      const perm = e as PermissionError;
+      if (perm.kind === "permission-denied") {
+        setPhase({
+          kind: "denied",
+          reason: "permission-denied",
+          message:
+            "Microphone access was denied. Update your browser's site settings to record memos.",
+        });
+      } else if (perm.kind === "no-device") {
+        setPhase({
+          kind: "denied",
+          reason: "no-device",
+          message: "No microphone was found on this device.",
+        });
+      } else {
+        setPhase({
+          kind: "denied",
+          reason: "unavailable",
+          message:
+            perm instanceof Error ? perm.message : "Microphone is not available in this browser.",
+        });
+      }
+    }
+  }, []);
+
+  const pauseRecording = useCallback(() => {
+    const rec = recorderRef.current;
+    if (!rec || phase.kind !== "recording") return;
+    rec.pause();
+    setPhase({ kind: "paused", elapsedMs });
+  }, [phase, elapsedMs]);
+
+  const resumeRecording = useCallback(() => {
+    const rec = recorderRef.current;
+    if (!rec || phase.kind !== "paused") return;
+    rec.resume();
+    setPhase({ kind: "recording", startedAt: Date.now() - phase.elapsedMs });
+  }, [phase]);
+
+  const stopRecording = useCallback(async () => {
+    const rec = recorderRef.current;
+    if (!rec) return;
+    if (phase.kind !== "recording" && phase.kind !== "paused") return;
+    try {
+      const result = await rec.stop();
+      recorderRef.current = null;
+      const blob = new Blob([result.data], { type: result.mimeType });
+      const url = URL.createObjectURL(blob);
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = url;
+      setPhase({
+        kind: "review",
+        data: result.data,
+        mimeType: result.mimeType,
+        url,
+        durationMs: result.durationMs,
+      });
+    } catch (e) {
+      setPhase({
+        kind: "error",
+        message: e instanceof Error ? e.message : "Recording failed.",
+      });
+    }
+  }, [phase]);
+
+  const discard = useCallback(() => {
+    const rec = recorderRef.current;
+    if (rec) {
+      rec.cancel();
+      recorderRef.current = null;
+    }
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+    setPhase({ kind: "idle" });
+    setElapsedMs(0);
+  }, []);
+
+  const save = useCallback(async () => {
+    if (phase.kind !== "review") return;
+    if (!db || !blobStore || !activeVault) {
+      pushToast("Sync queue not ready — try again in a moment.", "error");
+      return;
+    }
+    setPhase({ kind: "saving" });
+    const recordedAt = new Date();
+    const filename = memoFilename(phase.mimeType, recordedAt);
+    const path = memoPath(recordedAt);
+    const content = memoNoteContent(filename, recordedAt);
+    const localId = newLocalId();
+    const blobId = newBlobId();
+    try {
+      await blobStore.put(blobId, phase.data, phase.mimeType, activeVault.id);
+      await enqueue(
+        db,
+        {
+          kind: "create-note",
+          localId,
+          payload: { content, path, tags: ["memo"] },
+        },
+        { vaultId: activeVault.id },
+      );
+      await enqueue(
+        db,
+        { kind: "upload-attachment", blobId, filename, mimeType: phase.mimeType },
+        { vaultId: activeVault.id },
+      );
+      await enqueue(
+        db,
+        {
+          kind: "link-attachment",
+          noteId: localId,
+          pathRef: blobRef(blobId),
+          mimeType: phase.mimeType,
+        },
+        { vaultId: activeVault.id },
+      );
+      // Kick the engine so online users see it flush right away; offline it
+      // no-ops and the next online event picks it up.
+      void engine?.runOnce();
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+        previewUrlRef.current = null;
+      }
+      pushToast("Memo saved — syncing to your vault.", "success");
+      navigate("/notes");
+    } catch (e) {
+      setPhase({
+        kind: "review",
+        data: phase.data,
+        mimeType: phase.mimeType,
+        url: phase.url,
+        durationMs: phase.durationMs,
+      });
+      pushToast(e instanceof Error ? `Save failed: ${e.message}` : "Save failed.", "error");
+    }
+  }, [phase, db, blobStore, activeVault, engine, navigate, pushToast]);
+
+  if (!activeVault) return <Navigate to="/" replace />;
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-8">
+      <nav className="mb-4 text-sm text-fg-dim">
+        <Link to="/notes" className="hover:text-accent">
+          ← All notes
+        </Link>
+      </nav>
+
+      <header className="mb-8">
+        <h1 className="font-serif text-2xl text-fg">Voice memo</h1>
+        <p className="mt-1 text-sm text-fg-dim">
+          Capture a thought. Saves as a note in your vault with the audio attached.
+        </p>
+      </header>
+
+      <section className="flex flex-col items-center gap-6 rounded-xl border border-border bg-card p-10">
+        {phase.kind === "idle" ? (
+          <>
+            <RecordButton onClick={startRecording} label="Start recording" />
+            <p className="text-xs text-fg-dim">Tap to request microphone access.</p>
+          </>
+        ) : null}
+
+        {phase.kind === "requesting" ? (
+          <p className="text-sm text-fg-muted">Requesting microphone…</p>
+        ) : null}
+
+        {phase.kind === "denied" ? (
+          <div className="flex flex-col items-center gap-3 text-center">
+            <p className="text-sm text-red-400">{phase.message}</p>
+            <button
+              type="button"
+              onClick={startRecording}
+              className="rounded-md bg-accent px-4 py-1.5 text-sm font-medium text-white hover:bg-accent-hover"
+            >
+              Try again
+            </button>
+          </div>
+        ) : null}
+
+        {phase.kind === "recording" || phase.kind === "paused" ? (
+          <>
+            <div className="flex flex-col items-center gap-2">
+              <ElapsedBadge
+                ms={phase.kind === "paused" ? phase.elapsedMs : elapsedMs}
+                recording={phase.kind === "recording"}
+              />
+            </div>
+            <div className="flex gap-3">
+              {phase.kind === "recording" ? (
+                <button
+                  type="button"
+                  onClick={pauseRecording}
+                  className="rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg-muted hover:text-accent"
+                >
+                  Pause
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={resumeRecording}
+                  className="rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg-muted hover:text-accent"
+                >
+                  Resume
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={stopRecording}
+                className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+              >
+                Stop
+              </button>
+              <button
+                type="button"
+                onClick={discard}
+                className="rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg-dim hover:text-red-400"
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        ) : null}
+
+        {phase.kind === "review" ? (
+          <div className="flex w-full flex-col items-center gap-4">
+            <p className="text-sm text-fg-muted">
+              Recorded {formatElapsed(phase.durationMs)} of audio.
+            </p>
+            <audio controls src={phase.url} className="w-full">
+              <track kind="captions" />
+            </audio>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={discard}
+                className="rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg-muted hover:text-red-400"
+              >
+                Discard &amp; re-record
+              </button>
+              <button
+                type="button"
+                onClick={save}
+                className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+              >
+                Save memo
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {phase.kind === "saving" ? <p className="text-sm text-fg-muted">Saving…</p> : null}
+
+        {phase.kind === "error" ? (
+          <div className="flex flex-col items-center gap-3 text-center">
+            <p className="text-sm text-red-400">{phase.message}</p>
+            <button
+              type="button"
+              onClick={() => setPhase({ kind: "idle" })}
+              className="rounded-md bg-accent px-4 py-1.5 text-sm font-medium text-white hover:bg-accent-hover"
+            >
+              Start over
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      <aside className="mt-6 rounded-md border border-border bg-card/60 p-4 text-xs text-fg-dim">
+        <p className="mb-1 font-medium text-fg-muted">Tips</p>
+        <ul className="list-inside list-disc space-y-0.5">
+          <li>Recording stops if you leave the tab or lock your screen.</li>
+          <li>Audio is saved in your vault; no transcription yet (coming next).</li>
+          <li>If you're offline, memos queue up and sync when you're back.</li>
+        </ul>
+      </aside>
+    </div>
+  );
+}
+
+function RecordButton({ onClick, label }: { onClick: () => void; label: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className="flex h-40 w-40 flex-col items-center justify-center gap-2 rounded-full border border-accent/30 bg-accent/10 text-accent transition hover:bg-accent/15 focus:outline-none focus:ring-2 focus:ring-accent"
+    >
+      <MicIcon />
+      <span className="text-sm font-medium">{label}</span>
+    </button>
+  );
+}
+
+function ElapsedBadge({ ms, recording }: { ms: number; recording: boolean }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span
+        aria-hidden
+        className={`inline-block h-3 w-3 rounded-full ${
+          recording ? "animate-pulse bg-red-500" : "bg-fg-dim"
+        }`}
+      />
+      <span aria-live="polite" className="font-mono text-2xl tabular-nums text-fg">
+        {formatElapsed(ms)}
+      </span>
+    </div>
+  );
+}
+
+function MicIcon() {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="Microphone"
+    >
+      <title>Microphone</title>
+      <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3Z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" y1="19" x2="12" y2="23" />
+      <line x1="8" y1="23" x2="16" y2="23" />
+    </svg>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,6 +41,9 @@ export function Header() {
               <Link to="/graph" className="text-sm text-fg-muted hover:text-accent">
                 Graph
               </Link>
+              <Link to="/capture" className="text-sm text-fg-muted hover:text-accent">
+                + Memo
+              </Link>
               <label htmlFor="vault-switcher" className="sr-only">
                 Active vault
               </label>

--- a/src/lib/capture/recorder.test.ts
+++ b/src/lib/capture/recorder.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PREFERRED_MIME_TYPES,
+  createRecorder,
+  extensionFor,
+  memoFilename,
+  memoNoteContent,
+  memoPath,
+  pickMimeType,
+  requestMic,
+} from "./recorder";
+
+// Minimal stand-in for MediaRecorder so we can exercise the wrapper in jsdom.
+// We model just the surface the wrapper uses: ondataavailable / onstop events,
+// start / pause / resume / stop methods.
+class FakeMediaRecorder {
+  static supported = new Set<string>();
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  stream: MediaStream;
+  mimeType: string;
+  state: "inactive" | "recording" | "paused" = "inactive";
+
+  constructor(stream: MediaStream, opts: { mimeType: string }) {
+    this.stream = stream;
+    this.mimeType = opts.mimeType;
+  }
+  static isTypeSupported(t: string): boolean {
+    return FakeMediaRecorder.supported.has(t);
+  }
+  start() {
+    this.state = "recording";
+  }
+  pause() {
+    this.state = "paused";
+  }
+  resume() {
+    this.state = "recording";
+  }
+  stop() {
+    this.state = "inactive";
+    this.ondataavailable?.({ data: new Blob([new Uint8Array([1, 2, 3, 4])]) });
+    this.onstop?.();
+  }
+}
+
+function fakeStream(): MediaStream {
+  const tracks: MediaStreamTrack[] = [];
+  return {
+    getTracks: () => tracks,
+  } as unknown as MediaStream;
+}
+
+describe("pickMimeType", () => {
+  it("returns the first supported candidate", () => {
+    FakeMediaRecorder.supported = new Set(["audio/mp4", "audio/ogg;codecs=opus"]);
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder as unknown as typeof MediaRecorder);
+    try {
+      expect(pickMimeType(PREFERRED_MIME_TYPES)).toBe("audio/mp4");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("returns null when MediaRecorder is missing", () => {
+    vi.stubGlobal("MediaRecorder", undefined);
+    try {
+      expect(pickMimeType(PREFERRED_MIME_TYPES)).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("returns null when no candidate matches", () => {
+    FakeMediaRecorder.supported = new Set();
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder as unknown as typeof MediaRecorder);
+    try {
+      expect(pickMimeType(PREFERRED_MIME_TYPES)).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("extensionFor", () => {
+  it("maps common audio mime types", () => {
+    expect(extensionFor("audio/webm;codecs=opus")).toBe("webm");
+    expect(extensionFor("audio/mp4")).toBe("m4a");
+    expect(extensionFor("audio/ogg;codecs=opus")).toBe("ogg");
+    expect(extensionFor("audio/wav")).toBe("wav");
+    expect(extensionFor("application/octet-stream")).toBe("bin");
+  });
+});
+
+describe("createRecorder", () => {
+  beforeEach(() => {
+    FakeMediaRecorder.supported = new Set(["audio/webm;codecs=opus"]);
+  });
+
+  it("records, stops, and returns an ArrayBuffer + duration", async () => {
+    let t = 1_000;
+    const rec = createRecorder({
+      stream: fakeStream(),
+      mimeType: "audio/webm;codecs=opus",
+      now: () => t,
+      MediaRecorderCtor: FakeMediaRecorder as unknown as typeof MediaRecorder,
+    });
+    rec.start();
+    t += 3_500;
+    const result = await rec.stop();
+    expect(result.mimeType).toBe("audio/webm;codecs=opus");
+    expect(result.durationMs).toBe(3_500);
+    expect(Array.from(new Uint8Array(result.data))).toEqual([1, 2, 3, 4]);
+  });
+
+  it("pause + resume excludes paused time from duration", async () => {
+    let t = 0;
+    const rec = createRecorder({
+      stream: fakeStream(),
+      mimeType: "audio/webm;codecs=opus",
+      now: () => t,
+      MediaRecorderCtor: FakeMediaRecorder as unknown as typeof MediaRecorder,
+    });
+    rec.start();
+    t = 2_000;
+    rec.pause();
+    // 5 seconds of "pause" that should not count.
+    t = 7_000;
+    rec.resume();
+    t = 9_000;
+    const result = await rec.stop();
+    expect(result.durationMs).toBe(4_000);
+  });
+
+  it("cancel stops tracks without resolving", () => {
+    const trackStop = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop: trackStop } as unknown as MediaStreamTrack],
+    } as unknown as MediaStream;
+    const rec = createRecorder({
+      stream,
+      mimeType: "audio/webm;codecs=opus",
+      MediaRecorderCtor: FakeMediaRecorder as unknown as typeof MediaRecorder,
+    });
+    rec.start();
+    rec.cancel();
+    expect(trackStop).toHaveBeenCalled();
+    expect(rec.state).toBe("stopped");
+  });
+
+  it("rejects start() when not idle", () => {
+    const rec = createRecorder({
+      stream: fakeStream(),
+      mimeType: "audio/webm;codecs=opus",
+      MediaRecorderCtor: FakeMediaRecorder as unknown as typeof MediaRecorder,
+    });
+    rec.start();
+    expect(() => rec.start()).toThrow();
+  });
+});
+
+describe("requestMic", () => {
+  let savedDescriptor: PropertyDescriptor | undefined;
+  beforeEach(() => {
+    savedDescriptor = Object.getOwnPropertyDescriptor(navigator, "mediaDevices");
+  });
+  afterEach(() => {
+    if (savedDescriptor) {
+      Object.defineProperty(navigator, "mediaDevices", savedDescriptor);
+    } else {
+      Object.defineProperty(navigator, "mediaDevices", {
+        configurable: true,
+        value: undefined,
+      });
+    }
+  });
+
+  function stubMediaDevices(getUserMedia: () => Promise<MediaStream>) {
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia },
+    });
+  }
+
+  it("throws permission-denied on NotAllowedError", async () => {
+    stubMediaDevices(async () => {
+      throw new DOMException("denied", "NotAllowedError");
+    });
+    await expect(requestMic()).rejects.toMatchObject({ kind: "permission-denied" });
+  });
+
+  it("throws no-device on NotFoundError", async () => {
+    stubMediaDevices(async () => {
+      throw new DOMException("missing", "NotFoundError");
+    });
+    await expect(requestMic()).rejects.toMatchObject({ kind: "no-device" });
+  });
+
+  it("throws unavailable when mediaDevices is missing", async () => {
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: undefined,
+    });
+    await expect(requestMic()).rejects.toMatchObject({ kind: "unavailable" });
+  });
+});
+
+describe("memo helpers", () => {
+  it("filename follows memo-<iso>.<ext> convention", () => {
+    const at = new Date("2026-04-19T14:30:05.123Z");
+    expect(memoFilename("audio/webm;codecs=opus", at)).toBe("memo-2026-04-19T14-30-05-123.webm");
+    expect(memoFilename("audio/mp4", at)).toBe("memo-2026-04-19T14-30-05-123.m4a");
+  });
+
+  it("path slots into Memos/YYYY/MM-DD/HH-MM-SS", () => {
+    const at = new Date(2026, 3, 19, 14, 30, 5);
+    expect(memoPath(at)).toBe("Memos/2026/04-19/14-30-05");
+  });
+
+  it("note content embeds the filename as a wiki-attachment", () => {
+    const at = new Date("2026-04-19T14:30:00.000Z");
+    const body = memoNoteContent("memo-x.webm", at);
+    expect(body).toContain("🎙️ Voice memo");
+    expect(body).toContain("![[memo-x.webm]]");
+    expect(body).toContain("Transcript pending");
+  });
+});

--- a/src/lib/capture/recorder.ts
+++ b/src/lib/capture/recorder.ts
@@ -1,0 +1,221 @@
+// Minimal wrapper around MediaRecorder. We pick the best supported mimeType
+// up front, accumulate chunks, and hand back an ArrayBuffer on stop so the
+// sync-queue blob store (which operates on ArrayBuffer + mimeType) can take
+// it directly.
+
+// Preferred first. Opus-in-webm is the default on Chrome and Firefox; Safari
+// doesn't support webm, so we fall back to audio/mp4 (AAC). Ogg/Opus is a
+// distant third that some older Firefox builds prefer.
+export const PREFERRED_MIME_TYPES: readonly string[] = [
+  "audio/webm;codecs=opus",
+  "audio/mp4",
+  "audio/ogg;codecs=opus",
+];
+
+export function pickMimeType(candidates: readonly string[] = PREFERRED_MIME_TYPES): string | null {
+  if (typeof MediaRecorder === "undefined") return null;
+  for (const type of candidates) {
+    if (MediaRecorder.isTypeSupported(type)) return type;
+  }
+  return null;
+}
+
+export function extensionFor(mimeType: string): string {
+  if (mimeType.startsWith("audio/webm")) return "webm";
+  if (mimeType.startsWith("audio/mp4")) return "m4a";
+  if (mimeType.startsWith("audio/ogg")) return "ogg";
+  if (mimeType.startsWith("audio/wav")) return "wav";
+  return "bin";
+}
+
+export interface RecordingResult {
+  data: ArrayBuffer;
+  mimeType: string;
+  durationMs: number;
+}
+
+export type RecorderState = "idle" | "recording" | "paused" | "stopped";
+
+export interface RecorderController {
+  readonly state: RecorderState;
+  readonly mimeType: string;
+  start(): void;
+  pause(): void;
+  resume(): void;
+  // Resolves with the final buffer once the underlying MediaRecorder flushes.
+  // Stops microphone tracks as a side effect.
+  stop(): Promise<RecordingResult>;
+  // Discards the recording in progress without resolving stop(). Releases the
+  // mic.
+  cancel(): void;
+}
+
+export interface CreateRecorderOptions {
+  stream: MediaStream;
+  mimeType: string;
+  // Injection points for tests; default to the browser globals.
+  now?: () => number;
+  MediaRecorderCtor?: typeof MediaRecorder;
+}
+
+export function createRecorder(opts: CreateRecorderOptions): RecorderController {
+  const now = opts.now ?? (() => Date.now());
+  const Ctor = opts.MediaRecorderCtor ?? MediaRecorder;
+  const recorder = new Ctor(opts.stream, { mimeType: opts.mimeType });
+  const chunks: Blob[] = [];
+  let state: RecorderState = "idle";
+  // We track accumulated recording time manually instead of trusting wall
+  // clock alone, because the user can pause/resume.
+  let startedAt = 0;
+  let accumulatedMs = 0;
+
+  recorder.ondataavailable = (e) => {
+    if (e.data && e.data.size > 0) chunks.push(e.data);
+  };
+
+  const releaseTracks = () => {
+    for (const track of opts.stream.getTracks()) track.stop();
+  };
+
+  return {
+    get state() {
+      return state;
+    },
+    get mimeType() {
+      return opts.mimeType;
+    },
+    start(): void {
+      if (state !== "idle") throw new Error(`Cannot start from ${state}`);
+      recorder.start();
+      startedAt = now();
+      state = "recording";
+    },
+    pause(): void {
+      if (state !== "recording") return;
+      recorder.pause();
+      accumulatedMs += now() - startedAt;
+      state = "paused";
+    },
+    resume(): void {
+      if (state !== "paused") return;
+      recorder.resume();
+      startedAt = now();
+      state = "recording";
+    },
+    async stop(): Promise<RecordingResult> {
+      if (state === "idle" || state === "stopped") {
+        throw new Error(`Cannot stop from ${state}`);
+      }
+      if (state === "recording") {
+        accumulatedMs += now() - startedAt;
+      }
+      const result = new Promise<RecordingResult>((resolve) => {
+        recorder.onstop = async () => {
+          // Concatenate chunks ourselves instead of `new Blob(chunks)`. In jsdom
+          // the outer Blob stringifies nested Blobs; real browsers handle it
+          // fine but we want the same code path both places.
+          const data = await concatBlobs(chunks);
+          resolve({ data, mimeType: opts.mimeType, durationMs: accumulatedMs });
+        };
+      });
+      recorder.stop();
+      state = "stopped";
+      releaseTracks();
+      return result;
+    },
+    cancel(): void {
+      if (state === "recording" || state === "paused") {
+        try {
+          recorder.stop();
+        } catch {
+          // ignore; tracks still need releasing
+        }
+      }
+      state = "stopped";
+      chunks.length = 0;
+      releaseTracks();
+    },
+  };
+}
+
+// Real browsers have Blob.arrayBuffer(); jsdom does not, and also stringifies
+// Blobs passed to Response. FileReader is the lowest-common-denominator that
+// works across modern browsers, jsdom, and Safari PWA webviews.
+export async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  const b = blob as Blob & { arrayBuffer?: () => Promise<ArrayBuffer> };
+  if (typeof b.arrayBuffer === "function") return b.arrayBuffer();
+  return new Promise<ArrayBuffer>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error ?? new Error("FileReader error"));
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+async function concatBlobs(chunks: readonly Blob[]): Promise<ArrayBuffer> {
+  if (chunks.length === 0) return new ArrayBuffer(0);
+  const parts = await Promise.all(chunks.map((c) => blobToArrayBuffer(c)));
+  const total = parts.reduce((n, p) => n + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(new Uint8Array(p), offset);
+    offset += p.byteLength;
+  }
+  return out.buffer;
+}
+
+export interface PermissionError extends Error {
+  kind: "permission-denied" | "no-device" | "unavailable";
+}
+
+export async function requestMic(): Promise<MediaStream> {
+  if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+    const err = new Error("Microphone is not available in this browser.") as PermissionError;
+    err.kind = "unavailable";
+    throw err;
+  }
+  try {
+    return await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (e) {
+    const err = new Error(
+      e instanceof Error ? e.message : "Microphone permission denied.",
+    ) as PermissionError;
+    const name = e instanceof DOMException ? e.name : "";
+    err.kind =
+      name === "NotFoundError" || name === "OverconstrainedError"
+        ? "no-device"
+        : "permission-denied";
+    throw err;
+  }
+}
+
+export function memoFilename(mimeType: string, at: Date = new Date()): string {
+  const iso = at.toISOString().replace(/[:.]/g, "-").replace(/Z$/, "");
+  return `memo-${iso}.${extensionFor(mimeType)}`;
+}
+
+export function memoPath(at: Date = new Date()): string {
+  // YYYY/MM-DD — lightweight daily grouping so vaults don't end up with a single
+  // flat Memos/ folder. Adjust later if we want month folders instead.
+  const yyyy = at.getFullYear();
+  const mm = String(at.getMonth() + 1).padStart(2, "0");
+  const dd = String(at.getDate()).padStart(2, "0");
+  const hh = String(at.getHours()).padStart(2, "0");
+  const mi = String(at.getMinutes()).padStart(2, "0");
+  const ss = String(at.getSeconds()).padStart(2, "0");
+  return `Memos/${yyyy}/${mm}-${dd}/${hh}-${mi}-${ss}`;
+}
+
+export function memoNoteContent(filename: string, at: Date = new Date()): string {
+  return [
+    "# 🎙️ Voice memo",
+    "",
+    `_Recorded ${at.toLocaleString()}._`,
+    "",
+    "_Transcript pending._",
+    "",
+    `![[${filename}]]`,
+    "",
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- New `/capture` route with tap-to-record UI: idle → requesting → recording ↔ paused → review → saving. Pulsing elapsed-time badge, pause/resume/discard, `<audio controls>` playback.
- `src/lib/capture/recorder.ts` wraps `MediaRecorder` with a mimeType priority of webm/opus → mp4 → ogg/opus, accumulates chunks, and returns `{data: ArrayBuffer, mimeType, durationMs}` on stop. Tracks accumulated recording time across pause/resume. Injectable `MediaRecorderCtor` + `now()` for tests.
- Save path writes the blob to OPFS+IDB via `blobStore.put()` then enqueues three mutations in order — `create-note` (with `🎙️ Voice memo` stub body, `Memos/YYYY/MM-DD/HH-MM-SS` path, `tags: ["memo"]`), `upload-attachment`, `link-attachment` (pathRef `blob:<id>`) — so memos work offline and drain on reconnect.
- `+ Memo` link in the header; toast + navigate to `/notes` after save.

## Design calls
- **Route, not floating button.** Wanted discoverability with room for controls without cluttering every page. Floating button is easy to add later if we want both.
- **mimeType priority.** Opus-in-webm for Chrome/Firefox, mp4/AAC for Safari, ogg/opus as a distant third. Unsupported browsers get a clear error instead of a silent failure.
- **Uniform enqueue path.** Online and offline both go through the queue, so save is the same code path everywhere and drains naturally on reconnect. No direct vault dispatch.
- **Land on `/notes`, not the local note.** NoteView fetches from the vault and doesn't know about `local-*` ids. A toast is honest; a 404 would not be.
- **No waveform.** Not worth the complexity for v1. Elapsed-time badge communicates "recording" cleanly.

## Out of scope
Transcription (PR #4/#5), queue visibility UI, in-place editing of the review before save, waveform display, trim.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test --run` — 251/251 passing (14 new recorder tests, 6 new MemoCapture route tests)
- [x] `bun run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)