### PR TITLE
Fix graph depth off-by-one: Hops=1 shows 1-hop neighbors

### DIFF
--- a/src/components/NeighborhoodGraph.test.tsx
+++ b/src/components/NeighborhoodGraph.test.tsx
@@ -122,7 +122,7 @@ describe("NeighborhoodGraph", () => {
     ],
   };
 
-  it("renders the graph with anchor and neighbors at depth 2", async () => {
+  it("renders the graph with anchor and 1-hop neighbors at the default depth", async () => {
     seedActiveVault();
     mockFetchReturning({
       B: { id: "B", path: "notes/B", createdAt: "2026-04-18T00:00:00.000Z" },
@@ -170,28 +170,30 @@ describe("NeighborhoodGraph", () => {
     await waitFor(() => expect(screen.getByTestId("note-route")).toBeInTheDocument());
   });
 
-  it("depth=1 does not fetch any neighbors", async () => {
+  it("expands to 2-hop neighbors when Hops is raised", async () => {
     seedActiveVault();
-    const fetchImpl = mockFetchReturning({
-      B: { id: "B", path: "notes/B", createdAt: "2026-04-18T00:00:00.000Z" },
+    mockFetchReturning({
+      B: {
+        id: "B",
+        path: "notes/B",
+        createdAt: "2026-04-18T00:00:00.000Z",
+        links: [{ sourceId: "B", targetId: "D", relationship: "wikilink" }],
+      },
       C: { id: "C", path: "notes/C", createdAt: "2026-04-18T00:00:00.000Z" },
+      D: { id: "D", path: "notes/D", createdAt: "2026-04-18T00:00:00.000Z" },
     });
     render(
       <Wrap>
         <NeighborhoodGraph anchor={anchor} />
       </Wrap>,
     );
-    // Settle depth 2 default first (renders with 3 nodes).
     await waitFor(() => expect(screen.getByTestId("node-count").textContent).toBe("3"));
-    fetchImpl.mockClear();
 
-    const depth1 = screen.getByRole("button", { name: "1" });
+    const depth2 = screen.getByRole("button", { name: "2" });
     await act(async () => {
-      fireEvent.click(depth1);
+      fireEvent.click(depth2);
     });
-
-    await waitFor(() => expect(screen.getByText(/no neighbors yet/i)).toBeInTheDocument());
-    expect(fetchImpl).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByTestId("node-count").textContent).toBe("4"));
   });
 
   it("collapses and re-expands via the header toggle", async () => {
@@ -211,6 +213,6 @@ describe("NeighborhoodGraph", () => {
       fireEvent.click(toggle);
     });
     expect(screen.queryByTestId("mock-force-graph")).not.toBeInTheDocument();
-    expect(screen.queryByRole("group", { name: /graph depth/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /hops/i })).not.toBeInTheDocument();
   });
 });

--- a/src/components/NeighborhoodGraph.tsx
+++ b/src/components/NeighborhoodGraph.tsx
@@ -54,7 +54,7 @@ function DepthControl({ depth, onChange }: { depth: number; onChange: (d: number
   for (let i = MIN_DEPTH; i <= MAX_DEPTH; i++) options.push(i);
   return (
     <fieldset className="flex items-center gap-1 text-xs text-fg-dim">
-      <legend className="mr-1 inline-block">Depth</legend>
+      <legend className="mr-1 inline-block">Hops</legend>
       {options.map((d) => (
         <button
           key={d}

--- a/src/lib/vault/neighborhood.test.ts
+++ b/src/lib/vault/neighborhood.test.ts
@@ -89,18 +89,7 @@ describe("buildNeighborhoodGraph", () => {
 });
 
 describe("expandNeighborhood", () => {
-  it("returns just the anchor at depth 1", async () => {
-    const anchor = note("A", [["A", "B"]]);
-    const fetched: string[] = [];
-    const result = await expandNeighborhood(anchor, 1, async (id) => {
-      fetched.push(id);
-      return null;
-    });
-    expect(fetched).toEqual([]);
-    expect([...result.keys()]).toEqual(["A"]);
-  });
-
-  it("fetches 1-hop neighbors at depth 2", async () => {
+  it("fetches 1-hop neighbors at depth 1", async () => {
     const anchor = note("A", [
       ["A", "B"],
       ["C", "A"],
@@ -110,12 +99,12 @@ describe("expandNeighborhood", () => {
       fetched.push(id);
       return note(id);
     };
-    const result = await expandNeighborhood(anchor, 2, fetchNote);
+    const result = await expandNeighborhood(anchor, 1, fetchNote);
     expect(fetched.sort()).toEqual(["B", "C"]);
     expect([...result.keys()].sort()).toEqual(["A", "B", "C"]);
   });
 
-  it("fetches 2-hop neighbors at depth 3", async () => {
+  it("fetches 2-hop neighbors at depth 2", async () => {
     const anchor = note("A", [["A", "B"]]);
     const neighbors = new Map<string, Note>([
       ["B", note("B", [["B", "C"]])],
@@ -126,9 +115,26 @@ describe("expandNeighborhood", () => {
       fetched.push(id);
       return neighbors.get(id) ?? null;
     };
-    const result = await expandNeighborhood(anchor, 3, fetchNote);
+    const result = await expandNeighborhood(anchor, 2, fetchNote);
     expect(fetched).toEqual(["B", "C"]);
     expect([...result.keys()].sort()).toEqual(["A", "B", "C"]);
+  });
+
+  it("fetches 3-hop neighbors at depth 3", async () => {
+    const anchor = note("A", [["A", "B"]]);
+    const neighbors = new Map<string, Note>([
+      ["B", note("B", [["B", "C"]])],
+      ["C", note("C", [["C", "D"]])],
+      ["D", note("D")],
+    ]);
+    const fetched: string[] = [];
+    const fetchNote = async (id: string) => {
+      fetched.push(id);
+      return neighbors.get(id) ?? null;
+    };
+    const result = await expandNeighborhood(anchor, 3, fetchNote);
+    expect(fetched).toEqual(["B", "C", "D"]);
+    expect([...result.keys()].sort()).toEqual(["A", "B", "C", "D"]);
   });
 
   it("stops early if a layer has no new ids to fetch", async () => {

--- a/src/lib/vault/neighborhood.ts
+++ b/src/lib/vault/neighborhood.ts
@@ -22,9 +22,13 @@ export interface NeighborhoodGraphData {
   edges: GraphEdge[];
 }
 
+// `depth` is the number of hops out from the anchor to expand. 1 = anchor +
+// direct neighbors, 2 = + 2-hop, and so on. DEFAULT_DEPTH stays at 1 to
+// preserve the previous UI behavior (the old semantics hid the anchor-only
+// state behind a "depth=1" that actually fetched nothing).
 export const MIN_DEPTH = 1;
 export const MAX_DEPTH = 3;
-export const DEFAULT_DEPTH = 2;
+export const DEFAULT_DEPTH = 1;
 
 export function buildNeighborhoodGraph(
   anchorId: string,
@@ -71,7 +75,7 @@ export async function expandNeighborhood(
   notes.set(anchor.id, anchor);
 
   let frontier: Note[] = [anchor];
-  for (let layer = 1; layer < depth; layer++) {
+  for (let layer = 1; layer <= depth; layer++) {
     const toFetch = new Set<string>();
     for (const note of frontier) {
       for (const l of note.links ?? []) {


### PR DESCRIPTION
## Summary
- `expandNeighborhood` BFS loop used `<` instead of `<=`, so the Hops=1 control never expanded past the anchor and the old Hops=2 default was really a 1-hop graph.
- Loop bound is now `<=`, and `DEFAULT_DEPTH` is set to `1` so the visible default (1 hop out from anchor) is unchanged.
- UI control legend is now **Hops** instead of **Depth** to make the semantics explicit regardless of internal naming.
- Tests rewritten to the new semantics: each depth `n` fetches an `n`-hop neighborhood.

Closes #22

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 328/328 (48 files)
- [x] `bun run build`
- [ ] Manual: open a note with links; verify Hops=1 shows direct neighbors and Hops=2/3 expand further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)