### PR TITLE
Add scribe transcription integration

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,6 +12,7 @@ import { NoteNew } from "./routes/NoteNew";
 import { NoteView } from "./routes/NoteView";
 import { Notes } from "./routes/Notes";
 import { OAuthCallback } from "./routes/OAuthCallback";
+import { Settings } from "./routes/Settings";
 import { Tags } from "./routes/Tags";
 import { VaultGraph } from "./routes/VaultGraph";
 import { Vaults } from "./routes/Vaults";
@@ -38,6 +39,7 @@ export function App() {
                 <Route path="/add" element={<AddVault />} />
                 <Route path="/oauth/callback" element={<OAuthCallback />} />
                 <Route path="/vaults" element={<Vaults />} />
+                <Route path="/settings" element={<Settings />} />
                 <Route path="*" element={<Home />} />
               </Routes>
             </main>

--- a/src/app/routes/MemoCapture.test.tsx
+++ b/src/app/routes/MemoCapture.test.tsx
@@ -228,6 +228,59 @@ describe("MemoCapture route", () => {
       expect(rows[0].mutation.payload.path).toMatch(/^Memos\//);
       expect(rows[0].mutation.payload.tags).toEqual(["memo"]);
     }
+    // Without scribe configured, upload-attachment should not retain the blob.
+    if (upload.mutation.kind === "upload-attachment") {
+      expect(upload.mutation.retain).not.toBe(true);
+    }
+    db.close();
+  });
+
+  it("enqueues a transcribe-memo row when scribe is configured", async () => {
+    localStorage.setItem(
+      "lens:scribe:dev",
+      JSON.stringify({ url: "http://scribe.local:3200", cleanup: false }),
+    );
+    renderAt("/capture");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start recording/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^stop$/i })).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^stop$/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save memo/i })).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save memo/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("NotesListPage")).toBeInTheDocument();
+    });
+
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    const kinds = rows.map((r) => r.mutation.kind);
+    expect(kinds).toEqual([
+      "create-note",
+      "upload-attachment",
+      "link-attachment",
+      "transcribe-memo",
+    ]);
+    const upload = rows.find((r) => r.mutation.kind === "upload-attachment")!;
+    if (upload.mutation.kind === "upload-attachment") {
+      expect(upload.mutation.retain).toBe(true);
+    }
+    const transcribe = rows.find((r) => r.mutation.kind === "transcribe-memo")!;
+    if (transcribe.mutation.kind === "transcribe-memo") {
+      expect(transcribe.mutation.marker).toBe("_Transcript pending._");
+      expect(transcribe.mutation.blobId).toBe(
+        upload.mutation.kind === "upload-attachment" ? upload.mutation.blobId : "",
+      );
+    }
     db.close();
   });
 

--- a/src/app/routes/MemoCapture.tsx
+++ b/src/app/routes/MemoCapture.tsx
@@ -8,12 +8,18 @@ import {
   pickMimeType,
   requestMic,
 } from "@/lib/capture/recorder";
+import { loadScribeSettings } from "@/lib/scribe";
 import { blobRef, enqueue, newBlobId, newLocalId } from "@/lib/sync";
 import { useToastStore } from "@/lib/toast/store";
 import { useVaultStore } from "@/lib/vault";
 import { useSync } from "@/providers/SyncProvider";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, Navigate, useNavigate } from "react-router";
+
+// The stub line that `memoNoteContent` seeds. transcribe-memo looks for this
+// substring server-side before replacing; if the user has edited it out, we
+// don't clobber their work.
+const TRANSCRIPT_MARKER = "_Transcript pending._";
 
 type Phase =
   | { kind: "idle" }
@@ -171,6 +177,11 @@ export function MemoCapture() {
     const content = memoNoteContent(filename, recordedAt);
     const localId = newLocalId();
     const blobId = newBlobId();
+    // Only enqueue transcription (and retain the blob beyond upload) when the
+    // active vault has scribe configured. Otherwise memos save exactly as
+    // before, just without a transcript pass.
+    const scribe = loadScribeSettings(activeVault.id);
+    const willTranscribe = scribe !== null;
     try {
       await blobStore.put(blobId, phase.data, phase.mimeType, activeVault.id);
       await enqueue(
@@ -184,7 +195,13 @@ export function MemoCapture() {
       );
       await enqueue(
         db,
-        { kind: "upload-attachment", blobId, filename, mimeType: phase.mimeType },
+        {
+          kind: "upload-attachment",
+          blobId,
+          filename,
+          mimeType: phase.mimeType,
+          retain: willTranscribe,
+        },
         { vaultId: activeVault.id },
       );
       await enqueue(
@@ -197,6 +214,20 @@ export function MemoCapture() {
         },
         { vaultId: activeVault.id },
       );
+      if (willTranscribe) {
+        await enqueue(
+          db,
+          {
+            kind: "transcribe-memo",
+            noteId: localId,
+            blobId,
+            filename,
+            mimeType: phase.mimeType,
+            marker: TRANSCRIPT_MARKER,
+          },
+          { vaultId: activeVault.id },
+        );
+      }
       // Kick the engine so online users see it flush right away; offline it
       // no-ops and the next online event picks it up.
       void engine?.runOnce();

--- a/src/app/routes/Settings.test.tsx
+++ b/src/app/routes/Settings.test.tsx
@@ -1,0 +1,134 @@
+import { Settings } from "@/app/routes/Settings";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault/store";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub scribe client so the connection-test button hits our fake instead of
+// making a real network call.
+const scribeFake = {
+  health: vi.fn<() => Promise<boolean>>(async () => true),
+};
+
+vi.mock("@/lib/scribe", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/scribe")>("@/lib/scribe");
+  return {
+    ...actual,
+    scribeHealth: () => scribeFake.health(),
+  };
+});
+
+function seedActiveVault() {
+  useVaultStore.setState({
+    vaults: {
+      dev: {
+        id: "dev",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "client-test",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "dev",
+  });
+}
+
+function renderSettings() {
+  return render(
+    <MemoryRouter initialEntries={["/settings"]}>
+      <Routes>
+        <Route path="/settings" element={<Settings />} />
+        <Route path="/" element={<div>HomePage</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("Settings route", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useToastStore.setState({ toasts: [] });
+    scribeFake.health = vi.fn(async () => true);
+    seedActiveVault();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("redirects to / when no active vault", () => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    renderSettings();
+    expect(screen.getByText("HomePage")).toBeInTheDocument();
+  });
+
+  it("renders the scribe section for the active vault", () => {
+    renderSettings();
+    expect(screen.getByRole("heading", { name: /transcription/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/localhost:3200/)).toBeInTheDocument();
+  });
+
+  it("saves scribe settings to localStorage on Save", async () => {
+    renderSettings();
+    const urlInput = screen.getByPlaceholderText(/localhost:3200/) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(urlInput, { target: { value: "http://scribe.dev" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    });
+    const stored = JSON.parse(localStorage.getItem("lens:scribe:dev") ?? "{}");
+    expect(stored.url).toBe("http://scribe.dev");
+    expect(useToastStore.getState().toasts[0]?.message).toContain("Scribe settings saved");
+  });
+
+  it("shows success when test-connection succeeds", async () => {
+    scribeFake.health = vi.fn(async () => true);
+    renderSettings();
+    const urlInput = screen.getByPlaceholderText(/localhost:3200/) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(urlInput, { target: { value: "http://scribe.dev" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /test connection/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/scribe is reachable/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows failure when test-connection fails", async () => {
+    scribeFake.health = vi.fn(async () => false);
+    renderSettings();
+    const urlInput = screen.getByPlaceholderText(/localhost:3200/) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(urlInput, { target: { value: "http://scribe.dev" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /test connection/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/couldn't reach scribe/i)).toBeInTheDocument();
+    });
+  });
+
+  it("pre-fills from stored settings and clears on Clear", async () => {
+    localStorage.setItem(
+      "lens:scribe:dev",
+      JSON.stringify({ url: "http://scribe.dev", cleanup: true }),
+    );
+    renderSettings();
+    const urlInput = screen.getByPlaceholderText(/localhost:3200/) as HTMLInputElement;
+    expect(urlInput.value).toBe("http://scribe.dev");
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^clear$/i }));
+    });
+    expect(localStorage.getItem("lens:scribe:dev")).toBeNull();
+  });
+});

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -1,0 +1,183 @@
+import { type ScribeSettings, scribeHealth, useScribeSettings } from "@/lib/scribe";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault";
+import { useState } from "react";
+import { Link, Navigate } from "react-router";
+
+// Per-vault settings UI. v0.2 only surfaces scribe because it's the first
+// third-party integration; structured so additional sections slot in without
+// re-framing the page.
+export function Settings() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  if (!activeVault) return <Navigate to="/" replace />;
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <header className="mb-8">
+        <nav className="mb-3 text-sm text-fg-dim">
+          <Link to="/" className="hover:text-accent">
+            ← Home
+          </Link>
+        </nav>
+        <h1 className="font-serif text-3xl tracking-tight">Settings</h1>
+        <p className="mt-1 text-sm text-fg-muted">
+          Configuring <span className="text-fg">{activeVault.name}</span>.
+        </p>
+      </header>
+
+      <ScribeSettingsSection vaultId={activeVault.id} />
+    </div>
+  );
+}
+
+function ScribeSettingsSection({ vaultId }: { vaultId: string }) {
+  const { settings, setSettings } = useScribeSettings(vaultId);
+  const pushToast = useToastStore((s) => s.push);
+
+  const [url, setUrl] = useState<string>(settings?.url ?? "");
+  const [token, setToken] = useState<string>(settings?.token ?? "");
+  const [cleanup, setCleanup] = useState<boolean>(settings?.cleanup === true);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<"ok" | "fail" | null>(null);
+
+  const configured = settings !== null;
+
+  const save = () => {
+    const trimmed = url.trim();
+    if (!trimmed) {
+      pushToast("Scribe URL is required.", "error");
+      return;
+    }
+    const next: ScribeSettings = {
+      url: trimmed,
+      token: token.trim() || undefined,
+      cleanup,
+    };
+    setSettings(next);
+    pushToast("Scribe settings saved.", "success");
+  };
+
+  const clear = () => {
+    if (!configured) return;
+    if (!confirm("Remove scribe configuration for this vault? Transcription will stop running."))
+      return;
+    setSettings(null);
+    setUrl("");
+    setToken("");
+    setCleanup(false);
+    setTestResult(null);
+    pushToast("Scribe settings cleared.", "success");
+  };
+
+  const testConnection = async () => {
+    const trimmed = url.trim();
+    if (!trimmed) {
+      pushToast("Enter a scribe URL first.", "error");
+      return;
+    }
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const ok = await scribeHealth(trimmed, { token: token.trim() || undefined });
+      setTestResult(ok ? "ok" : "fail");
+    } catch {
+      setTestResult("fail");
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <section className="space-y-4 rounded-xl border border-border bg-card p-6">
+      <div>
+        <h2 className="font-serif text-xl text-fg">Transcription (scribe)</h2>
+        <p className="mt-1 text-xs text-fg-dim">
+          Point to a running{" "}
+          <a
+            href="https://github.com/ParachuteComputer/parachute-scribe"
+            className="underline hover:text-accent"
+          >
+            parachute-scribe
+          </a>{" "}
+          instance and new voice memos will transcribe automatically. Leave blank to keep
+          transcription disabled.
+        </p>
+      </div>
+
+      <label className="block text-sm">
+        <span className="mb-1 block text-fg-muted">Scribe URL</span>
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => {
+            setUrl(e.target.value);
+            setTestResult(null);
+          }}
+          placeholder="http://localhost:3200"
+          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-fg-dim focus:border-accent focus:outline-none"
+        />
+      </label>
+
+      <label className="block text-sm">
+        <span className="mb-1 block text-fg-muted">
+          Bearer token <span className="text-fg-dim">(optional)</span>
+        </span>
+        <input
+          type="password"
+          value={token}
+          onChange={(e) => {
+            setToken(e.target.value);
+            setTestResult(null);
+          }}
+          placeholder="Required if your scribe is gated behind a proxy"
+          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-fg-dim focus:border-accent focus:outline-none"
+        />
+      </label>
+
+      <label className="flex items-center gap-2 text-sm text-fg-muted">
+        <input
+          type="checkbox"
+          checked={cleanup}
+          onChange={(e) => setCleanup(e.target.checked)}
+          className="accent-accent"
+        />
+        <span>Clean up transcripts (LLM pass to fix filler words and punctuation)</span>
+      </label>
+
+      <div className="flex flex-wrap items-center gap-3 pt-2">
+        <button
+          type="button"
+          onClick={save}
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={testConnection}
+          disabled={testing}
+          className="rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg-muted hover:text-accent disabled:opacity-50"
+        >
+          {testing ? "Testing…" : "Test connection"}
+        </button>
+        {configured ? (
+          <button type="button" onClick={clear} className="text-sm text-red-400 hover:text-red-300">
+            Clear
+          </button>
+        ) : null}
+        {testResult === "ok" ? (
+          <span className="text-sm text-emerald-400">Scribe is reachable.</span>
+        ) : null}
+        {testResult === "fail" ? (
+          <span className="text-sm text-red-400">Couldn't reach scribe at that URL.</span>
+        ) : null}
+      </div>
+
+      <p className="rounded-md bg-bg/60 p-3 text-xs text-fg-dim">
+        Heads up: parachute-scribe doesn't send CORS headers by default. If the test fails with a
+        CORS error in the browser console, run scribe behind a reverse proxy that shares your
+        vault's origin.
+      </p>
+    </section>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -66,6 +66,9 @@ export function Header() {
               >
                 Manage
               </button>
+              <Link to="/settings" className="text-sm text-fg-muted hover:text-accent">
+                Settings
+              </Link>
               <InstallPrompt />
               <ThemeToggle />
             </>

--- a/src/lib/scribe/client.test.ts
+++ b/src/lib/scribe/client.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from "vitest";
+import { scribeHealth, transcribeAudio } from "./client";
+import { ScribeError } from "./types";
+
+function mockFetch(impl: (url: string, init?: RequestInit) => Promise<Response>) {
+  return vi.fn(impl) as unknown as typeof fetch;
+}
+
+describe("transcribeAudio", () => {
+  const bytes = new Uint8Array([1, 2, 3, 4]);
+
+  it("POSTs multipart/form-data with the audio and returns text", async () => {
+    let captured: { url: string; init?: RequestInit } | null = null;
+    const fetchImpl = mockFetch(async (url, init) => {
+      captured = { url, init };
+      return new Response(JSON.stringify({ text: "hello world" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const result = await transcribeAudio("http://scribe.local:3200", {
+      audio: bytes,
+      filename: "memo.webm",
+      mimeType: "audio/webm",
+      fetchImpl,
+    });
+    expect(result.text).toBe("hello world");
+    expect(captured!.url).toBe("http://scribe.local:3200/v1/audio/transcriptions");
+    expect(captured!.init?.method).toBe("POST");
+    const form = captured!.init?.body as FormData;
+    expect(form.get("file")).toBeInstanceOf(Blob);
+    const file = form.get("file") as Blob;
+    expect(file.size).toBe(4);
+  });
+
+  it("appends cleanup=true when requested", async () => {
+    let form: FormData | null = null;
+    const fetchImpl = mockFetch(async (_url, init) => {
+      form = init?.body as FormData;
+      return new Response(JSON.stringify({ text: "cleaned up" }), { status: 200 });
+    });
+    await transcribeAudio("http://scribe.local", {
+      audio: bytes,
+      filename: "memo.webm",
+      mimeType: "audio/webm",
+      cleanup: true,
+      fetchImpl,
+    });
+    expect(form!.get("cleanup")).toBe("true");
+  });
+
+  it("appends cleanup=false explicitly when disabled", async () => {
+    let form: FormData | null = null;
+    const fetchImpl = mockFetch(async (_url, init) => {
+      form = init?.body as FormData;
+      return new Response(JSON.stringify({ text: "raw" }), { status: 200 });
+    });
+    await transcribeAudio("http://scribe.local", {
+      audio: bytes,
+      filename: "memo.webm",
+      mimeType: "audio/webm",
+      cleanup: false,
+      fetchImpl,
+    });
+    expect(form!.get("cleanup")).toBe("false");
+  });
+
+  it("sends Authorization header when a token is provided", async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = mockFetch(async (_url, init) => {
+      captured = init;
+      return new Response(JSON.stringify({ text: "ok" }), { status: 200 });
+    });
+    await transcribeAudio("http://scribe.local", {
+      audio: bytes,
+      filename: "m.webm",
+      mimeType: "audio/webm",
+      token: "sk-secret",
+      fetchImpl,
+    });
+    const headers = captured?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer sk-secret");
+  });
+
+  it("maps 401 to ScribeError with kind=auth", async () => {
+    const fetchImpl = mockFetch(
+      async () =>
+        new Response(JSON.stringify({ error: "no token" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(
+      transcribeAudio("http://scribe.local", {
+        audio: bytes,
+        filename: "m.webm",
+        mimeType: "audio/webm",
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ kind: "auth", status: 401 });
+  });
+
+  it("maps 503 to ScribeError with kind=unavailable", async () => {
+    const fetchImpl = mockFetch(
+      async () => new Response(JSON.stringify({ error: "overloaded" }), { status: 503 }),
+    );
+    await expect(
+      transcribeAudio("http://scribe.local", {
+        audio: bytes,
+        filename: "m.webm",
+        mimeType: "audio/webm",
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ kind: "unavailable", status: 503 });
+  });
+
+  it("maps network failure to ScribeError with kind=unavailable", async () => {
+    const fetchImpl = mockFetch(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    await expect(
+      transcribeAudio("http://scribe.local", {
+        audio: bytes,
+        filename: "m.webm",
+        mimeType: "audio/webm",
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ kind: "unavailable" });
+  });
+
+  it("maps 400 to ScribeError with kind=bad-request", async () => {
+    const fetchImpl = mockFetch(
+      async () => new Response(JSON.stringify({ error: "missing file" }), { status: 400 }),
+    );
+    await expect(
+      transcribeAudio("http://scribe.local", {
+        audio: bytes,
+        filename: "m.webm",
+        mimeType: "audio/webm",
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ kind: "bad-request", status: 400 });
+  });
+
+  it("maps malformed response body to ScribeError with kind=parse", async () => {
+    const fetchImpl = mockFetch(
+      async () =>
+        new Response(JSON.stringify({ not_text: "oops" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(
+      transcribeAudio("http://scribe.local", {
+        audio: bytes,
+        filename: "m.webm",
+        mimeType: "audio/webm",
+        fetchImpl,
+      }),
+    ).rejects.toBeInstanceOf(ScribeError);
+  });
+
+  it("rethrows AbortError on cancellation", async () => {
+    const fetchImpl = mockFetch(async () => {
+      throw new DOMException("aborted", "AbortError");
+    });
+    await expect(
+      transcribeAudio("http://scribe.local", {
+        audio: bytes,
+        filename: "m.webm",
+        mimeType: "audio/webm",
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("joins baseUrl with trailing slash correctly", async () => {
+    let captured: string | null = null;
+    const fetchImpl = mockFetch(async (url) => {
+      captured = url;
+      return new Response(JSON.stringify({ text: "x" }), { status: 200 });
+    });
+    await transcribeAudio("http://scribe.local/", {
+      audio: bytes,
+      filename: "m.webm",
+      mimeType: "audio/webm",
+      fetchImpl,
+    });
+    expect(captured).toBe("http://scribe.local/v1/audio/transcriptions");
+  });
+});
+
+describe("scribeHealth", () => {
+  it("returns true when /health responds {ok:true}", async () => {
+    const fetchImpl = mockFetch(
+      async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    expect(await scribeHealth("http://scribe.local", { fetchImpl })).toBe(true);
+  });
+
+  it("returns false when /health responds non-200", async () => {
+    const fetchImpl = mockFetch(async () => new Response("nope", { status: 500 }));
+    expect(await scribeHealth("http://scribe.local", { fetchImpl })).toBe(false);
+  });
+
+  it("returns false on network error", async () => {
+    const fetchImpl = mockFetch(async () => {
+      throw new TypeError("offline");
+    });
+    expect(await scribeHealth("http://scribe.local", { fetchImpl })).toBe(false);
+  });
+
+  it("includes bearer token when provided", async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = mockFetch(async (_url, init) => {
+      captured = init;
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    await scribeHealth("http://scribe.local", { token: "abc", fetchImpl });
+    const headers = captured?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer abc");
+  });
+});

--- a/src/lib/scribe/client.ts
+++ b/src/lib/scribe/client.ts
@@ -1,0 +1,147 @@
+// Minimal client for parachute-scribe's HTTP surface.
+//
+// Scribe exposes a Whisper-compatible API at POST /v1/audio/transcriptions —
+// multipart upload of `file`, optional `cleanup` flag, response
+// `{ text: string }` on 200 / `{ error: string }` on 4xx/5xx.
+//
+// All calls are classified into a small set of `ScribeError` kinds so the
+// sync queue can decide between retry-with-backoff (unavailable) and
+// stop-trying (auth/bad-request).
+//
+// CAVEAT: parachute-scribe currently sets no CORS headers. When called from
+// a browser origin different from scribe's, preflight will fail. Users who
+// hit this need to proxy scribe behind the same origin (or have scribe
+// updated server-side).
+
+import { ScribeError } from "./types";
+
+export interface TranscribeOptions {
+  audio: Blob | ArrayBuffer | Uint8Array;
+  filename: string;
+  mimeType: string;
+  cleanup?: boolean;
+  model?: string;
+  token?: string;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+}
+
+export interface TranscribeResult {
+  text: string;
+}
+
+export async function transcribeAudio(
+  baseUrl: string,
+  opts: TranscribeOptions,
+): Promise<TranscribeResult> {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const form = new FormData();
+  const blob = toBlob(opts.audio, opts.mimeType);
+  form.append("file", blob, opts.filename);
+  if (opts.cleanup !== undefined) form.append("cleanup", opts.cleanup ? "true" : "false");
+  if (opts.model) form.append("model", opts.model);
+
+  const url = joinUrl(baseUrl, "/v1/audio/transcriptions");
+
+  const headers: Record<string, string> = {};
+  if (opts.token) headers.Authorization = `Bearer ${opts.token}`;
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: "POST",
+      body: form,
+      headers,
+      signal: opts.signal,
+    });
+  } catch (err) {
+    // TypeError usually = network error; DOMException with AbortError = cancelled.
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    const message = err instanceof Error ? err.message : "scribe network error";
+    throw new ScribeError("unavailable", message);
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    throw new ScribeError("auth", await errorMessage(res, "Scribe rejected the token"), res.status);
+  }
+  if (res.status >= 500) {
+    throw new ScribeError(
+      "unavailable",
+      await errorMessage(res, `Scribe server error (${res.status})`),
+      res.status,
+    );
+  }
+  if (!res.ok) {
+    throw new ScribeError(
+      "bad-request",
+      await errorMessage(res, `Scribe rejected the request (${res.status})`),
+      res.status,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "invalid response";
+    throw new ScribeError("parse", message);
+  }
+  if (!isTranscribeResult(body)) {
+    throw new ScribeError("parse", "Scribe response missing `text` field");
+  }
+  return body;
+}
+
+export interface HealthOptions {
+  token?: string;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+}
+
+// Returns true if scribe's /health endpoint responds 200 with {ok: true}.
+// All other outcomes (including network errors) return false — callers can
+// show a simple "reachable / not reachable" state.
+export async function scribeHealth(baseUrl: string, opts: HealthOptions = {}): Promise<boolean> {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const url = joinUrl(baseUrl, "/health");
+  const headers: Record<string, string> = {};
+  if (opts.token) headers.Authorization = `Bearer ${opts.token}`;
+  try {
+    const res = await fetchImpl(url, { headers, signal: opts.signal });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { ok?: unknown };
+    return body?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+function toBlob(audio: Blob | ArrayBuffer | Uint8Array, mimeType: string): Blob {
+  if (audio instanceof Blob) return audio;
+  const view = audio instanceof Uint8Array ? audio : new Uint8Array(audio);
+  return new Blob([view], { type: mimeType });
+}
+
+function joinUrl(base: string, path: string): string {
+  const trimmedBase = base.endsWith("/") ? base.slice(0, -1) : base;
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`;
+  return trimmedBase + trimmedPath;
+}
+
+async function errorMessage(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: unknown };
+    if (typeof body?.error === "string") return body.error;
+  } catch {
+    // fall through
+  }
+  return fallback;
+}
+
+function isTranscribeResult(body: unknown): body is TranscribeResult {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    typeof (body as { text?: unknown }).text === "string"
+  );
+}

--- a/src/lib/scribe/index.ts
+++ b/src/lib/scribe/index.ts
@@ -1,0 +1,10 @@
+export { scribeHealth, transcribeAudio } from "./client";
+export type { HealthOptions, TranscribeOptions, TranscribeResult } from "./client";
+export {
+  deleteScribeSettings,
+  loadScribeSettings,
+  saveScribeSettings,
+  useScribeSettings,
+} from "./settings";
+export { ScribeError } from "./types";
+export type { ScribeErrorKind, ScribeSettings } from "./types";

--- a/src/lib/scribe/settings.test.ts
+++ b/src/lib/scribe/settings.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deleteScribeSettings, loadScribeSettings, saveScribeSettings } from "./settings";
+
+describe("scribe settings storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("round-trips url, token, cleanup", () => {
+    saveScribeSettings("v1", { url: "http://scribe.local", token: "sk-x", cleanup: true });
+    const out = loadScribeSettings("v1");
+    expect(out).toEqual({ url: "http://scribe.local", token: "sk-x", cleanup: true });
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(loadScribeSettings("nope")).toBeNull();
+  });
+
+  it("returns null when stored JSON is missing url", () => {
+    localStorage.setItem("lens:scribe:v1", JSON.stringify({ token: "x" }));
+    expect(loadScribeSettings("v1")).toBeNull();
+  });
+
+  it("strips empty token on save", () => {
+    saveScribeSettings("v1", { url: "http://scribe.local", token: "", cleanup: false });
+    const out = loadScribeSettings("v1");
+    expect(out).toEqual({ url: "http://scribe.local", token: undefined, cleanup: false });
+  });
+
+  it("trims whitespace on url", () => {
+    saveScribeSettings("v1", { url: "   http://scribe.local/   " });
+    const out = loadScribeSettings("v1");
+    expect(out?.url).toBe("http://scribe.local/");
+  });
+
+  it("deleteScribeSettings removes the entry", () => {
+    saveScribeSettings("v1", { url: "http://scribe.local" });
+    deleteScribeSettings("v1");
+    expect(loadScribeSettings("v1")).toBeNull();
+  });
+
+  it("treats cleanup !== true as false", () => {
+    localStorage.setItem(
+      "lens:scribe:v1",
+      JSON.stringify({ url: "http://scribe.local", cleanup: "yes" }),
+    );
+    expect(loadScribeSettings("v1")?.cleanup).toBe(false);
+  });
+});

--- a/src/lib/scribe/settings.ts
+++ b/src/lib/scribe/settings.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ScribeSettings } from "./types";
+
+const STORAGE_PREFIX = "lens:scribe:";
+
+function keyFor(vaultId: string): string {
+  return STORAGE_PREFIX + vaultId;
+}
+
+export function loadScribeSettings(vaultId: string): ScribeSettings | null {
+  try {
+    const raw = localStorage.getItem(keyFor(vaultId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ScribeSettings>;
+    if (!parsed.url || typeof parsed.url !== "string") return null;
+    return {
+      url: parsed.url,
+      token: typeof parsed.token === "string" && parsed.token.length > 0 ? parsed.token : undefined,
+      cleanup: parsed.cleanup === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveScribeSettings(vaultId: string, settings: ScribeSettings): void {
+  // Strip empty strings so `loadScribeSettings` consistently returns undefined
+  // for missing optional fields.
+  const normalized: ScribeSettings = {
+    url: settings.url.trim(),
+    token: settings.token && settings.token.length > 0 ? settings.token : undefined,
+    cleanup: settings.cleanup === true,
+  };
+  try {
+    localStorage.setItem(keyFor(vaultId), JSON.stringify(normalized));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+export function deleteScribeSettings(vaultId: string): void {
+  try {
+    localStorage.removeItem(keyFor(vaultId));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+// Thin React hook for the settings form. Re-reads on mount and on vault
+// change. Saves go through the setter, which also broadcasts via the
+// `storage` event so other tabs pick them up on next mount.
+export function useScribeSettings(vaultId: string | null): {
+  settings: ScribeSettings | null;
+  setSettings: (next: ScribeSettings | null) => void;
+} {
+  const [settings, setState] = useState<ScribeSettings | null>(() =>
+    vaultId ? loadScribeSettings(vaultId) : null,
+  );
+
+  useEffect(() => {
+    setState(vaultId ? loadScribeSettings(vaultId) : null);
+  }, [vaultId]);
+
+  const setSettings = useCallback(
+    (next: ScribeSettings | null) => {
+      if (!vaultId) return;
+      if (next === null) {
+        deleteScribeSettings(vaultId);
+      } else {
+        saveScribeSettings(vaultId, next);
+      }
+      setState(next);
+    },
+    [vaultId],
+  );
+
+  return { settings, setSettings };
+}

--- a/src/lib/scribe/types.ts
+++ b/src/lib/scribe/types.ts
@@ -1,0 +1,24 @@
+// Per-vault scribe configuration. Stored in localStorage keyed by vaultId.
+// Empty/missing = transcription is disabled for that vault; memos still save,
+// they just never get a transcript run.
+export interface ScribeSettings {
+  url: string;
+  token?: string;
+  // Whether to pass `cleanup=true` on transcription requests. Scribe runs an
+  // LLM pass to fix filler words / punctuation. Costs extra on hosted setups,
+  // so default off; users opt in per-vault.
+  cleanup?: boolean;
+}
+
+export type ScribeErrorKind = "auth" | "unavailable" | "bad-request" | "parse";
+
+export class ScribeError extends Error {
+  readonly kind: ScribeErrorKind;
+  readonly status?: number;
+  constructor(kind: ScribeErrorKind, message: string, status?: number) {
+    super(message);
+    this.name = "ScribeError";
+    this.kind = kind;
+    this.status = status;
+  }
+}

--- a/src/lib/sync/engine.ts
+++ b/src/lib/sync/engine.ts
@@ -1,8 +1,18 @@
+import type { ScribeSettings } from "@/lib/scribe";
 import type { VaultClient } from "@/lib/vault/client";
 import type { BlobStore } from "./blob-store";
 import type { LensDB } from "./db";
 import { drain } from "./queue";
 import type { DrainOutcome } from "./types";
+
+export interface EngineDrainContext {
+  client: VaultClient;
+  vaultId: string;
+  // Per-vault scribe settings — passed through to drain so transcribe-memo
+  // rows have somewhere to POST. `null` (or missing) drops transcribe rows
+  // rather than retrying forever.
+  scribeSettings?: ScribeSettings | null;
+}
 
 export interface EngineOptions {
   db: LensDB;
@@ -10,7 +20,7 @@ export interface EngineOptions {
   // Resolves the client + vault-id to drain against on each tick. Returning
   // null (no active vault / no token) pauses the engine — the timer keeps
   // running in case state changes.
-  resolveContext: () => { client: VaultClient; vaultId: string } | null;
+  resolveContext: () => EngineDrainContext | null;
   tickIntervalMs?: number;
   onDrain?: (outcome: DrainOutcome) => void;
 }
@@ -69,6 +79,7 @@ export class SyncEngine {
         client: ctx.client,
         vaultId: ctx.vaultId,
         blobStore: this.opts.blobStore,
+        scribeSettings: ctx.scribeSettings ?? null,
       });
       this.opts.onDrain?.(outcome);
       return outcome;

--- a/src/lib/sync/queue.test.ts
+++ b/src/lib/sync/queue.test.ts
@@ -1,3 +1,4 @@
+import { ScribeError } from "@/lib/scribe";
 import { VaultAuthError, VaultConflictError, VaultNotFoundError } from "@/lib/vault/client";
 import type { VaultClient } from "@/lib/vault/client";
 import type { Note, NoteAttachment } from "@/lib/vault/types";
@@ -5,7 +6,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createIdbBlobStore, newBlobId } from "./blob-store";
 import { type LensDB, getMeta, openLensDB } from "./db";
 import { blobRef, newLocalId, resolveNoteId } from "./id-map";
-import { AUTH_HALT_META, countPending, drain, enqueue, listPending } from "./queue";
+import {
+  AUTH_HALT_META,
+  TRANSCRIBE_GIVE_UP_MS,
+  countPending,
+  drain,
+  enqueue,
+  listPending,
+} from "./queue";
 
 async function freshDb(): Promise<LensDB> {
   indexedDB.deleteDatabase("parachute-lens");
@@ -19,6 +27,7 @@ interface ClientOverrides {
   uploadStorageFile?: VaultClient["uploadStorageFile"];
   linkAttachment?: VaultClient["linkAttachment"];
   deleteAttachment?: VaultClient["deleteAttachment"];
+  getNote?: VaultClient["getNote"];
 }
 
 function makeClient(overrides: ClientOverrides = {}): VaultClient {
@@ -33,6 +42,7 @@ function makeClient(overrides: ClientOverrides = {}): VaultClient {
     })),
     linkAttachment: vi.fn(async () => ({ id: "att-1" }) as NoteAttachment),
     deleteAttachment: vi.fn(async () => {}),
+    getNote: vi.fn(async (id: string) => ({ id, createdAt: "now", content: "" }) as Note),
   };
   return { ...defaults, ...overrides } as unknown as VaultClient;
 }
@@ -275,6 +285,284 @@ describe("drain — error classification", () => {
     });
     expect(deleteNote).not.toHaveBeenCalled();
     expect(out.drained).toBe(0);
+  });
+});
+
+describe("drain — upload-attachment retention", () => {
+  let db: LensDB;
+  beforeEach(async () => {
+    db = await freshDb();
+  });
+  afterEach(() => db.close());
+
+  it("deletes the blob after a normal upload-attachment", async () => {
+    const blobId = newBlobId();
+    const blobStore = createIdbBlobStore(db);
+    await blobStore.put(blobId, new Uint8Array([9]).buffer, "audio/webm", "v1");
+    await enqueue(
+      db,
+      { kind: "upload-attachment", blobId, filename: "a.webm", mimeType: "audio/webm" },
+      { vaultId: "v1" },
+    );
+    await drain({ db, client: makeClient(), vaultId: "v1", blobStore });
+    expect(await blobStore.get(blobId)).toBeNull();
+  });
+
+  it("retains the blob when retain=true is set", async () => {
+    const blobId = newBlobId();
+    const blobStore = createIdbBlobStore(db);
+    await blobStore.put(blobId, new Uint8Array([9]).buffer, "audio/webm", "v1");
+    await enqueue(
+      db,
+      {
+        kind: "upload-attachment",
+        blobId,
+        filename: "a.webm",
+        mimeType: "audio/webm",
+        retain: true,
+      },
+      { vaultId: "v1" },
+    );
+    await drain({ db, client: makeClient(), vaultId: "v1", blobStore });
+    const stored = await blobStore.get(blobId);
+    expect(stored).not.toBeNull();
+    expect(stored!.mimeType).toBe("audio/webm");
+  });
+});
+
+describe("drain — transcribe-memo", () => {
+  let db: LensDB;
+  beforeEach(async () => {
+    db = await freshDb();
+  });
+  afterEach(() => db.close());
+
+  async function seedBlob(blobId: string): Promise<ReturnType<typeof createIdbBlobStore>> {
+    const blobStore = createIdbBlobStore(db);
+    await blobStore.put(blobId, new Uint8Array([1, 2, 3]).buffer, "audio/webm", "v1");
+    return blobStore;
+  }
+
+  const settings = { url: "http://scribe.local", cleanup: false };
+
+  it("PATCHes the note with the transcript and deletes the blob on success", async () => {
+    const blobId = newBlobId();
+    const blobStore = await seedBlob(blobId);
+    const stubContent = "# 🎙️ Voice memo\n\n_Transcript pending._\n";
+    await enqueue(
+      db,
+      {
+        kind: "transcribe-memo",
+        noteId: "srv-1",
+        blobId,
+        filename: "memo.webm",
+        mimeType: "audio/webm",
+        marker: "_Transcript pending._",
+      },
+      { vaultId: "v1" },
+    );
+
+    const getNote = vi.fn(
+      async (id: string) =>
+        ({
+          id,
+          createdAt: "now",
+          content: stubContent,
+        }) as Note,
+    );
+    const updateNote = vi.fn(
+      async (id: string) => ({ id, createdAt: "now", updatedAt: "now" }) as Note,
+    );
+    const transcribeImpl = vi.fn(async () => ({ text: "hello world" }));
+    const client = makeClient({ getNote, updateNote });
+
+    const out = await drain({
+      db,
+      client,
+      vaultId: "v1",
+      blobStore,
+      scribeSettings: settings,
+      transcribeImpl,
+    });
+
+    expect(out.drained).toBe(1);
+    expect(transcribeImpl).toHaveBeenCalledOnce();
+    expect(updateNote).toHaveBeenCalledWith("srv-1", {
+      content: expect.stringContaining("## Transcript\n\nhello world"),
+    });
+    expect(await blobStore.get(blobId)).toBeNull();
+  });
+
+  it("stashes as needs-human when the user has edited the note (marker gone)", async () => {
+    const blobId = newBlobId();
+    const blobStore = await seedBlob(blobId);
+    await enqueue(
+      db,
+      {
+        kind: "transcribe-memo",
+        noteId: "srv-1",
+        blobId,
+        filename: "memo.webm",
+        mimeType: "audio/webm",
+        marker: "_Transcript pending._",
+      },
+      { vaultId: "v1" },
+    );
+    const getNote = vi.fn(
+      async (id: string) =>
+        ({
+          id,
+          createdAt: "now",
+          content: "# 🎙️ Voice memo\n\nI already rewrote this.",
+        }) as Note,
+    );
+    const transcribeImpl = vi.fn(async () => ({ text: "not used" }));
+    const client = makeClient({ getNote });
+
+    const out = await drain({
+      db,
+      client,
+      vaultId: "v1",
+      blobStore,
+      scribeSettings: settings,
+      transcribeImpl,
+    });
+
+    expect(out.stashed).toBe(1);
+    expect(transcribeImpl).not.toHaveBeenCalled();
+    const rows = await listPending(db, "v1");
+    expect(rows[0].status).toBe("needs-human");
+    // Blob stays so the user can re-run transcription later.
+    expect(await blobStore.get(blobId)).not.toBeNull();
+  });
+
+  it("backs off and retains the row when scribe is unavailable", async () => {
+    const blobId = newBlobId();
+    const blobStore = await seedBlob(blobId);
+    await enqueue(
+      db,
+      {
+        kind: "transcribe-memo",
+        noteId: "srv-1",
+        blobId,
+        filename: "memo.webm",
+        mimeType: "audio/webm",
+        marker: "_Transcript pending._",
+      },
+      { vaultId: "v1" },
+    );
+    const getNote = vi.fn(
+      async (id: string) =>
+        ({
+          id,
+          createdAt: "now",
+          content: "# 🎙️ Voice memo\n\n_Transcript pending._\n",
+        }) as Note,
+    );
+    const transcribeImpl = vi.fn(async () => {
+      throw new ScribeError("unavailable", "offline");
+    });
+    const client = makeClient({ getNote });
+
+    const out = await drain({
+      db,
+      client,
+      vaultId: "v1",
+      blobStore,
+      scribeSettings: settings,
+      transcribeImpl,
+      now: () => 1_000_000,
+    });
+
+    expect(out.deferred).toBe(1);
+    const rows = await listPending(db, "v1");
+    expect(rows[0].attemptCount).toBe(1);
+    expect(rows[0].nextAttemptAt).toBeGreaterThan(1_000_000);
+    // Blob preserved across retry.
+    expect(await blobStore.get(blobId)).not.toBeNull();
+  });
+
+  it("drops the row and leaves an 'unavailable' footnote after 24h", async () => {
+    const blobId = newBlobId();
+    const blobStore = await seedBlob(blobId);
+    const t0 = 1_000_000;
+    await enqueue(
+      db,
+      {
+        kind: "transcribe-memo",
+        noteId: "srv-1",
+        blobId,
+        filename: "memo.webm",
+        mimeType: "audio/webm",
+        marker: "_Transcript pending._",
+      },
+      { vaultId: "v1" },
+    );
+    // Fix the row's createdAt retroactively so the age check trips.
+    const rows0 = await listPending(db);
+    await db.put("pending", { ...rows0[0], createdAt: t0 });
+
+    const getNote = vi.fn(
+      async (id: string) =>
+        ({
+          id,
+          createdAt: "now",
+          content: "# 🎙️ Voice memo\n\n_Transcript pending._\n",
+        }) as Note,
+    );
+    const updateNote = vi.fn(
+      async (id: string) => ({ id, createdAt: "now", updatedAt: "now" }) as Note,
+    );
+    const transcribeImpl = vi.fn(async () => ({ text: "never runs" }));
+    const client = makeClient({ getNote, updateNote });
+
+    const out = await drain({
+      db,
+      client,
+      vaultId: "v1",
+      blobStore,
+      scribeSettings: settings,
+      transcribeImpl,
+      now: () => t0 + TRANSCRIBE_GIVE_UP_MS + 1,
+    });
+
+    expect(out.drained).toBe(1);
+    expect(transcribeImpl).not.toHaveBeenCalled();
+    expect(updateNote).toHaveBeenCalledWith("srv-1", {
+      content: expect.stringContaining("_Transcription unavailable._"),
+    });
+    expect(await blobStore.get(blobId)).toBeNull();
+    expect(await countPending(db, "v1")).toBe(0);
+  });
+
+  it("drops the row and cleans up the blob when scribe settings are missing", async () => {
+    const blobId = newBlobId();
+    const blobStore = await seedBlob(blobId);
+    await enqueue(
+      db,
+      {
+        kind: "transcribe-memo",
+        noteId: "srv-1",
+        blobId,
+        filename: "memo.webm",
+        mimeType: "audio/webm",
+        marker: "_Transcript pending._",
+      },
+      { vaultId: "v1" },
+    );
+
+    const client = makeClient();
+    const out = await drain({
+      db,
+      client,
+      vaultId: "v1",
+      blobStore,
+      scribeSettings: null,
+    });
+
+    expect(out.drained).toBe(1);
+    expect(await blobStore.get(blobId)).toBeNull();
+    expect(await countPending(db, "v1")).toBe(0);
   });
 });
 

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -1,3 +1,4 @@
+import { ScribeError, type ScribeSettings, transcribeAudio } from "@/lib/scribe";
 import {
   VaultAuthError,
   type VaultClient,
@@ -23,6 +24,12 @@ export const AUTH_HALT_META = "auth-halted";
 // Backoff schedule for transient errors. Caps at 10 minutes to keep the loop
 // cheap during extended outages.
 const BACKOFF_CEILING_MS = 10 * 60 * 1000;
+
+// How long we'll keep retrying a transcribe-memo row before giving up and
+// dropping the blob. 24h is enough to cover overnight scribe downtime but
+// avoids accumulating long-lived rows that will never complete (e.g. when a
+// user pointed at a scribe instance that has since gone away).
+export const TRANSCRIBE_GIVE_UP_MS = 24 * 60 * 60 * 1000;
 
 function backoffFor(attempt: number): number {
   const base = 2 ** attempt * 1000;
@@ -67,6 +74,11 @@ export interface DrainContext {
   client: VaultClient;
   vaultId: string;
   blobStore: BlobStore;
+  // Optional per-vault scribe settings. When absent, transcribe-memo rows
+  // are dropped (with a lastError explanation) rather than retried forever.
+  scribeSettings?: ScribeSettings | null;
+  // Injection for tests: lets us stub transcribeAudio without mocking fetch.
+  transcribeImpl?: typeof transcribeAudio;
   now?: () => number;
 }
 
@@ -122,6 +134,36 @@ export async function drain(ctx: DrainContext): Promise<DrainOutcome> {
         outcome.deferred += 1;
         break;
       }
+      if (err instanceof DropRowError) {
+        // Terminal: remove the row, move on.
+        await ctx.db.delete("pending", next.seq);
+        outcome.drained += 1;
+        continue;
+      }
+      if (err instanceof SkipNoClobberError) {
+        // Surface in needs-human so the user can re-run transcription.
+        await ctx.db.put("pending", {
+          ...next,
+          status: "needs-human",
+          lastError: err.message,
+          attemptCount: next.attemptCount + 1,
+        });
+        outcome.stashed += 1;
+        continue;
+      }
+      if (err instanceof ScribeError) {
+        // "unavailable" is transient — backoff and retry on the next tick.
+        // "auth" we also treat as retryable (users may fix their token
+        // without re-auth to the vault). "bad-request" / "parse" are terminal.
+        if (err.kind === "unavailable" || err.kind === "auth") {
+          await bumpAttempt(ctx.db, next, err, now);
+          outcome.deferred += 1;
+          break;
+        }
+        await ctx.db.delete("pending", next.seq);
+        outcome.drained += 1;
+        continue;
+      }
       if (err instanceof VaultNotFoundError) {
         // Target is gone — drop the row rather than retry forever.
         await ctx.db.delete("pending", next.seq);
@@ -172,6 +214,14 @@ async function bumpAttempt(
 
 class DeferRowError extends Error {}
 
+// A terminal error: this row cannot complete, remove it from the queue.
+// Used when upstream state (config, blob, note) has gone away.
+class DropRowError extends Error {}
+
+// A "don't overwrite user content" signal — we stash the row as needs-human so
+// the user can decide whether to re-run transcription later.
+class SkipNoClobberError extends Error {}
+
 async function runMutation(ctx: DrainContext, row: PendingRow): Promise<void> {
   const m = row.mutation;
   switch (m.kind) {
@@ -205,7 +255,9 @@ async function runMutation(ctx: DrainContext, row: PendingRow): Promise<void> {
       const file = new File([stored.data], m.filename, { type: mimeType });
       const uploaded = await ctx.client.uploadStorageFile(file);
       await recordBlobPath(ctx.db, m.blobId, uploaded.path, ctx.vaultId);
-      await ctx.blobStore.delete(m.blobId);
+      // Keep the blob when a downstream transcribe-memo row still needs it;
+      // that row owns cleanup.
+      if (!m.retain) await ctx.blobStore.delete(m.blobId);
       return;
     }
     case "link-attachment": {
@@ -231,6 +283,95 @@ async function runMutation(ctx: DrainContext, row: PendingRow): Promise<void> {
       await ctx.client.deleteAttachment(noteId, m.attachmentId);
       return;
     }
+    case "transcribe-memo": {
+      await runTranscribeMemo(ctx, row, m);
+      return;
+    }
+  }
+}
+
+async function runTranscribeMemo(
+  ctx: DrainContext,
+  row: PendingRow,
+  m: Extract<PendingPayload, { kind: "transcribe-memo" }>,
+): Promise<void> {
+  const noteId = await resolveNoteId(ctx.db, m.noteId, ctx.vaultId);
+  if (!noteId) throw new DeferRowError(`Awaiting local id ${m.noteId}`);
+
+  const now = ctx.now ?? (() => Date.now());
+
+  // Settings may have been cleared between enqueue and drain. We treat that
+  // as a permanent failure (drop the row + blob) rather than retry forever.
+  if (!ctx.scribeSettings?.url) {
+    await ctx.blobStore.delete(m.blobId);
+    throw new DropRowError("scribe not configured for this vault");
+  }
+
+  // Bail out if we've been retrying too long. Drop the blob and leave a
+  // trailing footnote so the user knows transcription didn't run.
+  if (now() - row.createdAt > TRANSCRIBE_GIVE_UP_MS) {
+    await replaceMarkerIfPresent(ctx.client, noteId, m.marker, transcriptionUnavailableText());
+    await ctx.blobStore.delete(m.blobId);
+    throw new DropRowError("transcription gave up after 24h");
+  }
+
+  const stored = await ctx.blobStore.get(m.blobId);
+  if (!stored) {
+    // Blob was swept by some other path — nothing to transcribe.
+    throw new DropRowError(`missing blob ${m.blobId}`);
+  }
+
+  // Don't clobber if the user already edited the note. We check server-side
+  // because the local stub isn't authoritative (the user might have edited
+  // on another device or tab).
+  const note = await ctx.client.getNote(noteId);
+  if (!note) {
+    await ctx.blobStore.delete(m.blobId);
+    throw new VaultNotFoundError(`note ${noteId} gone`);
+  }
+  const currentContent = note.content ?? "";
+  if (!currentContent.includes(m.marker)) {
+    // User edited ahead of us — surface as needs-human via conflict-like semantics.
+    throw new SkipNoClobberError("note no longer contains transcript marker");
+  }
+
+  const transcribe = ctx.transcribeImpl ?? transcribeAudio;
+  const result = await transcribe(ctx.scribeSettings.url, {
+    audio: stored.data,
+    filename: m.filename,
+    mimeType: m.mimeType,
+    cleanup: ctx.scribeSettings.cleanup,
+    token: ctx.scribeSettings.token,
+  });
+
+  const transcriptBlock = transcriptBody(result.text.trim());
+  const nextContent = currentContent.replace(m.marker, transcriptBlock);
+  await ctx.client.updateNote(noteId, { content: nextContent });
+  await ctx.blobStore.delete(m.blobId);
+}
+
+function transcriptBody(text: string): string {
+  if (!text) return "_Transcription produced no text._";
+  return `## Transcript\n\n${text}`;
+}
+
+function transcriptionUnavailableText(): string {
+  return "_Transcription unavailable._";
+}
+
+async function replaceMarkerIfPresent(
+  client: VaultClient,
+  noteId: string,
+  marker: string,
+  replacement: string,
+): Promise<void> {
+  try {
+    const note = await client.getNote(noteId);
+    if (!note?.content?.includes(marker)) return;
+    const next = note.content.replace(marker, replacement);
+    await client.updateNote(noteId, { content: next });
+  } catch {
+    // Best-effort — if we can't reach the vault we just skip the footnote.
   }
 }
 

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -9,7 +9,8 @@ export type PendingKind =
   | "delete-note"
   | "upload-attachment"
   | "link-attachment"
-  | "delete-attachment";
+  | "delete-attachment"
+  | "transcribe-memo";
 
 export interface PendingCreateNote {
   kind: "create-note";
@@ -37,6 +38,10 @@ export interface PendingUploadAttachment {
   blobId: string;
   filename: string;
   mimeType: string;
+  // When true, the blob is kept in the store after a successful upload so
+  // downstream rows (currently just `transcribe-memo`) can still read it.
+  // Those rows are responsible for deleting the blob when they finish.
+  retain?: boolean;
 }
 
 export interface PendingLinkAttachment {
@@ -55,13 +60,29 @@ export interface PendingDeleteAttachment {
   attachmentId: string;
 }
 
+export interface PendingTranscribeMemo {
+  kind: "transcribe-memo";
+  // Server or local id — resolved against the id-map at drain time like other rows.
+  noteId: string;
+  // Blob kept alive by an upstream upload-attachment row with retain=true.
+  blobId: string;
+  filename: string;
+  mimeType: string;
+  // Substring that must still appear in the note's content for the transcript
+  // to overwrite it. If the user edited the note before the transcript
+  // arrived, the marker will be gone and we skip clobbering. Defaults to
+  // "_Transcript pending._" to match the MemoCapture stub.
+  marker: string;
+}
+
 export type PendingPayload =
   | PendingCreateNote
   | PendingUpdateNote
   | PendingDeleteNote
   | PendingUploadAttachment
   | PendingLinkAttachment
-  | PendingDeleteAttachment;
+  | PendingDeleteAttachment
+  | PendingTranscribeMemo;
 
 export type PendingStatus = "pending" | "needs-human";
 

--- a/src/providers/SyncProvider.tsx
+++ b/src/providers/SyncProvider.tsx
@@ -1,3 +1,4 @@
+import { loadScribeSettings } from "@/lib/scribe";
 import { type BlobStore, createBlobStore } from "@/lib/sync/blob-store";
 import { type LensDB, openLensDB } from "@/lib/sync/db";
 import { SyncEngine } from "@/lib/sync/engine";
@@ -99,7 +100,9 @@ export function SyncProvider({ children }: { children: ReactNode }): ReactNode {
         const c = clientRef.current;
         const v = activeVaultIdRef.current;
         if (!c || !v) return null;
-        return { client: c, vaultId: v };
+        // Re-read per tick — settings live in localStorage and may change
+        // between drains without any React-tree signal.
+        return { client: c, vaultId: v, scribeSettings: loadScribeSettings(v) };
       },
       onDrain: (outcome) => {
         if (outcome.drained > 0) {


### PR DESCRIPTION
## Summary
- Scribe client (`transcribeAudio`, `scribeHealth`) for parachute-scribe's Whisper-compatible API, with typed `ScribeError` kinds (auth / unavailable / bad-request / parse) so the sync queue can decide retry vs. drop
- Per-vault Settings page (URL, optional bearer token, cleanup toggle, connection-test button); stored in `localStorage` under `lens:scribe:<vaultId>`
- New `transcribe-memo` sync mutation: runs after `upload-attachment` drains, POSTs the retained blob to scribe, and replaces a `_Transcript pending._` stub in the note with a `## Transcript` block
- Blob-lifecycle: `upload-attachment` gets a `retain?: boolean` flag — when set, the blob survives past upload so `transcribe-memo` can use it; transcribe-memo owns cleanup on success / permanent failure
- MemoCapture now conditionally enqueues `transcribe-memo` when scribe is configured, and writes the stub marker into the note body

## Design decisions
- **Per-vault settings, not global.** Each vault may live near a specific scribe instance (different LAN, different proxy). Settings hang off the vault id.
- **24h give-up.** `TRANSCRIBE_GIVE_UP_MS = 86_400_000`. After 24h of unavailable/auth failures the row drops, the blob is deleted, and a best-effort `_Transcription unavailable._` footnote swap runs on the note.
- **No-clobber marker guard.** If the note's current content no longer contains the stub at drain time (user edited ahead of us), transcribe-memo stashes as `needs-human` instead of overwriting. User can manually re-run later.
- **Cleanup toggle scoped per-vault.** The LLM cleanup pass is a flag on scribe settings, not a per-recording decision — matches how users think about their scribe instance.
- **Missing settings at drain time = drop.** If the user removed scribe config between enqueue and drain, the row drops + the blob is deleted rather than retrying forever.
- **`DrainContext.transcribeImpl` injection.** Tests stub without mocking fetch.

## CORS caveat
parachute-scribe doesn't send CORS headers. Users who hit this need to run scribe behind a reverse proxy that shares their vault's origin. Documented inline in the Settings UI and at the top of `client.ts`.

## Out of scope
- Queue status UI (PR #6)
- On-device Whisper
- Re-transcribe-on-demand button
- Transcription diff / conflict-resolution UI

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test --run` — 287/287 green (15 scribe client tests, 7 settings-store tests, 6 Settings-UI tests, 7 transcribe-memo queue tests, 1 scribe-configured MemoCapture test)
- [x] `bun run build` clean
- [ ] Manual smoke against a live scribe instance (deferred — CORS will likely block from a browser origin; will need to either add CORS scribe-side or run behind a proxy before manual verify is possible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)