### PR TITLE
Per-vault tag roles (pinned / archived / capture defaults)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# parachute-lens
+
+## Tag roles — the per-vault customization primitive
+
+Features that rely on a specific tag name (e.g. "this is a pinned note", "this
+is a voice capture") must **not** hardcode the tag. Different users have
+different vault conventions; hardcoding forces one convention on everyone and
+collides with tags they already use.
+
+Instead, add the tag to the `TagRoles` object and read it at the point of use.
+
+### Where it lives
+
+- Type + helpers: `src/lib/vault/tag-roles.ts`
+- Settings UI: `TagRolesSection` in `src/app/routes/Settings.tsx`
+- Storage key: `lens:tag-roles:<vaultId>` in `localStorage` (per-vault, like
+  `lens:scribe:<vaultId>`)
+
+### Current roles
+
+| Key | Default | Used by |
+|---|---|---|
+| `pinned` | `pinned` | (reserved for #25 pinned views) |
+| `archived` | `archived` | (reserved for #25 archived views) |
+| `captureVoice` | `voice` | `src/app/routes/MemoCapture.tsx` |
+| `captureText` | `quick` | `src/app/routes/TextCapture.tsx` |
+
+### Adding a new role
+
+1. Add the key to `TagRoles` and a sensible default to `DEFAULT_TAG_ROLES` in
+   `src/lib/vault/tag-roles.ts`. Include it in `TAG_ROLE_KEYS` and add an
+   entry to `ROLE_LABELS` in `Settings.tsx` so the settings UI renders it.
+2. At the feature's point of use, read the role with
+   `const { roles } = useTagRoles(activeVault?.id ?? null);`
+   and pass `roles.<yourKey>` where the tag is needed. Don't inline the key
+   name; don't add a fallback to a literal tag string in the feature code.
+3. If your feature queries notes by the role tag, filter on `roles.<yourKey>`
+   from `useTagRoles`, not on a hardcoded string.
+4. Remember: remapping a role never retags existing notes. The role points at
+   the new tag going forward only. Make that explicit in any UI where the
+   mapping change has user-visible consequences.
+
+### Pattern: per-vault UI/integration settings in general
+
+Other per-vault settings (currently just scribe: `src/lib/scribe/settings.ts`)
+follow the same shape:
+
+- Plain `load<Feature>(vaultId)` / `save<Feature>(vaultId, x)` /
+  `delete<Feature>(vaultId)` around `localStorage` with a key of
+  `lens:<feature>:<vaultId>`.
+- A thin `use<Feature>(vaultId)` hook that re-reads on `vaultId` change and
+  returns `{ value, setValue }`.
+- No zustand for these — localStorage is the source of truth and the hook is
+  just a convenience.
+
+Reach for this primitive (not a new store pattern) when you need "a small
+JSON blob that belongs to a single vault and rarely changes."

--- a/src/app/routes/MemoCapture.test.tsx
+++ b/src/app/routes/MemoCapture.test.tsx
@@ -226,7 +226,7 @@ describe("MemoCapture route", () => {
     expect(link.mutation.mimeType).toBe("audio/webm;codecs=opus");
     if (rows[0].mutation.kind === "create-note") {
       expect(rows[0].mutation.payload.path).toMatch(/^Memos\//);
-      expect(rows[0].mutation.payload.tags).toEqual(["memo"]);
+      expect(rows[0].mutation.payload.tags).toEqual(["voice"]);
     }
     // Without scribe configured, upload-attachment should not retain the blob.
     if (upload.mutation.kind === "upload-attachment") {

--- a/src/app/routes/MemoCapture.tsx
+++ b/src/app/routes/MemoCapture.tsx
@@ -11,7 +11,7 @@ import {
 import { loadScribeSettings } from "@/lib/scribe";
 import { blobRef, enqueue, newBlobId, newLocalId } from "@/lib/sync";
 import { useToastStore } from "@/lib/toast/store";
-import { useVaultStore } from "@/lib/vault";
+import { useTagRoles, useVaultStore } from "@/lib/vault";
 import { useSync } from "@/providers/SyncProvider";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, Navigate, useNavigate } from "react-router";
@@ -45,6 +45,7 @@ export function MemoCapture({ embedded = false }: { embedded?: boolean } = {}) {
   const navigate = useNavigate();
   const pushToast = useToastStore((s) => s.push);
   const { db, blobStore, engine } = useSync();
+  const { roles } = useTagRoles(activeVault?.id ?? null);
 
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const [elapsedMs, setElapsedMs] = useState(0);
@@ -191,7 +192,7 @@ export function MemoCapture({ embedded = false }: { embedded?: boolean } = {}) {
         {
           kind: "create-note",
           localId,
-          payload: { content, path, tags: ["memo"] },
+          payload: { content, path, tags: [roles.captureVoice] },
         },
         { vaultId: activeVault.id },
       );
@@ -249,7 +250,7 @@ export function MemoCapture({ embedded = false }: { embedded?: boolean } = {}) {
       });
       pushToast(e instanceof Error ? `Save failed: ${e.message}` : "Save failed.", "error");
     }
-  }, [phase, db, blobStore, activeVault, engine, navigate, pushToast]);
+  }, [phase, db, blobStore, activeVault, engine, navigate, pushToast, roles.captureVoice]);
 
   if (!activeVault) return <Navigate to="/" replace />;
 

--- a/src/app/routes/Settings.test.tsx
+++ b/src/app/routes/Settings.test.tsx
@@ -1,7 +1,8 @@
 import { Settings } from "@/app/routes/Settings";
 import { useToastStore } from "@/lib/toast/store";
 import { useVaultStore } from "@/lib/vault/store";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -38,14 +39,24 @@ function seedActiveVault() {
 }
 
 function renderSettings() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
   return render(
-    <MemoryRouter initialEntries={["/settings"]}>
-      <Routes>
-        <Route path="/settings" element={<Settings />} />
-        <Route path="/" element={<div>HomePage</div>} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/settings"]}>
+        <Routes>
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/" element={<div>HomePage</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
+}
+
+function scribeSection(): HTMLElement {
+  const heading = screen.getByRole("heading", { name: /transcription/i });
+  const section = heading.closest("section");
+  if (!section) throw new Error("scribe section not found");
+  return section as HTMLElement;
 }
 
 describe("Settings route", () => {
@@ -80,7 +91,7 @@ describe("Settings route", () => {
       fireEvent.change(urlInput, { target: { value: "http://scribe.dev" } });
     });
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+      fireEvent.click(within(scribeSection()).getByRole("button", { name: /^save$/i }));
     });
     const stored = JSON.parse(localStorage.getItem("lens:scribe:dev") ?? "{}");
     expect(stored.url).toBe("http://scribe.dev");
@@ -127,8 +138,56 @@ describe("Settings route", () => {
     expect(urlInput.value).toBe("http://scribe.dev");
     vi.spyOn(window, "confirm").mockReturnValue(true);
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /^clear$/i }));
+      fireEvent.click(within(scribeSection()).getByRole("button", { name: /^clear$/i }));
     });
     expect(localStorage.getItem("lens:scribe:dev")).toBeNull();
+  });
+
+  it("renders tag roles with defaults and saves overrides to localStorage", async () => {
+    renderSettings();
+    const section = screen
+      .getByRole("heading", { name: /tag roles/i })
+      .closest("section") as HTMLElement;
+    const pinnedInput = within(section).getByLabelText(/pinned tag role/i);
+    expect((pinnedInput as HTMLInputElement).value).toBe("pinned");
+
+    await act(async () => {
+      fireEvent.change(pinnedInput, { target: { value: "starred" } });
+    });
+    await act(async () => {
+      fireEvent.click(within(section).getByRole("button", { name: /^save$/i }));
+    });
+    const stored = JSON.parse(localStorage.getItem("lens:tag-roles:dev") ?? "{}") as {
+      pinned: string;
+      archived: string;
+    };
+    expect(stored.pinned).toBe("starred");
+    expect(stored.archived).toBe("archived");
+  });
+
+  it("reset-to-defaults wipes the stored tag roles", async () => {
+    localStorage.setItem(
+      "lens:tag-roles:dev",
+      JSON.stringify({
+        pinned: "starred",
+        archived: "done",
+        captureVoice: "memo",
+        captureText: "inbox",
+      }),
+    );
+    renderSettings();
+    const section = screen
+      .getByRole("heading", { name: /tag roles/i })
+      .closest("section") as HTMLElement;
+    expect((within(section).getByLabelText(/pinned tag role/i) as HTMLInputElement).value).toBe(
+      "starred",
+    );
+    await act(async () => {
+      fireEvent.click(within(section).getByRole("button", { name: /reset to defaults/i }));
+    });
+    expect(localStorage.getItem("lens:tag-roles:dev")).toBeNull();
+    expect((within(section).getByLabelText(/pinned tag role/i) as HTMLInputElement).value).toBe(
+      "pinned",
+    );
   });
 });

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -1,8 +1,16 @@
 import { isStandalone } from "@/lib/pwa";
 import { type ScribeSettings, scribeHealth, useScribeSettings } from "@/lib/scribe";
 import { useToastStore } from "@/lib/toast/store";
-import { useVaultStore } from "@/lib/vault";
-import { useEffect, useState } from "react";
+import {
+  DEFAULT_TAG_ROLES,
+  TAG_ROLE_KEYS,
+  type TagRoleKey,
+  type TagRoles,
+  useTagRoles,
+  useTags,
+  useVaultStore,
+} from "@/lib/vault";
+import { useEffect, useId, useMemo, useState } from "react";
 import { Link, Navigate } from "react-router";
 
 // Per-vault settings UI. v0.2 only surfaces scribe because it's the first
@@ -27,6 +35,7 @@ export function Settings() {
       </header>
 
       <ScribeSettingsSection vaultId={activeVault.id} />
+      <TagRolesSection vaultId={activeVault.id} />
       <InstallStateSection />
     </div>
   );
@@ -200,6 +209,113 @@ function ScribeSettingsSection({ vaultId }: { vaultId: string }) {
         CORS error in the browser console, run scribe behind a reverse proxy that shares your
         vault's origin.
       </p>
+    </section>
+  );
+}
+
+const ROLE_LABELS: Record<TagRoleKey, { title: string; help: string }> = {
+  pinned: {
+    title: "Pinned",
+    help: "Tag for notes you want at the top of views.",
+  },
+  archived: {
+    title: "Archived",
+    help: "Tag for notes you've moved out of the way.",
+  },
+  captureVoice: {
+    title: "Voice capture",
+    help: "Default tag for new voice memos.",
+  },
+  captureText: {
+    title: "Text capture",
+    help: "Default tag for quick typed notes.",
+  },
+};
+
+function TagRolesSection({ vaultId }: { vaultId: string }) {
+  const { roles, setRoles } = useTagRoles(vaultId);
+  const tagsQuery = useTags();
+  const pushToast = useToastStore((s) => s.push);
+  const datalistId = useId();
+
+  const [draft, setDraft] = useState<TagRoles>(roles);
+  useEffect(() => setDraft(roles), [roles]);
+
+  const tagOptions = useMemo(() => {
+    const names = (tagsQuery.data ?? []).map((t) => t.name);
+    return [...new Set(names)].sort((a, b) => a.localeCompare(b));
+  }, [tagsQuery.data]);
+
+  const isDirty = TAG_ROLE_KEYS.some((k) => draft[k].trim() !== roles[k]);
+
+  const save = () => {
+    setRoles(draft);
+    pushToast("Tag roles saved.", "success");
+  };
+
+  const resetDefaults = () => {
+    setRoles(null);
+    setDraft(DEFAULT_TAG_ROLES);
+    pushToast("Tag roles reset to defaults.", "success");
+  };
+
+  return (
+    <section className="mt-6 space-y-4 rounded-xl border border-border bg-card p-6">
+      <div>
+        <h2 className="font-serif text-xl text-fg">Tag roles</h2>
+        <p className="mt-1 text-xs text-fg-dim">
+          Point each role at whatever tag your vault already uses. Changes apply to future notes
+          only — existing notes keep their current tags.
+        </p>
+      </div>
+
+      <datalist id={datalistId}>
+        {tagOptions.map((t) => (
+          <option key={t} value={t} />
+        ))}
+      </datalist>
+
+      <div className="space-y-3">
+        {TAG_ROLE_KEYS.map((key) => (
+          <label key={key} className="block text-sm">
+            <span className="mb-1 flex items-baseline justify-between gap-2">
+              <span className="text-fg-muted">{ROLE_LABELS[key].title}</span>
+              <span className="text-xs text-fg-dim">default: #{DEFAULT_TAG_ROLES[key]}</span>
+            </span>
+            <input
+              type="text"
+              value={draft[key]}
+              onChange={(e) => setDraft((d) => ({ ...d, [key]: e.target.value }))}
+              list={datalistId}
+              placeholder={DEFAULT_TAG_ROLES[key]}
+              aria-label={`${ROLE_LABELS[key].title} tag role`}
+              spellCheck={false}
+              autoCapitalize="none"
+              autoCorrect="off"
+              className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-fg-dim focus:border-accent focus:outline-none"
+            />
+            <span className="mt-1 block text-xs text-fg-dim">{ROLE_LABELS[key].help}</span>
+          </label>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 pt-2">
+        <button
+          type="button"
+          onClick={save}
+          disabled={!isDirty}
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-40"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={resetDefaults}
+          className="text-sm text-fg-muted hover:text-accent"
+        >
+          Reset to defaults
+        </button>
+      </div>
     </section>
   );
 }

--- a/src/app/routes/TextCapture.tsx
+++ b/src/app/routes/TextCapture.tsx
@@ -1,9 +1,9 @@
 import { TagEditor, normalizeTag } from "@/components/TagEditor";
 import { enqueue, newLocalId } from "@/lib/sync";
 import { useToastStore } from "@/lib/toast/store";
-import { useVaultStore } from "@/lib/vault";
+import { useTagRoles, useVaultStore } from "@/lib/vault";
 import { useSync } from "@/providers/SyncProvider";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 // Apple-Notes-fast typed capture. Pure text + inline tag editor, no path or
 // metadata — the vault auto-names the note from its first line.
@@ -20,15 +20,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
 // The visible button is still there because a discoverable save affordance
 // matters more than absolute chrome-minimalism, and Cmd+Enter is invisible on
 // touch devices.
-const DEFAULT_TAGS = ["quick"];
 
 export function TextCapture() {
   const activeVault = useVaultStore((s) => s.getActiveVault());
   const pushToast = useToastStore((s) => s.push);
   const { db, engine } = useSync();
+  const { roles } = useTagRoles(activeVault?.id ?? null);
 
+  const defaultTags = useMemo(() => [roles.captureText], [roles.captureText]);
   const [content, setContent] = useState("");
-  const [tags, setTags] = useState<string[]>(DEFAULT_TAGS);
+  const [tags, setTags] = useState<string[]>(() => [roles.captureText]);
   const [tagInput, setTagInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -62,7 +63,7 @@ export function TextCapture() {
       );
       void engine?.runOnce();
       setContent("");
-      setTags(DEFAULT_TAGS);
+      setTags(defaultTags);
       setTagInput("");
       pushToast("Captured.", "success");
       // Keep focus so the user can dash off the next thought.
@@ -72,7 +73,7 @@ export function TextCapture() {
       pushToast(e instanceof Error ? `Capture failed: ${e.message}` : "Capture failed.", "error");
       return false;
     }
-  }, [content, tags, db, activeVault, engine, pushToast]);
+  }, [content, tags, db, activeVault, engine, pushToast, defaultTags]);
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -9,5 +9,6 @@ export * from "./probe";
 export * from "./queries";
 export * from "./storage";
 export * from "./store";
+export * from "./tag-roles";
 export * from "./types";
 export * from "./url";

--- a/src/lib/vault/tag-roles.test.ts
+++ b/src/lib/vault/tag-roles.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_TAG_ROLES, deleteTagRoles, loadTagRoles, saveTagRoles } from "./tag-roles";
+
+describe("tag roles storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns defaults when nothing is stored", () => {
+    expect(loadTagRoles("v1")).toEqual(DEFAULT_TAG_ROLES);
+  });
+
+  it("round-trips every role", () => {
+    saveTagRoles("v1", {
+      pinned: "favs",
+      archived: "done",
+      captureVoice: "memo",
+      captureText: "inbox",
+    });
+    expect(loadTagRoles("v1")).toEqual({
+      pinned: "favs",
+      archived: "done",
+      captureVoice: "memo",
+      captureText: "inbox",
+    });
+  });
+
+  it("scopes storage by vaultId", () => {
+    saveTagRoles("v1", { ...DEFAULT_TAG_ROLES, pinned: "starred" });
+    saveTagRoles("v2", { ...DEFAULT_TAG_ROLES, pinned: "important" });
+    expect(loadTagRoles("v1").pinned).toBe("starred");
+    expect(loadTagRoles("v2").pinned).toBe("important");
+  });
+
+  it("strips leading # and trims whitespace on save", () => {
+    saveTagRoles("v1", {
+      pinned: "  #starred  ",
+      archived: "#done",
+      captureVoice: " voice ",
+      captureText: "#quick",
+    });
+    expect(loadTagRoles("v1")).toEqual({
+      pinned: "starred",
+      archived: "done",
+      captureVoice: "voice",
+      captureText: "quick",
+    });
+  });
+
+  it("falls back to defaults for blank or missing entries", () => {
+    saveTagRoles("v1", {
+      pinned: "   ",
+      archived: "",
+      captureVoice: "#",
+      captureText: "keep",
+    });
+    const out = loadTagRoles("v1");
+    expect(out.pinned).toBe(DEFAULT_TAG_ROLES.pinned);
+    expect(out.archived).toBe(DEFAULT_TAG_ROLES.archived);
+    expect(out.captureVoice).toBe(DEFAULT_TAG_ROLES.captureVoice);
+    expect(out.captureText).toBe("keep");
+  });
+
+  it("tolerates partial stored JSON by filling defaults", () => {
+    localStorage.setItem("lens:tag-roles:v1", JSON.stringify({ pinned: "starred" }));
+    const out = loadTagRoles("v1");
+    expect(out.pinned).toBe("starred");
+    expect(out.archived).toBe(DEFAULT_TAG_ROLES.archived);
+    expect(out.captureVoice).toBe(DEFAULT_TAG_ROLES.captureVoice);
+    expect(out.captureText).toBe(DEFAULT_TAG_ROLES.captureText);
+  });
+
+  it("returns defaults on malformed JSON", () => {
+    localStorage.setItem("lens:tag-roles:v1", "not-json{");
+    expect(loadTagRoles("v1")).toEqual(DEFAULT_TAG_ROLES);
+  });
+
+  it("deleteTagRoles removes the entry and load falls back to defaults", () => {
+    saveTagRoles("v1", { ...DEFAULT_TAG_ROLES, pinned: "starred" });
+    deleteTagRoles("v1");
+    expect(loadTagRoles("v1")).toEqual(DEFAULT_TAG_ROLES);
+  });
+});

--- a/src/lib/vault/tag-roles.ts
+++ b/src/lib/vault/tag-roles.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useState } from "react";
+
+// Per-vault "tag role" settings. Features like capture, pin, archive want to
+// apply a specific tag — but hardcoding tag names pushes one vault's
+// conventions onto every vault. Each role holds a customizable tag name; the
+// defaults preserve sensible behavior for a fresh vault.
+//
+// Stored per-vault in localStorage, analogous to scribe settings. Remapping a
+// role never retags existing notes — the role just points at the new tag
+// going forward.
+export interface TagRoles {
+  pinned: string;
+  archived: string;
+  captureVoice: string;
+  captureText: string;
+}
+
+export const DEFAULT_TAG_ROLES: TagRoles = {
+  pinned: "pinned",
+  archived: "archived",
+  captureVoice: "voice",
+  captureText: "quick",
+};
+
+export const TAG_ROLE_KEYS = ["pinned", "archived", "captureVoice", "captureText"] as const;
+export type TagRoleKey = (typeof TAG_ROLE_KEYS)[number];
+
+const STORAGE_PREFIX = "lens:tag-roles:";
+
+function keyFor(vaultId: string): string {
+  return STORAGE_PREFIX + vaultId;
+}
+
+function normalizeTag(name: string | undefined, fallback: string): string {
+  if (typeof name !== "string") return fallback;
+  const trimmed = name.trim().replace(/^#/, "");
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+export function loadTagRoles(vaultId: string): TagRoles {
+  try {
+    const raw = localStorage.getItem(keyFor(vaultId));
+    if (!raw) return { ...DEFAULT_TAG_ROLES };
+    const parsed = JSON.parse(raw) as Partial<TagRoles>;
+    return {
+      pinned: normalizeTag(parsed.pinned, DEFAULT_TAG_ROLES.pinned),
+      archived: normalizeTag(parsed.archived, DEFAULT_TAG_ROLES.archived),
+      captureVoice: normalizeTag(parsed.captureVoice, DEFAULT_TAG_ROLES.captureVoice),
+      captureText: normalizeTag(parsed.captureText, DEFAULT_TAG_ROLES.captureText),
+    };
+  } catch {
+    return { ...DEFAULT_TAG_ROLES };
+  }
+}
+
+export function saveTagRoles(vaultId: string, roles: TagRoles): void {
+  const normalized: TagRoles = {
+    pinned: normalizeTag(roles.pinned, DEFAULT_TAG_ROLES.pinned),
+    archived: normalizeTag(roles.archived, DEFAULT_TAG_ROLES.archived),
+    captureVoice: normalizeTag(roles.captureVoice, DEFAULT_TAG_ROLES.captureVoice),
+    captureText: normalizeTag(roles.captureText, DEFAULT_TAG_ROLES.captureText),
+  };
+  try {
+    localStorage.setItem(keyFor(vaultId), JSON.stringify(normalized));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+export function deleteTagRoles(vaultId: string): void {
+  try {
+    localStorage.removeItem(keyFor(vaultId));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+// Re-reads on mount and on vaultId change. `setRoles(null)` resets to defaults.
+// Returns defaults (not null) when nothing is stored so call sites can read a
+// role tag without null-checks.
+export function useTagRoles(vaultId: string | null): {
+  roles: TagRoles;
+  setRoles: (next: TagRoles | null) => void;
+} {
+  const [roles, setState] = useState<TagRoles>(() =>
+    vaultId ? loadTagRoles(vaultId) : { ...DEFAULT_TAG_ROLES },
+  );
+
+  useEffect(() => {
+    setState(vaultId ? loadTagRoles(vaultId) : { ...DEFAULT_TAG_ROLES });
+  }, [vaultId]);
+
+  const setRoles = useCallback(
+    (next: TagRoles | null) => {
+      if (!vaultId) return;
+      if (next === null) {
+        deleteTagRoles(vaultId);
+        setState({ ...DEFAULT_TAG_ROLES });
+      } else {
+        saveTagRoles(vaultId, next);
+        setState(loadTagRoles(vaultId));
+      }
+    },
+    [vaultId],
+  );
+
+  return { roles, setRoles };
+}


### PR DESCRIPTION
## Summary
- New `TagRoles` primitive (`src/lib/vault/tag-roles.ts`) — per-vault JSON in `localStorage` (`lens:tag-roles:<vaultId>`), mirrors the scribe-settings pattern. Roles: `pinned`, `archived`, `captureVoice`, `captureText`.
- `TagRolesSection` in Settings with inputs for each role, shared `<datalist>` autocomplete from the vault's existing tag list, Save / Reset, and a "changes apply to new notes only" note.
- `TextCapture` and `MemoCapture` now read defaults from `useTagRoles(vaultId)` instead of hardcoding `"quick"` / `"memo"`.
- `CLAUDE.md` documents the pattern so future role-bearing features (pinned/archived views, etc.) reuse this primitive.

## Notes on defaults
Per the issue spec, the voice-capture default is `voice` (the issue listed this as an explicit default). Existing code used the literal `"memo"`; any current user who wants that back can set it in Settings. Pinned/archived defaults are the role names themselves, matching the issue.

## Out of scope
- First-connect "scan existing tags and suggest role mappings" UX. The scope bullets in the issue cover the store, the settings section, and the capture refactor — the suggest-on-first-connect UX is a nice-to-have and a good follow-up. Users can open Settings after first connect to customize.

Closes #23

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 338/338 (49 files). Adds tag-roles storage tests (8) and two Settings UI tests for TagRolesSection (save overrides, reset to defaults).
- [x] `bun run build` — clean
- [ ] Manual: change a role in Settings; verify next text + voice capture uses the new tag; verify existing notes are not retagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)