### PR TITLE
Add typed capture with voice/text tabs on /capture

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,8 +5,8 @@ import { QueryProvider } from "@/providers/QueryProvider";
 import { SyncProvider } from "@/providers/SyncProvider";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { AddVault } from "./routes/AddVault";
+import { Capture } from "./routes/Capture";
 import { Home } from "./routes/Home";
-import { MemoCapture } from "./routes/MemoCapture";
 import { NoteEditor } from "./routes/NoteEditor";
 import { NoteNew } from "./routes/NoteNew";
 import { NoteView } from "./routes/NoteView";
@@ -32,7 +32,7 @@ export function App() {
                 <Route path="/notes" element={<Notes />} />
                 <Route path="/tags" element={<Tags />} />
                 <Route path="/new" element={<NoteNew />} />
-                <Route path="/capture" element={<MemoCapture />} />
+                <Route path="/capture" element={<Capture />} />
                 <Route path="/graph" element={<VaultGraph />} />
                 <Route path="/notes/:id" element={<NoteView />} />
                 <Route path="/notes/:id/edit" element={<NoteEditor />} />

--- a/src/app/routes/Capture.test.tsx
+++ b/src/app/routes/Capture.test.tsx
@@ -1,0 +1,98 @@
+import { Capture } from "@/app/routes/Capture";
+import { useVaultStore } from "@/lib/vault/store";
+import { SyncProvider } from "@/providers/SyncProvider";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      dev: {
+        id: "dev",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "client-test",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "dev",
+  });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return (
+    <QueryClientProvider client={client}>
+      <SyncProvider>{children}</SyncProvider>
+    </QueryClientProvider>
+  );
+}
+
+function renderCapture() {
+  return render(
+    <MemoryRouter initialEntries={["/capture"]}>
+      <Routes>
+        <Route path="/capture" element={<Capture />} />
+        <Route path="/" element={<div>HomePage</div>} />
+      </Routes>
+    </MemoryRouter>,
+    { wrapper: Wrapper },
+  );
+}
+
+describe("Capture container", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("redirects to / when no active vault", () => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    renderCapture();
+    expect(screen.getByText("HomePage")).toBeInTheDocument();
+  });
+
+  it("defaults to the Text tab", async () => {
+    renderCapture();
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Text" })).toHaveAttribute("aria-selected", "true");
+    });
+    expect(screen.getByLabelText(/quick note content/i)).toBeInTheDocument();
+    // Voice UI shouldn't be present when Text is active.
+    expect(screen.queryByRole("button", { name: /start recording/i })).not.toBeInTheDocument();
+  });
+
+  it("switches to Voice when the Voice tab is clicked and persists the choice", async () => {
+    renderCapture();
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Voice" })).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: "Voice" }));
+    });
+    expect(screen.getByRole("tab", { name: "Voice" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("button", { name: /start recording/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/quick note content/i)).not.toBeInTheDocument();
+    expect(localStorage.getItem("lens:capture:mode")).toBe("voice");
+  });
+
+  it("remembers the last-used tab across renders", async () => {
+    localStorage.setItem("lens:capture:mode", "voice");
+    renderCapture();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /start recording/i })).toBeInTheDocument();
+    });
+    expect(screen.getByRole("tab", { name: "Voice" })).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/src/app/routes/Capture.tsx
+++ b/src/app/routes/Capture.tsx
@@ -1,0 +1,74 @@
+import { MemoCapture } from "@/app/routes/MemoCapture";
+import { TextCapture } from "@/app/routes/TextCapture";
+import { useVaultStore } from "@/lib/vault";
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router";
+
+// Persisted so someone who always types gets typed-mode by default; someone
+// who always records lands on voice. Defaults to text because Apple-Notes-fast
+// typing is the more common capture shape.
+const MODE_KEY = "lens:capture:mode";
+type Mode = "text" | "voice";
+
+function loadMode(): Mode {
+  try {
+    const raw = localStorage.getItem(MODE_KEY);
+    return raw === "voice" ? "voice" : "text";
+  } catch {
+    return "text";
+  }
+}
+
+export function Capture() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const [mode, setMode] = useState<Mode>(() => loadMode());
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(MODE_KEY, mode);
+    } catch {
+      // quota/private-mode — not worth surfacing
+    }
+  }, [mode]);
+
+  if (!activeVault) return <Navigate to="/" replace />;
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-8">
+      <div
+        role="tablist"
+        aria-label="Capture mode"
+        className="mb-6 inline-flex rounded-full border border-border bg-card p-1 text-sm"
+      >
+        <TabButton active={mode === "text"} onClick={() => setMode("text")} label="Text" />
+        <TabButton active={mode === "voice"} onClick={() => setMode("voice")} label="Voice" />
+      </div>
+
+      {mode === "text" ? <TextCapture /> : <MemoCapture embedded />}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`rounded-full px-4 py-1.5 transition ${
+        active ? "bg-accent text-white" : "text-fg-muted hover:text-accent"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/app/routes/MemoCapture.tsx
+++ b/src/app/routes/MemoCapture.tsx
@@ -38,7 +38,9 @@ function formatElapsed(ms: number): string {
   return `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
 }
 
-export function MemoCapture() {
+// `embedded` skips the outer container + header when rendered inside the
+// Capture tabs wrapper, which already owns that chrome.
+export function MemoCapture({ embedded = false }: { embedded?: boolean } = {}) {
   const activeVault = useVaultStore((s) => s.getActiveVault());
   const navigate = useNavigate();
   const pushToast = useToastStore((s) => s.push);
@@ -251,21 +253,8 @@ export function MemoCapture() {
 
   if (!activeVault) return <Navigate to="/" replace />;
 
-  return (
-    <div className="mx-auto max-w-2xl px-6 py-8">
-      <nav className="mb-4 text-sm text-fg-dim">
-        <Link to="/notes" className="hover:text-accent">
-          ← All notes
-        </Link>
-      </nav>
-
-      <header className="mb-8">
-        <h1 className="font-serif text-2xl text-fg">Voice memo</h1>
-        <p className="mt-1 text-sm text-fg-dim">
-          Capture a thought. Saves as a note in your vault with the audio attached.
-        </p>
-      </header>
-
+  const inner = (
+    <>
       <section className="flex flex-col items-center gap-6 rounded-xl border border-border bg-card p-10">
         {phase.kind === "idle" ? (
           <>
@@ -382,10 +371,28 @@ export function MemoCapture() {
         <p className="mb-1 font-medium text-fg-muted">Tips</p>
         <ul className="list-inside list-disc space-y-0.5">
           <li>Recording stops if you leave the tab or lock your screen.</li>
-          <li>Audio is saved in your vault; no transcription yet (coming next).</li>
+          <li>Audio is saved in your vault; transcription runs if scribe is configured.</li>
           <li>If you're offline, memos queue up and sync when you're back.</li>
         </ul>
       </aside>
+    </>
+  );
+
+  if (embedded) return inner;
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-8">
+      <nav className="mb-4 text-sm text-fg-dim">
+        <Link to="/notes" className="hover:text-accent">
+          ← All notes
+        </Link>
+      </nav>
+      <header className="mb-8">
+        <h1 className="font-serif text-2xl text-fg">Voice memo</h1>
+        <p className="mt-1 text-sm text-fg-dim">
+          Capture a thought. Saves as a note in your vault with the audio attached.
+        </p>
+      </header>
+      {inner}
     </div>
   );
 }

--- a/src/app/routes/TextCapture.test.tsx
+++ b/src/app/routes/TextCapture.test.tsx
@@ -1,0 +1,272 @@
+import { TextCapture } from "@/app/routes/TextCapture";
+import { type LensDB, openLensDB } from "@/lib/sync/db";
+import { listPending } from "@/lib/sync/queue";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault/store";
+import { SyncProvider } from "@/providers/SyncProvider";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { type ReactNode, useState } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      dev: {
+        id: "dev",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "client-test",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "dev",
+  });
+  localStorage.setItem(
+    "lens:token:dev",
+    JSON.stringify({ accessToken: "pvt_abc", scope: "full", vault: "default" }),
+  );
+}
+
+async function freshDb(): Promise<LensDB> {
+  indexedDB.deleteDatabase("parachute-lens");
+  return openLensDB();
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return (
+    <QueryClientProvider client={client}>
+      <SyncProvider>{children}</SyncProvider>
+    </QueryClientProvider>
+  );
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/capture" element={<TextCapture />} />
+        <Route path="/notes" element={<div>NotesListPage</div>} />
+      </Routes>
+    </MemoryRouter>,
+    { wrapper: Wrapper },
+  );
+}
+
+describe("TextCapture route", () => {
+  let restoreOnline: (() => void) | null = null;
+
+  beforeEach(async () => {
+    const db = await freshDb();
+    db.close();
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useToastStore.setState({ toasts: [] });
+    seedStore();
+    // Pin offline so the sync engine no-ops — we only verify enqueue.
+    const desc = Object.getOwnPropertyDescriptor(Navigator.prototype, "onLine");
+    Object.defineProperty(navigator, "onLine", { configurable: true, get: () => false });
+    restoreOnline = () => {
+      if (desc) Object.defineProperty(navigator, "onLine", desc);
+    };
+  });
+
+  afterEach(() => {
+    restoreOnline?.();
+    vi.restoreAllMocks();
+  });
+
+  async function waitForSync() {
+    // SyncProvider opens IDB asynchronously; first render has db=null.
+    await waitFor(() => {
+      expect(screen.getByLabelText(/quick note content/i)).toBeInTheDocument();
+    });
+  }
+
+  it("shows disabled Capture button when content is empty", async () => {
+    renderAt("/capture");
+    await waitForSync();
+    expect(screen.getByRole("button", { name: /^capture$/i })).toBeDisabled();
+    expect(screen.getByText(/nothing to save/i)).toBeInTheDocument();
+  });
+
+  it("Cmd+Enter enqueues a create-note and resets the editor", async () => {
+    renderAt("/capture");
+    await waitForSync();
+    const textarea = screen.getByLabelText(/quick note content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "a thought" } });
+    });
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    });
+    // Let the enqueue/toast flush.
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+    });
+    expect(textarea.value).toBe("");
+
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.mutation.kind).toBe("create-note");
+    if (rows[0]?.mutation.kind === "create-note") {
+      expect(rows[0].mutation.payload.content).toBe("a thought");
+      expect(rows[0].mutation.payload.tags).toEqual(["quick"]);
+      expect(rows[0].mutation.payload.path).toBeUndefined();
+    }
+    db.close();
+  });
+
+  it("Capture button enqueues on click", async () => {
+    renderAt("/capture");
+    await waitForSync();
+    const textarea = screen.getByLabelText(/quick note content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "another" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    });
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+    });
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    expect(rows.length).toBe(1);
+    db.close();
+  });
+
+  it("discards whitespace-only content without enqueueing", async () => {
+    renderAt("/capture");
+    await waitForSync();
+    const textarea = screen.getByLabelText(/quick note content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "   \n  " } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    });
+    // Button was disabled — click is a no-op; no toast + no row.
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    expect(rows.length).toBe(0);
+    db.close();
+  });
+
+  it("unmount with dirty content flushes the draft to the queue", async () => {
+    // Toggle-only-the-TextCapture so the SyncProvider (and its DB) stays
+    // mounted and the fire-and-forget enqueue can land before verify.
+    function Toggler() {
+      const [mounted, setMounted] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setMounted(false)}>
+            unmount-text
+          </button>
+          {mounted ? <TextCapture /> : <div>unmounted</div>}
+        </>
+      );
+    }
+    render(
+      <MemoryRouter>
+        <Toggler />
+      </MemoryRouter>,
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText(/quick note content/i)).toBeInTheDocument();
+    });
+    const textarea = screen.getByLabelText(/quick note content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "walked away mid-thought" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "unmount-text" }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("unmounted")).toBeInTheDocument();
+    });
+    await waitFor(async () => {
+      const db = await openLensDB();
+      const rows = await listPending(db, "dev");
+      db.close();
+      expect(rows.length).toBe(1);
+    });
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    if (rows[0]?.mutation.kind === "create-note") {
+      expect(rows[0].mutation.payload.content).toBe("walked away mid-thought");
+    }
+    db.close();
+  });
+
+  it("unmount with empty content does NOT enqueue", async () => {
+    function Toggler() {
+      const [mounted, setMounted] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setMounted(false)}>
+            unmount-text
+          </button>
+          {mounted ? <TextCapture /> : <div>unmounted</div>}
+        </>
+      );
+    }
+    render(
+      <MemoryRouter>
+        <Toggler />
+      </MemoryRouter>,
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText(/quick note content/i)).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "unmount-text" }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("unmounted")).toBeInTheDocument();
+    });
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    expect(rows.length).toBe(0);
+    db.close();
+  });
+
+  it("tags can be added and removed; custom tags replace the default", async () => {
+    renderAt("/capture");
+    await waitForSync();
+    const textarea = screen.getByLabelText(/quick note content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "tagged" } });
+    });
+    // Remove default "quick"
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /remove tag quick/i }));
+    });
+    // Add a custom tag
+    const tagInput = screen.getByLabelText(/add tag/i) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(tagInput, { target: { value: "idea" } });
+      fireEvent.keyDown(tagInput, { key: "Enter" });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    });
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+    });
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    if (rows[0]?.mutation.kind === "create-note") {
+      expect(rows[0].mutation.payload.tags).toEqual(["idea"]);
+    }
+    db.close();
+  });
+});

--- a/src/app/routes/TextCapture.tsx
+++ b/src/app/routes/TextCapture.tsx
@@ -1,0 +1,173 @@
+import { TagEditor, normalizeTag } from "@/components/TagEditor";
+import { enqueue, newLocalId } from "@/lib/sync";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault";
+import { useSync } from "@/providers/SyncProvider";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Apple-Notes-fast typed capture. Pure text + inline tag editor, no path or
+// metadata — the vault auto-names the note from its first line.
+//
+// Save semantics:
+//   - Cmd/Ctrl+Enter or the Capture button — enqueue create-note, reset
+//     editor in place, stay on /capture so the next thought lands fast.
+//   - On unmount (tab-switch, nav away) with non-empty content — a
+//     silent flush enqueues the draft. The queue is offline-safe, so this is
+//     the thing that makes the experience feel Apple-Notes-like: typing
+//     something and walking away never loses work.
+//   - Empty content is always discarded (no zero-content notes).
+//
+// The visible button is still there because a discoverable save affordance
+// matters more than absolute chrome-minimalism, and Cmd+Enter is invisible on
+// touch devices.
+const DEFAULT_TAGS = ["quick"];
+
+export function TextCapture() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const pushToast = useToastStore((s) => s.push);
+  const { db, engine } = useSync();
+
+  const [content, setContent] = useState("");
+  const [tags, setTags] = useState<string[]>(DEFAULT_TAGS);
+  const [tagInput, setTagInput] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Unmount-flush uses refs to avoid tearing the cleanup effect's deps. A naive
+  // `useEffect(() => cleanup, [db, content, tags, …])` would fire the flush on
+  // every keystroke; we want it exactly once — at real unmount.
+  const latest = useRef({ db, activeVaultId: activeVault?.id ?? null, content, tags });
+  latest.current = { db, activeVaultId: activeVault?.id ?? null, content, tags };
+
+  const save = useCallback(async (): Promise<boolean> => {
+    const text = content.trim();
+    if (!text) return false;
+    if (!db || !activeVault) {
+      pushToast("Sync queue not ready — try again in a moment.", "error");
+      return false;
+    }
+    const localId = newLocalId();
+    const cleanTags = tags.filter((t) => t.length > 0);
+    try {
+      await enqueue(
+        db,
+        {
+          kind: "create-note",
+          localId,
+          payload: {
+            content,
+            ...(cleanTags.length ? { tags: cleanTags } : {}),
+          },
+        },
+        { vaultId: activeVault.id },
+      );
+      void engine?.runOnce();
+      setContent("");
+      setTags(DEFAULT_TAGS);
+      setTagInput("");
+      pushToast("Captured.", "success");
+      // Keep focus so the user can dash off the next thought.
+      textareaRef.current?.focus();
+      return true;
+    } catch (e) {
+      pushToast(e instanceof Error ? `Capture failed: ${e.message}` : "Capture failed.", "error");
+      return false;
+    }
+  }, [content, tags, db, activeVault, engine, pushToast]);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void save();
+      }
+    },
+    [save],
+  );
+
+  // Focus on mount so typing is the first thing a user does — same UX as
+  // autoFocus, but satisfies the a11y lint that flags the attribute itself.
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      const { db, activeVaultId, content, tags } = latest.current;
+      const text = content.trim();
+      if (!text || !db || !activeVaultId) return;
+      const cleanTags = tags.filter((t) => t.length > 0);
+      // Fire-and-forget: IDB writes complete synchronously at the
+      // microtask level, so the enqueue usually lands even during navigation.
+      void enqueue(
+        db,
+        {
+          kind: "create-note",
+          localId: newLocalId(),
+          payload: {
+            content,
+            ...(cleanTags.length ? { tags: cleanTags } : {}),
+          },
+        },
+        { vaultId: activeVaultId },
+      );
+    };
+  }, []);
+
+  const addTag = (raw: string) => {
+    const t = normalizeTag(raw);
+    if (!t || tags.includes(t)) return;
+    setTags((prev) => [...prev, t]);
+    setTagInput("");
+  };
+  const removeTag = (name: string) => {
+    setTags((prev) => prev.filter((x) => x !== name));
+  };
+
+  const isDirty = content.trim().length > 0;
+
+  return (
+    <section className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
+      <header>
+        <h2 className="font-serif text-xl text-fg">Quick note</h2>
+        <p className="mt-1 text-xs text-fg-dim">
+          Start typing. <kbd className="rounded bg-bg/60 px-1">⌘</kbd>
+          <kbd className="rounded bg-bg/60 px-1">↵</kbd> to capture and keep going. Leaves without
+          ceremony if you walk away.
+        </p>
+      </header>
+
+      <textarea
+        ref={textareaRef}
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="What are you thinking?"
+        aria-label="Quick note content"
+        rows={10}
+        className="min-h-[40vh] w-full resize-y rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-fg-dim focus:border-accent focus:outline-none"
+      />
+
+      <TagEditor
+        tags={tags}
+        input={tagInput}
+        onInputChange={setTagInput}
+        onAdd={addTag}
+        onRemove={removeTag}
+      />
+
+      <div className="flex items-center gap-3 pt-2">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={!isDirty}
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-40"
+        >
+          Capture
+        </button>
+        <span className="text-xs text-fg-dim">
+          {isDirty ? "Draft — will save on capture or when you leave." : "Nothing to save yet."}
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,7 +42,7 @@ export function Header() {
                 Graph
               </Link>
               <Link to="/capture" className="text-sm text-fg-muted hover:text-accent">
-                + Memo
+                + Capture
               </Link>
               <label htmlFor="vault-switcher" className="sr-only">
                 Active vault


### PR DESCRIPTION
## Summary
- `/capture` now hosts a small tabbed container (📝 Text / 🎙️ Voice) instead of jumping straight into the recorder; last-used tab is persisted in `localStorage` under `lens:capture:mode`
- New `TextCapture` component — lightweight textarea, inline tag editor (defaulted to `quick`), no path, no metadata, no attachments
- Cmd/Ctrl+Enter or the **Capture** button enqueues a `create-note`, resets the editor, and stays on `/capture` so the next thought lands immediately
- Unmount-flush: if the editor has non-empty content when `TextCapture` unmounts (tab switch, nav away), a silent `create-note` enqueue fires — queue is offline-safe, so walking away mid-thought never loses work
- Empty / whitespace-only drafts are always discarded
- Header link renamed `+ Memo` → `+ Capture`; existing MemoCapture is embedded as the Voice pane (outer chrome skipped via an `embedded` prop)

## Design decisions
- **One `/capture` route with tabs, not separate sub-routes.** Tabs keep mode as ephemeral UI state, the URL stays bookmarkable, and the user's last-used mode becomes the default — matches team-lead's lean.
- **Hybrid save: explicit button + Cmd+Enter + unmount-flush.** Pure auto-save-on-debounce would commit mid-thought pauses. Pure explicit save forces ceremony. The hybrid gives Apple-Notes-fast ergonomics — typing then walking away saves, typing then Cmd+Enter saves-and-resets — without creating notes mid-sentence.
- **Stay on `/capture` after save.** The editor clears and refocuses so the next thought lands immediately; no navigation surprise. (Voice tab still navigates to `/notes` after save since listening-back is a natural next step.)
- **Default tag `quick`** so the note shows up somewhere predictable. User can remove it or add custom tags.
- **Relationship to `/new`.** `/new` is the full editor: required path, metadata, CodeMirror, attachments, preview. `/capture` is deliberately lighter: no path (vault auto-generates), no metadata, no attachments, plain textarea. Different jobs; documented inline.
- **No `beforeunload` handler.** React's unmount cleanup covers in-app navigation. Full-tab close is rare enough to not warrant the always-on warning dialog — the queue's IDB writes typically land before the browser tears down.

## Out of scope (as specified)
- Rich formatting toolbars
- Attachments in quick-capture (voice memo covers audio)
- Image paste

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test --run` — 298/298 (7 TextCapture tests: empty disabled, Cmd+Enter, button click, whitespace-discard, unmount-flush-dirty, unmount-no-empty, tag add/remove; 4 Capture-container tests: redirect, default-text, switch-to-voice-persists, remembers-last-mode)
- [x] `bun run build` clean
- [ ] Manual smoke (quick typing, Cmd+Enter, tab-switch flush, offline enqueue) — dev-server verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)