### PR TITLE
Add offline + sync status UI: header pill, popover panel, reconnect flow

### DIFF
--- a/src/app/routes/NoteView.tsx
+++ b/src/app/routes/NoteView.tsx
@@ -1,6 +1,7 @@
 import { DeleteNoteButton } from "@/components/DeleteNoteButton";
 import { MarkdownView, buildWikilinkResolver } from "@/components/MarkdownView";
 import { NeighborhoodGraph } from "@/components/NeighborhoodGraph";
+import { TranscriptionStatus } from "@/components/TranscriptionStatus";
 import { relativeTime } from "@/lib/time";
 import { useActiveVaultClient, useNote, useVaultStore } from "@/lib/vault";
 import { VaultAuthError } from "@/lib/vault/client";
@@ -80,6 +81,8 @@ function NoteBody({ note }: { note: Note }) {
             <DeleteNoteButton note={note} />
           </div>
         </header>
+
+        <TranscriptionStatus noteId={note.id} content={note.content ?? ""} />
 
         <MarkdownView content={note.content ?? ""} resolve={resolver} />
 

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -1,7 +1,8 @@
+import { isStandalone } from "@/lib/pwa";
 import { type ScribeSettings, scribeHealth, useScribeSettings } from "@/lib/scribe";
 import { useToastStore } from "@/lib/toast/store";
 import { useVaultStore } from "@/lib/vault";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, Navigate } from "react-router";
 
 // Per-vault settings UI. v0.2 only surfaces scribe because it's the first
@@ -26,7 +27,28 @@ export function Settings() {
       </header>
 
       <ScribeSettingsSection vaultId={activeVault.id} />
+      <InstallStateSection />
     </div>
+  );
+}
+
+function InstallStateSection() {
+  // matchMedia is only reliable at render time on some browsers, so sample
+  // once on mount.
+  const [installed, setInstalled] = useState(false);
+  useEffect(() => {
+    setInstalled(isStandalone());
+  }, []);
+  if (!installed) return null;
+  return (
+    <section className="mt-6 rounded-md border border-border bg-card p-4 text-sm">
+      <p className="text-fg-muted">
+        <span className="mr-2 inline-block rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-300">
+          Installed
+        </span>
+        Parachute Lens is running as an installed app on this device.
+      </p>
+    </section>
   );
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { InstallPrompt } from "@/components/InstallPrompt";
+import { SyncStatusIndicator } from "@/components/SyncStatusIndicator";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { type VaultRecord, useVaultStore } from "@/lib/vault";
 import { Link, useNavigate } from "react-router";
@@ -69,6 +70,7 @@ export function Header() {
               <Link to="/settings" className="text-sm text-fg-muted hover:text-accent">
                 Settings
               </Link>
+              <SyncStatusIndicator />
               <InstallPrompt />
               <ThemeToggle />
             </>

--- a/src/components/SyncStatusIndicator.test.tsx
+++ b/src/components/SyncStatusIndicator.test.tsx
@@ -1,0 +1,240 @@
+import { SyncStatusIndicator } from "@/components/SyncStatusIndicator";
+import type { QueueStatus } from "@/lib/sync";
+import { useVaultStore } from "@/lib/vault";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockStatus = vi.fn<() => QueueStatus>(() => ({
+  rows: [],
+  byKind: {},
+  total: 0,
+  pendingCount: 0,
+  needsHumanCount: 0,
+  authHalt: null,
+}));
+const mockSync = vi.fn<
+  () => {
+    db: null;
+    blobStore: null;
+    engine: null;
+    isOnline: boolean;
+    isDraining: boolean;
+    lastSyncedAt: number | null;
+  }
+>(() => ({
+  db: null,
+  blobStore: null,
+  engine: null,
+  isOnline: true,
+  isDraining: false,
+  lastSyncedAt: null,
+}));
+
+vi.mock("@/providers/SyncProvider", () => ({
+  useSync: () => mockSync(),
+}));
+vi.mock("@/lib/sync", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sync")>("@/lib/sync");
+  return {
+    ...actual,
+    useQueueStatus: () => mockStatus(),
+  };
+});
+
+function seedVault() {
+  useVaultStore.setState({
+    vaults: {
+      v: {
+        id: "v",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v",
+  });
+}
+
+function renderIndicator() {
+  return render(
+    <MemoryRouter>
+      <SyncStatusIndicator />
+    </MemoryRouter>,
+  );
+}
+
+describe("SyncStatusIndicator tone", () => {
+  beforeEach(() => {
+    seedVault();
+    mockStatus.mockReset();
+    mockSync.mockReset();
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: {},
+      total: 0,
+      pendingCount: 0,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    mockSync.mockReturnValue({
+      db: null,
+      blobStore: null,
+      engine: null,
+      isOnline: true,
+      isDraining: false,
+      lastSyncedAt: null,
+    });
+  });
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+
+  it("reads 'Online' when connected, not draining, no halt", () => {
+    renderIndicator();
+    expect(screen.getByRole("button", { name: /sync status: online/i })).toBeInTheDocument();
+  });
+
+  it("reads 'Offline' when navigator is offline", () => {
+    mockSync.mockReturnValue({
+      db: null,
+      blobStore: null,
+      engine: null,
+      isOnline: false,
+      isDraining: false,
+      lastSyncedAt: null,
+    });
+    renderIndicator();
+    expect(screen.getByRole("button", { name: /sync status: offline/i })).toBeInTheDocument();
+  });
+
+  it("reads 'Syncing…' while draining", () => {
+    mockSync.mockReturnValue({
+      db: null,
+      blobStore: null,
+      engine: null,
+      isOnline: true,
+      isDraining: true,
+      lastSyncedAt: null,
+    });
+    renderIndicator();
+    expect(screen.getByRole("button", { name: /sync status: syncing/i })).toBeInTheDocument();
+  });
+
+  it("reads 'Reconnect' when auth-halt is set (highest priority)", () => {
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: {},
+      total: 0,
+      pendingCount: 0,
+      needsHumanCount: 0,
+      authHalt: { vaultId: "v", at: 1, message: "expired" },
+    });
+    mockSync.mockReturnValue({
+      db: null,
+      blobStore: null,
+      engine: null,
+      isOnline: false,
+      isDraining: true,
+      lastSyncedAt: null,
+    });
+    renderIndicator();
+    expect(screen.getByRole("button", { name: /sync status: reconnect/i })).toBeInTheDocument();
+  });
+});
+
+describe("SyncStatusIndicator pending badge", () => {
+  beforeEach(() => {
+    seedVault();
+    mockSync.mockReturnValue({
+      db: null,
+      blobStore: null,
+      engine: null,
+      isOnline: true,
+      isDraining: false,
+      lastSyncedAt: null,
+    });
+  });
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+
+  it("hides the badge when total = 0", () => {
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: {},
+      total: 0,
+      pendingCount: 0,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    renderIndicator();
+    expect(screen.queryByLabelText(/pending/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the pending count when > 0", () => {
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: { "delete-note": 3 },
+      total: 3,
+      pendingCount: 3,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    renderIndicator();
+    expect(screen.getByLabelText("3 pending")).toHaveTextContent("3");
+  });
+});
+
+describe("SyncStatusIndicator open/close", () => {
+  beforeEach(() => {
+    seedVault();
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: {},
+      total: 0,
+      pendingCount: 0,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    mockSync.mockReturnValue({
+      db: null,
+      blobStore: null,
+      engine: null,
+      isOnline: true,
+      isDraining: false,
+      lastSyncedAt: null,
+    });
+  });
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+
+  it("clicking the button opens the panel", () => {
+    renderIndicator();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /sync status/i }));
+    expect(screen.getByRole("dialog", { name: /sync status details/i })).toBeInTheDocument();
+  });
+
+  it("clicking outside closes the panel", () => {
+    render(
+      <MemoryRouter>
+        <div>
+          <button type="button">outside</button>
+          <SyncStatusIndicator />
+        </div>
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /sync status/i }));
+    expect(screen.getByRole("dialog", { name: /sync status details/i })).toBeInTheDocument();
+    act(() => {
+      fireEvent.mouseDown(screen.getByRole("button", { name: "outside" }));
+    });
+    expect(screen.queryByRole("dialog", { name: /sync status details/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/SyncStatusIndicator.tsx
+++ b/src/components/SyncStatusIndicator.tsx
@@ -1,0 +1,110 @@
+import { SyncStatusPanel } from "@/components/SyncStatusPanel";
+import { useQueueStatus } from "@/lib/sync";
+import { useVaultStore } from "@/lib/vault";
+import { useSync } from "@/providers/SyncProvider";
+import { useEffect, useRef, useState } from "react";
+
+type Tone = "online" | "offline" | "syncing" | "halted";
+
+// Resolves the most important thing to communicate at a glance. Order matters:
+// auth-halt beats offline beats syncing beats online, because the user's next
+// action depends on the most severe state.
+function resolveTone(opts: {
+  isOnline: boolean;
+  isDraining: boolean;
+  authHalt: boolean;
+}): Tone {
+  if (opts.authHalt) return "halted";
+  if (!opts.isOnline) return "offline";
+  if (opts.isDraining) return "syncing";
+  return "online";
+}
+
+export function SyncStatusIndicator() {
+  const { db, isOnline, isDraining } = useSync();
+  const activeVaultId = useVaultStore((s) => s.activeVaultId);
+  const status = useQueueStatus(db, activeVaultId);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // Close the panel when the user clicks anywhere outside. Bound at the
+  // document level so it catches clicks on header siblings too.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!rootRef.current) return;
+      if (rootRef.current.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const tone = resolveTone({
+    isOnline,
+    isDraining,
+    authHalt: status.authHalt !== null,
+  });
+
+  const label = describeTone(tone);
+  const badge = status.total > 0 ? status.total : null;
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-label={`Sync status: ${label}${badge ? `, ${badge} pending` : ""}`}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1.5 text-sm text-fg-muted hover:text-accent"
+      >
+        <Dot tone={tone} />
+        <span className="hidden text-xs sm:inline">{label}</span>
+        {badge !== null ? (
+          <span
+            aria-label={`${badge} pending`}
+            className="rounded-full bg-accent/20 px-1.5 text-[10px] font-medium tabular-nums text-accent"
+          >
+            {badge}
+          </span>
+        ) : null}
+      </button>
+
+      {open ? (
+        // biome-ignore lint/a11y/useSemanticElements: a native <dialog> requires imperative show()/showModal() calls; this is a popover, not a modal.
+        <div
+          role="dialog"
+          aria-label="Sync status details"
+          className="absolute right-0 z-30 mt-2 w-80 rounded-md border border-border bg-card p-4 text-sm shadow-lg"
+        >
+          <SyncStatusPanel onDismiss={() => setOpen(false)} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function describeTone(tone: Tone): string {
+  switch (tone) {
+    case "online":
+      return "Online";
+    case "offline":
+      return "Offline";
+    case "syncing":
+      return "Syncing…";
+    case "halted":
+      return "Reconnect";
+  }
+}
+
+function Dot({ tone }: { tone: Tone }) {
+  const color =
+    tone === "online"
+      ? "bg-emerald-400"
+      : tone === "offline"
+        ? "bg-amber-400"
+        : tone === "syncing"
+          ? "bg-sky-400 animate-pulse"
+          : "bg-red-500";
+  return <span aria-hidden className={`inline-block h-2 w-2 rounded-full ${color}`} />;
+}

--- a/src/components/SyncStatusPanel.test.tsx
+++ b/src/components/SyncStatusPanel.test.tsx
@@ -1,0 +1,355 @@
+import { SyncStatusPanel } from "@/components/SyncStatusPanel";
+import type { PendingRow, QueueStatus, QuotaReport } from "@/lib/sync";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks -----------------------------------------------------------------
+
+const mockStatus = vi.fn<() => QueueStatus>(() => ({
+  rows: [],
+  byKind: {},
+  total: 0,
+  pendingCount: 0,
+  needsHumanCount: 0,
+  authHalt: null,
+}));
+const mockSync = vi.fn(() => ({
+  db: {} as unknown as ReturnType<typeof Object>,
+  blobStore: null,
+  engine: null,
+  isOnline: true,
+  isDraining: false,
+  lastSyncedAt: null as number | null,
+}));
+const retryRowMock = vi.fn(async (_db: unknown, _seq: number) => {});
+const discardRowMock = vi.fn(async (_db: unknown, _seq: number) => {});
+const clearMock = vi.fn(async (_db: unknown, _vaultId: string) => 0);
+const estimateMock = vi.fn<() => Promise<QuotaReport>>(async () => ({
+  supported: false,
+  persisted: false,
+  usage: null,
+  quota: null,
+}));
+
+vi.mock("@/providers/SyncProvider", () => ({
+  useSync: () => mockSync(),
+}));
+vi.mock("@/lib/sync", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sync")>("@/lib/sync");
+  return {
+    ...actual,
+    useQueueStatus: () => mockStatus(),
+    retryRow: (...args: Parameters<typeof retryRowMock>) => retryRowMock(...args),
+    discardRow: (...args: Parameters<typeof discardRowMock>) => discardRowMock(...args),
+    clearPendingForVault: (...args: Parameters<typeof clearMock>) => clearMock(...args),
+    estimate: () => estimateMock(),
+  };
+});
+
+// --- Helpers ---------------------------------------------------------------
+
+function seedVault() {
+  useVaultStore.setState({
+    vaults: {
+      v: {
+        id: "v",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v",
+  });
+}
+
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <SyncStatusPanel />
+    </MemoryRouter>,
+  );
+}
+
+function needsHumanRow(seq: number, targetId: string): PendingRow {
+  return {
+    seq,
+    id: `row-${seq}`,
+    vaultId: "v",
+    mutation: { kind: "delete-note", targetId },
+    createdAt: Date.now(),
+    attemptCount: 3,
+    nextAttemptAt: 0,
+    lastError: "conflict",
+    status: "needs-human",
+  };
+}
+
+// --- Tests -----------------------------------------------------------------
+
+describe("SyncStatusPanel headline", () => {
+  beforeEach(() => {
+    seedVault();
+    useToastStore.setState({ toasts: [] });
+    retryRowMock.mockReset();
+    discardRowMock.mockReset();
+    clearMock.mockReset();
+    estimateMock.mockReset();
+    estimateMock.mockResolvedValue({ supported: false, persisted: false, usage: null, quota: null });
+    mockStatus.mockReset();
+    mockSync.mockReset();
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: {},
+      total: 0,
+      pendingCount: 0,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    mockSync.mockReturnValue({
+      db: {},
+      blobStore: null,
+      engine: null,
+      isOnline: true,
+      isDraining: false,
+      lastSyncedAt: null,
+    });
+  });
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+
+  it("renders 'All caught up' when online, not draining, queue empty", () => {
+    renderPanel();
+    expect(screen.getByRole("heading", { name: /all caught up/i })).toBeInTheDocument();
+  });
+
+  it("renders 'Offline — changes queued' when offline", () => {
+    mockSync.mockReturnValue({
+      db: {},
+      blobStore: null,
+      engine: null,
+      isOnline: false,
+      isDraining: false,
+      lastSyncedAt: null,
+    });
+    renderPanel();
+    expect(screen.getByRole("heading", { name: /offline/i })).toBeInTheDocument();
+  });
+
+  it("renders a Reconnect link when authHalt is present", () => {
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: {},
+      total: 0,
+      pendingCount: 0,
+      needsHumanCount: 0,
+      authHalt: { vaultId: "v", at: 1, message: "session expired" },
+    });
+    renderPanel();
+    expect(screen.getByRole("heading", { name: /reconnect needed/i })).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /reconnect to resume sync/i });
+    expect(link).toHaveAttribute("href", "/add");
+  });
+
+  it("renders the 'Sync pending' headline with queue breakdown when rows exist", () => {
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: { "create-note": 2, "delete-note": 1 },
+      total: 3,
+      pendingCount: 3,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    renderPanel();
+    expect(screen.getByRole("heading", { name: /sync pending/i })).toBeInTheDocument();
+    expect(screen.getByText(/new notes/i)).toBeInTheDocument();
+    expect(screen.getByText(/deletions/i)).toBeInTheDocument();
+  });
+});
+
+describe("SyncStatusPanel needs-human actions", () => {
+  beforeEach(() => {
+    seedVault();
+    useToastStore.setState({ toasts: [] });
+    retryRowMock.mockReset();
+    discardRowMock.mockReset();
+    mockStatus.mockReset();
+    mockSync.mockReturnValue({
+      db: {},
+      blobStore: null,
+      engine: null,
+      isOnline: true,
+      isDraining: false,
+      lastSyncedAt: null,
+    });
+    estimateMock.mockResolvedValue({ supported: false, persisted: false, usage: null, quota: null });
+  });
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    vi.restoreAllMocks();
+  });
+
+  it("Retry calls retryRow with the row's seq and toasts", async () => {
+    const row = needsHumanRow(7, "target-1");
+    mockStatus.mockReturnValue({
+      rows: [row],
+      byKind: { "delete-note": 1 },
+      total: 1,
+      pendingCount: 0,
+      needsHumanCount: 1,
+      authHalt: null,
+    });
+
+    renderPanel();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    });
+
+    expect(retryRowMock).toHaveBeenCalledWith({}, 7);
+    expect(useToastStore.getState().toasts.some((t) => /retrying/i.test(t.message))).toBe(true);
+  });
+
+  it("Discard confirms then calls discardRow", async () => {
+    const row = needsHumanRow(9, "target-2");
+    mockStatus.mockReturnValue({
+      rows: [row],
+      byKind: { "delete-note": 1 },
+      total: 1,
+      pendingCount: 0,
+      needsHumanCount: 1,
+      authHalt: null,
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderPanel();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /discard/i }));
+    });
+
+    expect(discardRowMock).toHaveBeenCalledWith({}, 9);
+  });
+
+  it("Discard does nothing when the user cancels the confirm", async () => {
+    const row = needsHumanRow(11, "target-3");
+    mockStatus.mockReturnValue({
+      rows: [row],
+      byKind: { "delete-note": 1 },
+      total: 1,
+      pendingCount: 0,
+      needsHumanCount: 1,
+      authHalt: null,
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    renderPanel();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /discard/i }));
+    });
+
+    expect(discardRowMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("SyncStatusPanel Clear-all", () => {
+  beforeEach(() => {
+    seedVault();
+    useToastStore.setState({ toasts: [] });
+    clearMock.mockReset();
+    estimateMock.mockResolvedValue({ supported: false, persisted: false, usage: null, quota: null });
+    mockSync.mockReturnValue({
+      db: {},
+      blobStore: null,
+      engine: null,
+      isOnline: true,
+      isDraining: false,
+      lastSyncedAt: null,
+    });
+  });
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    vi.restoreAllMocks();
+  });
+
+  it("wipes all pending and toasts the count", async () => {
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: { "delete-note": 2 },
+      total: 2,
+      pendingCount: 2,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    clearMock.mockResolvedValue(2);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderPanel();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /clear all pending/i }));
+    });
+
+    expect(clearMock).toHaveBeenCalledWith({}, "v");
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.some((t) => /cleared 2/i.test(t.message))).toBe(true);
+    });
+  });
+});
+
+describe("SyncStatusPanel storage bar", () => {
+  beforeEach(() => {
+    seedVault();
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: {},
+      total: 0,
+      pendingCount: 0,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    mockSync.mockReturnValue({
+      db: {},
+      blobStore: null,
+      engine: null,
+      isOnline: true,
+      isDraining: false,
+      lastSyncedAt: null,
+    });
+  });
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+
+  it("does not show a warning below the 80% threshold", async () => {
+    // 40% full
+    estimateMock.mockResolvedValue({
+      supported: true,
+      persisted: true,
+      usage: 400,
+      quota: 1000,
+    });
+    renderPanel();
+    await waitFor(() => {
+      expect(screen.getByText(/storage/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/nearly full/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a warning at or above the 80% threshold", async () => {
+    estimateMock.mockResolvedValue({
+      supported: true,
+      persisted: true,
+      usage: 900,
+      quota: 1000,
+    });
+    renderPanel();
+    await waitFor(() => {
+      expect(screen.getByText(/nearly full/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/SyncStatusPanel.test.tsx
+++ b/src/components/SyncStatusPanel.test.tsx
@@ -101,7 +101,12 @@ describe("SyncStatusPanel headline", () => {
     discardRowMock.mockReset();
     clearMock.mockReset();
     estimateMock.mockReset();
-    estimateMock.mockResolvedValue({ supported: false, persisted: false, usage: null, quota: null });
+    estimateMock.mockResolvedValue({
+      supported: false,
+      persisted: false,
+      usage: null,
+      quota: null,
+    });
     mockStatus.mockReset();
     mockSync.mockReset();
     mockStatus.mockReturnValue({
@@ -189,7 +194,12 @@ describe("SyncStatusPanel needs-human actions", () => {
       isDraining: false,
       lastSyncedAt: null,
     });
-    estimateMock.mockResolvedValue({ supported: false, persisted: false, usage: null, quota: null });
+    estimateMock.mockResolvedValue({
+      supported: false,
+      persisted: false,
+      usage: null,
+      quota: null,
+    });
   });
   afterEach(() => {
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
@@ -262,7 +272,12 @@ describe("SyncStatusPanel Clear-all", () => {
     seedVault();
     useToastStore.setState({ toasts: [] });
     clearMock.mockReset();
-    estimateMock.mockResolvedValue({ supported: false, persisted: false, usage: null, quota: null });
+    estimateMock.mockResolvedValue({
+      supported: false,
+      persisted: false,
+      usage: null,
+      quota: null,
+    });
     mockSync.mockReturnValue({
       db: {},
       blobStore: null,

--- a/src/components/SyncStatusPanel.tsx
+++ b/src/components/SyncStatusPanel.tsx
@@ -1,0 +1,251 @@
+import {
+  type PendingPayload,
+  type PendingRow,
+  clearPendingForVault,
+  discardRow,
+  estimate,
+  retryRow,
+  useQueueStatus,
+} from "@/lib/sync";
+import { relativeTime } from "@/lib/time";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault";
+import { useSync } from "@/providers/SyncProvider";
+import { useEffect, useState } from "react";
+import { Link } from "react-router";
+
+// Detail popover opened from the header indicator. Everything here runs off a
+// live polling hook (useQueueStatus) so the user sees the queue change
+// without manually refreshing. Destructive actions (discard, clear-all) gate
+// on a confirm().
+
+const KIND_LABELS: Record<string, string> = {
+  "create-note": "new notes",
+  "update-note": "note edits",
+  "delete-note": "deletions",
+  "upload-attachment": "uploads",
+  "link-attachment": "attachment links",
+  "delete-attachment": "attachment removals",
+  "transcribe-memo": "transcriptions",
+};
+
+// Trip point for the storage warning. At 80% of quota we surface a gentle
+// nudge — iOS Safari caps OPFS/IDB at roughly 50 MB, so running out while
+// offline is a real hazard worth flagging.
+const STORAGE_WARN_THRESHOLD = 0.8;
+
+export function SyncStatusPanel({ onDismiss }: { onDismiss?: () => void }) {
+  const { db, isOnline, isDraining, lastSyncedAt } = useSync();
+  const activeVaultId = useVaultStore((s) => s.activeVaultId);
+  const pushToast = useToastStore((s) => s.push);
+  const status = useQueueStatus(db, activeVaultId);
+
+  const [quota, setQuota] = useState<{ usage: number; quota: number } | null>(null);
+  // Live-tick the "Last synced" relative time without jamming the main render.
+  const [, forceTick] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => forceTick((n) => n + 1), 15_000);
+    return () => clearInterval(t);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void estimate().then((r) => {
+      if (cancelled) return;
+      if (r.supported && typeof r.usage === "number" && typeof r.quota === "number") {
+        setQuota({ usage: r.usage, quota: r.quota });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const stateHeadline = status.authHalt
+    ? "Reconnect needed"
+    : !isOnline
+      ? "Offline — changes queued"
+      : isDraining
+        ? "Syncing…"
+        : status.total > 0
+          ? "Sync pending"
+          : "All caught up";
+
+  const handleRetry = async (seq: number) => {
+    if (!db) return;
+    await retryRow(db, seq);
+    pushToast("Retrying…", "success");
+  };
+  const handleDiscard = async (seq: number, row: PendingRow) => {
+    if (!db) return;
+    if (!confirm(`Discard this ${describeMutation(row.mutation)}? It cannot be recovered.`)) return;
+    await discardRow(db, seq);
+    pushToast("Row discarded.", "success");
+  };
+  const handleClearAll = async () => {
+    if (!db || !activeVaultId) return;
+    if (!confirm(`Clear every pending row for this vault (${status.total} total)? Destructive.`))
+      return;
+    const n = await clearPendingForVault(db, activeVaultId);
+    pushToast(`Cleared ${n} pending row${n === 1 ? "" : "s"}.`, "success");
+  };
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-baseline justify-between">
+        <h3 className="font-serif text-base text-fg">{stateHeadline}</h3>
+        {onDismiss ? (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Close sync status"
+            className="text-xs text-fg-dim hover:text-accent"
+          >
+            ×
+          </button>
+        ) : null}
+      </header>
+
+      {status.authHalt ? (
+        <div className="rounded-md border border-red-500/30 bg-red-500/5 p-3 text-xs text-red-300">
+          <p className="mb-2">{status.authHalt.message || "Vault rejected the current session."}</p>
+          <Link
+            to="/add"
+            onClick={onDismiss}
+            className="inline-block rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover"
+          >
+            Reconnect to resume sync
+          </Link>
+        </div>
+      ) : null}
+
+      {status.total === 0 ? (
+        <p className="text-xs text-fg-dim">Nothing pending in this vault.</p>
+      ) : (
+        <section>
+          <h4 className="mb-1 text-xs uppercase tracking-wider text-fg-dim">Queue</h4>
+          <ul className="space-y-0.5 text-xs">
+            {Object.entries(status.byKind).map(([kind, count]) => (
+              <li key={kind} className="flex justify-between">
+                <span className="text-fg-muted">{KIND_LABELS[kind] ?? kind}</span>
+                <span className="tabular-nums text-fg-dim">{count}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {status.needsHumanCount > 0 ? (
+        <section>
+          <h4 className="mb-1 text-xs uppercase tracking-wider text-fg-dim">Needs your help</h4>
+          <ul className="space-y-1.5">
+            {status.rows
+              .filter((r) => r.status === "needs-human")
+              .map((row) => (
+                <li
+                  key={row.seq}
+                  className="rounded border border-amber-500/30 bg-amber-500/5 p-2 text-xs"
+                >
+                  <p className="font-medium text-amber-200">{describeMutation(row.mutation)}</p>
+                  {row.lastError ? (
+                    <p className="mt-0.5 break-words text-amber-100/70">{row.lastError}</p>
+                  ) : null}
+                  <div className="mt-1 flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleRetry(row.seq)}
+                      className="text-accent hover:underline"
+                    >
+                      Retry
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDiscard(row.seq, row)}
+                      className="text-red-300 hover:underline"
+                    >
+                      Discard
+                    </button>
+                  </div>
+                </li>
+              ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className="text-xs text-fg-dim">
+        <p>
+          Last synced:{" "}
+          <span className="text-fg-muted">
+            {lastSyncedAt ? relativeTime(new Date(lastSyncedAt).toISOString()) : "never"}
+          </span>
+        </p>
+      </section>
+
+      {quota ? <StorageBar usage={quota.usage} quota={quota.quota} /> : null}
+
+      {status.total > 0 ? (
+        <div className="flex justify-end border-t border-border pt-3">
+          <button
+            type="button"
+            onClick={handleClearAll}
+            className="text-xs text-red-400 hover:underline"
+          >
+            Clear all pending
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function describeMutation(m: PendingPayload): string {
+  switch (m.kind) {
+    case "create-note":
+      return `Create note (${m.payload.path ?? "untitled"})`;
+    case "update-note":
+      return `Update note ${m.targetId}`;
+    case "delete-note":
+      return `Delete note ${m.targetId}`;
+    case "upload-attachment":
+      return `Upload ${m.filename}`;
+    case "link-attachment":
+      return `Link attachment to ${m.noteId}`;
+    case "delete-attachment":
+      return `Remove attachment from ${m.noteId}`;
+    case "transcribe-memo":
+      return `Transcribe ${m.filename}`;
+  }
+}
+
+function StorageBar({ usage, quota }: { usage: number; quota: number }) {
+  const pct = quota > 0 ? usage / quota : 0;
+  const warn = pct >= STORAGE_WARN_THRESHOLD;
+  return (
+    <section className="text-xs">
+      <div className="mb-1 flex justify-between text-fg-dim">
+        <span>Storage</span>
+        <span className={warn ? "text-amber-300" : "text-fg-muted"}>
+          {formatBytes(usage)} / {formatBytes(quota)}
+        </span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-border/40">
+        <div
+          className={`h-full ${warn ? "bg-amber-400" : "bg-accent"}`}
+          style={{ width: `${Math.min(100, Math.round(pct * 100))}%` }}
+        />
+      </div>
+      {warn ? (
+        <p className="mt-1 text-amber-300">
+          Nearly full. Sync what you can and consider clearing stuck rows.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}

--- a/src/components/TranscriptionStatus.test.tsx
+++ b/src/components/TranscriptionStatus.test.tsx
@@ -1,0 +1,118 @@
+import { TranscriptionStatus } from "@/components/TranscriptionStatus";
+import type { PendingRow, QueueStatus } from "@/lib/sync";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockStatus = vi.fn<() => QueueStatus>(() => ({
+  rows: [],
+  byKind: {},
+  total: 0,
+  pendingCount: 0,
+  needsHumanCount: 0,
+  authHalt: null,
+}));
+vi.mock("@/providers/SyncProvider", () => ({
+  useSync: () => ({
+    db: {},
+    blobStore: null,
+    engine: null,
+    isOnline: true,
+    isDraining: false,
+    lastSyncedAt: null,
+  }),
+}));
+vi.mock("@/lib/vault", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/vault")>("@/lib/vault");
+  return {
+    ...actual,
+    useVaultStore: Object.assign(
+      (selector: (s: unknown) => unknown) => selector({ activeVaultId: "v" }),
+      {
+        setState: () => {},
+      },
+    ),
+  };
+});
+vi.mock("@/lib/sync", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sync")>("@/lib/sync");
+  return {
+    ...actual,
+    useQueueStatus: () => mockStatus(),
+  };
+});
+
+function transcribeRow(noteId: string): PendingRow {
+  return {
+    seq: 1,
+    id: "row-1",
+    vaultId: "v",
+    mutation: {
+      kind: "transcribe-memo",
+      noteId,
+      blobId: "blob-1",
+      filename: "memo.wav",
+      mimeType: "audio/wav",
+      marker: "_Transcript pending._",
+    },
+    createdAt: Date.now(),
+    attemptCount: 0,
+    nextAttemptAt: 0,
+    status: "pending",
+  };
+}
+
+describe("TranscriptionStatus", () => {
+  beforeEach(() => {
+    mockStatus.mockReset();
+    mockStatus.mockReturnValue({
+      rows: [],
+      byKind: {},
+      total: 0,
+      pendingCount: 0,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders nothing when no transcribe row and no unavailable marker", () => {
+    const { container } = render(<TranscriptionStatus noteId="n1" content="plain note body" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows 'Transcribing…' while a transcribe-memo row is queued for this note", () => {
+    mockStatus.mockReturnValue({
+      rows: [transcribeRow("n1")],
+      byKind: { "transcribe-memo": 1 },
+      total: 1,
+      pendingCount: 1,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    render(<TranscriptionStatus noteId="n1" content="_Transcript pending._" />);
+    expect(screen.getByText(/transcribing/i)).toBeInTheDocument();
+  });
+
+  it("ignores transcribe rows that belong to a different note", () => {
+    mockStatus.mockReturnValue({
+      rows: [transcribeRow("other")],
+      byKind: { "transcribe-memo": 1 },
+      total: 1,
+      pendingCount: 1,
+      needsHumanCount: 0,
+      authHalt: null,
+    });
+    const { container } = render(<TranscriptionStatus noteId="n1" content="body without marker" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows unavailable chip when content carries the marker and no row is queued", () => {
+    render(
+      <TranscriptionStatus
+        noteId="n1"
+        content="Some preamble.\n\n_Transcription unavailable._\n\nrest"
+      />,
+    );
+    expect(screen.getByText(/transcription unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/TranscriptionStatus.tsx
+++ b/src/components/TranscriptionStatus.tsx
@@ -1,0 +1,50 @@
+import { useQueueStatus } from "@/lib/sync";
+import { useVaultStore } from "@/lib/vault";
+import { useSync } from "@/providers/SyncProvider";
+
+// Single-purpose chip for voice-memo notes. A transcribe-memo row sits in the
+// queue from capture-time until either the server returns a transcript or the
+// engine gives up after 24h. The "unavailable" marker is a string the
+// transcribe step writes into the note body when it exhausts retries — we
+// detect it by content match because by that point the queue row is gone.
+
+const UNAVAILABLE_MARKER = "_Transcription unavailable._";
+
+export function TranscriptionStatus({
+  noteId,
+  content,
+}: {
+  noteId: string;
+  content: string;
+}) {
+  const { db } = useSync();
+  const activeVaultId = useVaultStore((s) => s.activeVaultId);
+  const status = useQueueStatus(db, activeVaultId);
+
+  const pending = status.rows.some(
+    (r) => r.mutation.kind === "transcribe-memo" && r.mutation.noteId === noteId,
+  );
+  const unavailable = !pending && content.includes(UNAVAILABLE_MARKER);
+
+  if (pending) {
+    return (
+      <output
+        aria-live="polite"
+        className="mb-4 inline-flex items-center gap-2 rounded-md border border-sky-500/30 bg-sky-500/5 px-3 py-1.5 text-xs text-sky-300"
+      >
+        <span aria-hidden className="inline-block h-2 w-2 animate-pulse rounded-full bg-sky-400" />
+        Transcribing…
+      </output>
+    );
+  }
+
+  if (unavailable) {
+    return (
+      <output className="mb-4 inline-flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-1.5 text-xs text-amber-200">
+        Transcription unavailable — open the audio below and add a note by hand.
+      </output>
+    );
+  }
+
+  return null;
+}

--- a/src/lib/sync/engine.ts
+++ b/src/lib/sync/engine.ts
@@ -22,6 +22,8 @@ export interface EngineOptions {
   // running in case state changes.
   resolveContext: () => EngineDrainContext | null;
   tickIntervalMs?: number;
+  // Fires right before a drain starts — UI can flip "syncing" on.
+  onDrainStart?: () => void;
   onDrain?: (outcome: DrainOutcome) => void;
 }
 
@@ -67,12 +69,17 @@ export class SyncEngine {
     }
   }
 
+  get isDraining(): boolean {
+    return this.draining;
+  }
+
   async runOnce(): Promise<DrainOutcome | null> {
     if (this.draining) return null;
     if (typeof navigator !== "undefined" && navigator.onLine === false) return null;
     const ctx = this.opts.resolveContext();
     if (!ctx) return null;
     this.draining = true;
+    this.opts.onDrainStart?.();
     try {
       const outcome = await drain({
         db: this.opts.db,

--- a/src/lib/sync/index.ts
+++ b/src/lib/sync/index.ts
@@ -11,7 +11,19 @@ export {
   resolveBlobPath,
   resolveNoteId,
 } from "./id-map";
-export { AUTH_HALT_META, clearAuthHalt, countPending, drain, enqueue, listPending } from "./queue";
+export {
+  AUTH_HALT_META,
+  clearAuthHalt,
+  clearPendingForVault,
+  countPending,
+  discardRow,
+  drain,
+  enqueue,
+  listPending,
+  retryRow,
+} from "./queue";
+export { useQueueStatus } from "./useQueueStatus";
+export type { AuthHaltInfo, QueueStatus } from "./useQueueStatus";
 export { estimate, isPersisted, type QuotaReport, requestPersistent } from "./storage-quota";
 export type {
   BlobPathMapRow,

--- a/src/lib/sync/queue.test.ts
+++ b/src/lib/sync/queue.test.ts
@@ -9,10 +9,13 @@ import { blobRef, newLocalId, resolveNoteId } from "./id-map";
 import {
   AUTH_HALT_META,
   TRANSCRIBE_GIVE_UP_MS,
+  clearPendingForVault,
   countPending,
+  discardRow,
   drain,
   enqueue,
   listPending,
+  retryRow,
 } from "./queue";
 
 async function freshDb(): Promise<LensDB> {
@@ -587,5 +590,57 @@ describe("drain — vault isolation", () => {
     expect(out.drained).toBe(1);
     expect(deleteNote).toHaveBeenCalledWith("A1");
     expect(await countPending(db, "vB")).toBe(1);
+  });
+});
+
+describe("retryRow / discardRow / clearPendingForVault", () => {
+  let db: LensDB;
+  beforeEach(async () => {
+    db = await freshDb();
+  });
+  afterEach(() => db.close());
+
+  it("retryRow resets status, attemptCount, nextAttemptAt, and lastError", async () => {
+    const row = await enqueue(db, { kind: "delete-note", targetId: "n1" }, { vaultId: "v1" });
+    // Simulate a needs-human stash by mutating the row directly.
+    await db.put("pending", {
+      ...row,
+      status: "needs-human",
+      attemptCount: 5,
+      nextAttemptAt: Date.now() + 60_000,
+      lastError: "boom",
+    });
+
+    await retryRow(db, row.seq);
+
+    const after = await db.get("pending", row.seq);
+    expect(after?.status).toBe("pending");
+    expect(after?.attemptCount).toBe(0);
+    expect(after?.nextAttemptAt).toBe(0);
+    expect(after?.lastError).toBeUndefined();
+  });
+
+  it("retryRow is a no-op when seq is missing (already discarded)", async () => {
+    await expect(retryRow(db, 9999)).resolves.toBeUndefined();
+  });
+
+  it("discardRow removes a single row but leaves peers alone", async () => {
+    const a = await enqueue(db, { kind: "delete-note", targetId: "a" }, { vaultId: "v1" });
+    await enqueue(db, { kind: "delete-note", targetId: "b" }, { vaultId: "v1" });
+    await discardRow(db, a.seq);
+    const rows = await listPending(db, "v1");
+    expect(rows.map((r) => (r.mutation as { targetId: string }).targetId)).toEqual(["b"]);
+  });
+
+  it("clearPendingForVault wipes only the target vault's rows and reports the count", async () => {
+    await enqueue(db, { kind: "delete-note", targetId: "a" }, { vaultId: "v1" });
+    await enqueue(db, { kind: "delete-note", targetId: "b" }, { vaultId: "v1" });
+    await enqueue(db, { kind: "delete-note", targetId: "c" }, { vaultId: "v2" });
+
+    const cleared = await clearPendingForVault(db, "v1");
+
+    expect(cleared).toBe(2);
+    expect(await countPending(db, "v1")).toBe(0);
+    expect(await countPending(db, "v2")).toBe(1);
   });
 });

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -378,3 +378,37 @@ async function replaceMarkerIfPresent(
 export async function clearAuthHalt(db: LensDB): Promise<void> {
   await db.delete("meta", AUTH_HALT_META);
 }
+
+// Reset a stashed row so the next drain picks it back up. Used by the sync
+// status panel's "Retry" action on a needs-human row. Clears the error
+// counters so the row gets a fresh attempt budget, not a backoff from its
+// previous failure.
+export async function retryRow(db: LensDB, seq: number): Promise<void> {
+  const row = await db.get("pending", seq);
+  if (!row) return;
+  await db.put("pending", {
+    ...row,
+    status: "pending",
+    attemptCount: 0,
+    nextAttemptAt: 0,
+    lastError: undefined,
+  });
+}
+
+// Drop a single pending row — used by "Discard" on a stashed row.
+export async function discardRow(db: LensDB, seq: number): Promise<void> {
+  await db.delete("pending", seq);
+}
+
+// Nuke every pending row for `vaultId`. Destructive escape hatch when a row
+// is wedged in a way the user can't unpick inline. Does not touch blobs or
+// id-map — those are cleaned by their own GC paths.
+export async function clearPendingForVault(db: LensDB, vaultId: string): Promise<number> {
+  const rows = await listPending(db, vaultId);
+  const tx = db.transaction("pending", "readwrite");
+  for (const row of rows) {
+    await tx.store.delete(row.seq);
+  }
+  await tx.done;
+  return rows.length;
+}

--- a/src/lib/sync/useQueueStatus.test.tsx
+++ b/src/lib/sync/useQueueStatus.test.tsx
@@ -1,0 +1,77 @@
+import { type LensDB, openLensDB, setMeta } from "@/lib/sync/db";
+import { AUTH_HALT_META, enqueue, useQueueStatus } from "@/lib/sync/index";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+async function freshDb(): Promise<LensDB> {
+  indexedDB.deleteDatabase("parachute-lens");
+  return openLensDB();
+}
+
+describe("useQueueStatus", () => {
+  let db: LensDB;
+
+  beforeEach(async () => {
+    db = await freshDb();
+  });
+  afterEach(() => db.close());
+
+  it("returns EMPTY when db or vaultId is null", () => {
+    const { result } = renderHook(() => useQueueStatus(null, "v1", 50));
+    expect(result.current.total).toBe(0);
+    expect(result.current.rows).toEqual([]);
+    expect(result.current.authHalt).toBeNull();
+  });
+
+  it("groups rows by kind and counts pending vs needs-human", async () => {
+    const a = await enqueue(db, { kind: "delete-note", targetId: "n1" }, { vaultId: "v1" });
+    const b = await enqueue(
+      db,
+      { kind: "create-note", localId: "tmp:x", payload: { content: "hi" } },
+      { vaultId: "v1" },
+    );
+    // Force one into needs-human.
+    const row = await db.get("pending", b.seq);
+    if (row) await db.put("pending", { ...row, status: "needs-human" });
+
+    const { result } = renderHook(() => useQueueStatus(db, "v1", 50));
+    await waitFor(() => {
+      expect(result.current.total).toBe(2);
+    });
+    expect(result.current.byKind["delete-note"]).toBe(1);
+    expect(result.current.byKind["create-note"]).toBe(1);
+    expect(result.current.pendingCount).toBe(1);
+    expect(result.current.needsHumanCount).toBe(1);
+    // Keep references used to silence unused-var lints.
+    expect(a.seq).toBeGreaterThan(0);
+  });
+
+  it("filters auth-halt meta by vaultId (other vault's halt is ignored)", async () => {
+    await setMeta(db, AUTH_HALT_META, {
+      vaultId: "other",
+      at: Date.now(),
+      message: "not mine",
+    });
+
+    const { result } = renderHook(() => useQueueStatus(db, "v1", 50));
+    await waitFor(() => {
+      expect(result.current.rows).toEqual([]);
+    });
+    expect(result.current.authHalt).toBeNull();
+  });
+
+  it("surfaces auth-halt meta that matches the active vaultId", async () => {
+    await setMeta(db, AUTH_HALT_META, {
+      vaultId: "v1",
+      at: 12345,
+      message: "reconnect",
+    });
+
+    const { result } = renderHook(() => useQueueStatus(db, "v1", 50));
+    await waitFor(() => {
+      expect(result.current.authHalt).not.toBeNull();
+    });
+    expect(result.current.authHalt?.message).toBe("reconnect");
+    expect(result.current.authHalt?.vaultId).toBe("v1");
+  });
+});

--- a/src/lib/sync/useQueueStatus.ts
+++ b/src/lib/sync/useQueueStatus.ts
@@ -1,0 +1,94 @@
+// Polls the sync queue for UI surfaces (status indicator, status panel,
+// per-note transcription chip). Intentionally lightweight — no
+// subscribe/notify plumbing. Drains run on a 30s tick and whenever the
+// engine fires onDrain; a 2s poll is enough for human-scale visible state.
+
+import { useEffect, useRef, useState } from "react";
+import { AUTH_HALT_META, type LensDB, type PendingRow, listPending } from ".";
+import { getMeta } from "./db";
+import type { PendingKind } from "./types";
+
+export interface AuthHaltInfo {
+  vaultId: string;
+  at: number;
+  message: string;
+}
+
+export interface QueueStatus {
+  rows: PendingRow[];
+  byKind: Partial<Record<PendingKind, number>>;
+  total: number;
+  pendingCount: number;
+  needsHumanCount: number;
+  authHalt: AuthHaltInfo | null;
+}
+
+const EMPTY: QueueStatus = {
+  rows: [],
+  byKind: {},
+  total: 0,
+  pendingCount: 0,
+  needsHumanCount: 0,
+  authHalt: null,
+};
+
+export function useQueueStatus(
+  db: LensDB | null,
+  vaultId: string | null,
+  pollMs = 2_000,
+): QueueStatus {
+  const [status, setStatus] = useState<QueueStatus>(EMPTY);
+  // Ref so the polling effect doesn't need to re-subscribe on every render.
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    if (!db || !vaultId) {
+      setStatus(EMPTY);
+      return;
+    }
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const refresh = async () => {
+      try {
+        const [rows, halt] = await Promise.all([
+          listPending(db, vaultId),
+          getMeta<AuthHaltInfo>(db, AUTH_HALT_META),
+        ]);
+        if (cancelledRef.current) return;
+        const byKind: Partial<Record<PendingKind, number>> = {};
+        let pendingCount = 0;
+        let needsHumanCount = 0;
+        for (const row of rows) {
+          const k = row.mutation.kind;
+          byKind[k] = (byKind[k] ?? 0) + 1;
+          if (row.status === "needs-human") needsHumanCount += 1;
+          else pendingCount += 1;
+        }
+        // Ignore halt meta that belongs to a different vault — each vault
+        // carries its own auth state.
+        const activeHalt = halt && halt.vaultId === vaultId ? halt : null;
+        setStatus({
+          rows,
+          byKind,
+          total: rows.length,
+          pendingCount,
+          needsHumanCount,
+          authHalt: activeHalt,
+        });
+      } catch {
+        // Transient IDB errors (eg. db closing during unmount) are fine to
+        // swallow — the next tick will refresh.
+      }
+    };
+
+    void refresh();
+    timer = setInterval(refresh, pollMs);
+    return () => {
+      cancelledRef.current = true;
+      if (timer) clearInterval(timer);
+    };
+  }, [db, vaultId, pollMs]);
+
+  return status;
+}

--- a/src/providers/SyncProvider.tsx
+++ b/src/providers/SyncProvider.tsx
@@ -21,6 +21,26 @@ export interface SyncContext {
   blobStore: BlobStore | null;
   engine: SyncEngine | null;
   isOnline: boolean;
+  // Flipped by the engine around each drain attempt. UI shows a subtle
+  // "syncing" affordance while true.
+  isDraining: boolean;
+  // Wall-clock ms of the most recent drain that actually flushed rows. Null
+  // if nothing has drained since mount. Persisted to localStorage so the
+  // status panel can show a meaningful "Last synced" across reloads.
+  lastSyncedAt: number | null;
+}
+
+const LAST_SYNCED_KEY = "lens:sync:lastSyncedAt";
+
+function loadLastSyncedAt(): number | null {
+  try {
+    const raw = localStorage.getItem(LAST_SYNCED_KEY);
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
 }
 
 const SyncCtx = createContext<SyncContext>({
@@ -28,18 +48,31 @@ const SyncCtx = createContext<SyncContext>({
   blobStore: null,
   engine: null,
   isOnline: true,
+  isDraining: false,
+  lastSyncedAt: null,
 });
 
 export function useSync(): SyncContext {
   return useContext(SyncCtx);
 }
 
+// Provider-scoped IndexedDB lifecycle: the DB handle is opened on mount and
+// closed on unmount. When writing tests that unmount route components which
+// perform fire-and-forget enqueues during cleanup (e.g. TextCapture's
+// unmount-flush), be aware that the provider's cleanup closes the DB in the
+// same tick — if both unmount together, in-flight IDB transactions race the
+// close and fake-indexeddb raises InvalidStateError. Real SPA navigation
+// doesn't tear down the provider, so to reproduce the true shape in tests,
+// toggle only the inner component's mount (see TextCapture.test.tsx for the
+// pattern) rather than unmounting the whole render tree.
 export function SyncProvider({ children }: { children: ReactNode }): ReactNode {
   const [db, setDb] = useState<LensDB | null>(null);
   const [blobStore, setBlobStore] = useState<BlobStore | null>(null);
   const [isOnline, setIsOnline] = useState(
     typeof navigator !== "undefined" ? navigator.onLine : true,
   );
+  const [isDraining, setIsDraining] = useState(false);
+  const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(() => loadLastSyncedAt());
   const client = useActiveVaultClient();
   const activeVaultId = useVaultStore((s) => s.activeVaultId);
   const qc = useQueryClient();
@@ -104,8 +137,19 @@ export function SyncProvider({ children }: { children: ReactNode }): ReactNode {
         // between drains without any React-tree signal.
         return { client: c, vaultId: v, scribeSettings: loadScribeSettings(v) };
       },
+      onDrainStart: () => {
+        setIsDraining(true);
+      },
       onDrain: (outcome) => {
+        setIsDraining(false);
         if (outcome.drained > 0) {
+          const now = Date.now();
+          setLastSyncedAt(now);
+          try {
+            localStorage.setItem(LAST_SYNCED_KEY, String(now));
+          } catch {
+            // quota/private-mode — not worth surfacing
+          }
           const v = activeVaultIdRef.current;
           qcRef.current.invalidateQueries({ queryKey: ["notes", v] });
           qcRef.current.invalidateQueries({ queryKey: ["tags", v] });
@@ -122,8 +166,8 @@ export function SyncProvider({ children }: { children: ReactNode }): ReactNode {
   }, [engine]);
 
   const value = useMemo<SyncContext>(
-    () => ({ db, blobStore, engine, isOnline }),
-    [db, blobStore, engine, isOnline],
+    () => ({ db, blobStore, engine, isOnline, isDraining, lastSyncedAt }),
+    [db, blobStore, engine, isOnline, isDraining, lastSyncedAt],
   );
 
   return <SyncCtx.Provider value={value}>{children}</SyncCtx.Provider>;


### PR DESCRIPTION
## Summary

Final PR of the v0.2 arc (task #53). Makes the offline queue legible: the user can tell at a glance whether writes are syncing, why they're stuck, and take action on anything that needs a human.

- **Header indicator** (`SyncStatusIndicator`): pill with tone dot + hidden-on-mobile label + pending-count badge. Tone priority: `halted > offline > syncing > online`. Click opens a popover; click outside closes.
- **Detail panel** (`SyncStatusPanel`): state headline, auth-halt banner with a "Reconnect to resume sync" link to `/add`, per-kind queue breakdown, needs-human rows with inline Retry/Discard, "Last synced" (via persisted `lastSyncedAt`), storage bar (warning at ≥80% of `navigator.storage.estimate().quota`), Clear-all escape hatch.
- **Transcription status** (`/notes/:id`): "Transcribing…" chip while a `transcribe-memo` row is queued for that note; "Transcription unavailable" chip when the 24h give-up marker is present in the note content.
- **Install visibility** (Settings): an "Installed" chip appears when the app is running as a standalone PWA.
- **Supporting infra**: `useQueueStatus` 2s polling hook (with per-vault auth-halt filtering); `SyncEngine.onDrainStart` + public `isDraining`; `SyncProvider` now persists `lastSyncedAt` to `localStorage`; `retryRow` / `discardRow` / `clearPendingForVault` helpers in `sync/queue`.

## Design decisions

- **Indicator style** — small pill with a colored dot + terse label + count badge. Ambient when all is well, louder when it's not. Uses Tailwind only — no new primitive.
- **Header placement** — after Settings, before InstallPrompt. Keeps the right cluster of "app state" affordances together.
- **Default panel state** — closed. Click to open. No persistence of open-state across renders — this is a peek, not a surface you live in.
- **Mobile layout** — the pill's text label is hidden below `sm` breakpoint, leaving dot + badge. The popover is 20rem wide, positioned `right-0` under the button; it stays legible on phones and doesn't block the main nav.
- **Popover vs dialog** — the popover is a non-modal `<div role="dialog">`, not a `<dialog>`. Native `<dialog>` requires imperative `showModal()` calls and traps focus; this is a peek, not a task flow.
- **Polling (2s) over subscribe/notify** — the queue doesn't currently emit events on every row change; the drain loop fires `onDrain` at the end of a cycle but not on individual row writes. A 2s tick matches human perception and keeps IDB traffic trivial.
- **Per-vault auth-halt filtering** — meta key is global, but the hook ignores halts that belong to a different vault. Keeps a stale halt in vault A from bleeding into the UI after the user switches to vault B.
- **Transcription "unavailable" detection via content match** — the give-up step deletes the queue row and rewrites the note body with a marker. By the time the chip renders, the queue has no trace, so the chip falls back to content detection. No retry affordance because the blob is gone.
- **SyncProvider lifecycle note** — added the header comment the team-lead asked for about the TextCapture/unmount-flush test-shape quirk.

## Out of scope (deliberately)

- Background sync (Periodic Background Sync API) — reserved for a later iteration.
- Richer conflict-resolution UX beyond Retry/Discard on the stashed row.
- A per-note pending indicator in the notes list.

## Test plan

- [x] `lint` — biome clean
- [x] `typecheck` — tsc passes
- [x] `test --run` — 328 passed, 48 files
- [x] `build` — production bundle builds + service worker generated
- [x] New tests: queue helpers (retry/discard/clear-all), `useQueueStatus` (grouping + auth-halt filter), indicator (tones, badge, open/close), panel (headlines, auth-halt reconnect, retry/discard/clear-all, storage threshold), transcription chip (pending vs unavailable)

Closes #53.

After this merges, v0.2 is complete and ready to tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)