### PR TITLE
Add tag rename + merge (client-orchestrated)

### DIFF
--- a/src/app/routes/Tags.test.tsx
+++ b/src/app/routes/Tags.test.tsx
@@ -91,8 +91,8 @@ describe("Tags route", () => {
       </Wrap>,
     );
     const list = await screen.findByRole("list", { name: /tag list/i });
-    const items = within(list).getAllByRole("listitem");
-    expect(items.map((el) => el.textContent ?? "")).toEqual(["canon9", "idea5", "daily2"]);
+    const links = within(list).getAllByRole("link");
+    expect(links.map((el) => el.textContent ?? "")).toEqual(["#canon9", "#idea5", "#daily2"]);
   });
 
   it("filters tags by the search input", async () => {
@@ -158,6 +158,82 @@ describe("Tags route", () => {
       </Wrap>,
     );
     expect(await screen.findByText(/no tags in this vault yet/i)).toBeInTheDocument();
+  });
+
+  it("rename button opens a dialog and runs the rename flow", async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    const impl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      calls.push({ url, method, body });
+      if (url.endsWith("/api/tags") && method === "GET") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [{ name: "work", count: 2 }],
+        } as Response;
+      }
+      if (url.includes("/api/notes?") && url.includes("tag=work")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            { id: "n1", createdAt: "2026-04-18T00:00:00Z", tags: ["work"] },
+            { id: "n2", createdAt: "2026-04-18T00:00:00Z", tags: ["work"] },
+          ],
+        } as Response;
+      }
+      if (method === "PATCH") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ id: "x", tags: ["projects"] }),
+        } as Response;
+      }
+      if (method === "DELETE") {
+        return { ok: true, status: 204, json: async () => undefined } as Response;
+      }
+      return { ok: true, status: 200, json: async () => [] } as Response;
+    });
+    vi.stubGlobal("fetch", impl);
+
+    render(
+      <Wrap>
+        <Tags />
+      </Wrap>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /rename tag work/i }));
+    const input = await screen.findByLabelText(/new tag name/i);
+    fireEvent.change(input, { target: { value: "projects" } });
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+    await waitFor(() => {
+      expect(calls.some((c) => c.method === "PATCH")).toBe(true);
+    });
+    const patches = calls.filter((c) => c.method === "PATCH");
+    expect(patches).toHaveLength(2);
+    expect(patches[0]?.body).toEqual({ tags: { add: ["projects"], remove: ["work"] } });
+  });
+
+  it("merge requires 2+ selected tags before the merge button enables", async () => {
+    installFetch({
+      tags: [
+        { name: "alpha", count: 1 },
+        { name: "beta", count: 1 },
+      ],
+    });
+    render(
+      <Wrap>
+        <Tags />
+      </Wrap>,
+    );
+    await screen.findByRole("link", { name: /alpha/i });
+    fireEvent.click(screen.getByRole("checkbox", { name: /select tag alpha/i }));
+    expect(screen.getByRole("button", { name: /merge into/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole("checkbox", { name: /select tag beta/i }));
+    expect(screen.getByRole("button", { name: /merge into/i })).toBeEnabled();
   });
 
   it("shows the filtered-empty state when filter matches nothing", async () => {

--- a/src/app/routes/Tags.tsx
+++ b/src/app/routes/Tags.tsx
@@ -1,6 +1,8 @@
-import { useTags, useVaultStore } from "@/lib/vault";
+import { TagRenameDialog } from "@/components/TagRenameDialog";
+import { useMergeTags, useRenameTag, useTags, useVaultStore } from "@/lib/vault";
 import { VaultAuthError } from "@/lib/vault/client";
 import type { TagSummary } from "@/lib/vault/types";
+import { useSync } from "@/providers/SyncProvider";
 import { useMemo, useState } from "react";
 import { Link, Navigate } from "react-router";
 
@@ -9,15 +11,37 @@ type SortMode = "count" | "alpha";
 export function Tags() {
   const activeVault = useVaultStore((s) => s.getActiveVault());
   const tags = useTags();
+  const { isOnline } = useSync();
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<SortMode>("count");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [renameTarget, setRenameTarget] = useState<string | null>(null);
+  const [mergeOpen, setMergeOpen] = useState(false);
+
+  const renameMut = useRenameTag();
+  const mergeMut = useMergeTags();
 
   const visible = useMemo(
     () => filterAndSort(tags.data ?? [], search, sort),
     [tags.data, search, sort],
   );
+  const tagNames = useMemo(() => (tags.data ?? []).map((t) => t.name), [tags.data]);
+
+  const toggleSelected = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelected(new Set());
 
   if (!activeVault) return <Navigate to="/" replace />;
+
+  const selectedCount = selected.size;
+  const offline = !isOnline;
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-10">
@@ -42,27 +66,55 @@ export function Tags() {
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         aria-label="Filter tags"
-        className="mb-6 w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-fg focus:border-accent focus:outline-none"
+        className="mb-4 w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-fg focus:border-accent focus:outline-none"
       />
 
+      {selectedCount > 0 ? (
+        <div
+          className="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-accent/30 bg-accent/5 px-3 py-2 text-sm"
+          aria-label="Tag selection actions"
+        >
+          <span className="text-fg-muted">
+            {selectedCount} selected: {Array.from(selected).join(", ")}
+          </span>
+          <button
+            type="button"
+            onClick={() => setMergeOpen(true)}
+            disabled={selectedCount < 2 || offline}
+            className="rounded-md bg-accent px-3 py-1 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-40"
+          >
+            Merge into…
+          </button>
+          <button
+            type="button"
+            onClick={clearSelection}
+            className="text-xs text-fg-muted hover:text-accent"
+          >
+            Clear
+          </button>
+        </div>
+      ) : null}
+
       {tags.isPending ? (
-        <SkeletonChips />
+        <SkeletonRows />
       ) : tags.isError ? (
         <ErrorBlock error={tags.error} />
       ) : visible.length === 0 ? (
         <EmptyBlock filtering={search.trim().length > 0} hasAny={(tags.data ?? []).length > 0} />
       ) : (
-        <ul className="flex flex-wrap gap-2" aria-label="Tag list">
+        <ul
+          className="divide-y divide-border rounded-md border border-border bg-card"
+          aria-label="Tag list"
+        >
           {visible.map((t) => (
-            <li key={t.name}>
-              <Link
-                to={`/notes?tag=${encodeURIComponent(t.name)}`}
-                className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-sm text-fg hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-accent"
-              >
-                <span>{t.name}</span>
-                <span className="text-xs text-fg-dim">{t.count}</span>
-              </Link>
-            </li>
+            <TagRow
+              key={t.name}
+              tag={t}
+              selected={selected.has(t.name)}
+              onToggle={() => toggleSelected(t.name)}
+              onRename={() => setRenameTarget(t.name)}
+              offline={offline}
+            />
           ))}
         </ul>
       )}
@@ -72,7 +124,88 @@ export function Tags() {
           {visible.length} / {tags.data.length} tag{tags.data.length === 1 ? "" : "s"}
         </p>
       ) : null}
+
+      {renameTarget !== null ? (
+        <TagRenameDialog
+          mode="rename"
+          sources={[renameTarget]}
+          tagOptions={tagNames}
+          onClose={() => setRenameTarget(null)}
+          pending={renameMut.isPending}
+          offline={offline}
+          onRun={async (target) => {
+            const res = await renameMut.mutateAsync({ oldName: renameTarget, newName: target });
+            if (res.failed.length === 0) setRenameTarget(null);
+            return res;
+          }}
+        />
+      ) : null}
+
+      {mergeOpen ? (
+        <TagRenameDialog
+          mode="merge"
+          sources={Array.from(selected)}
+          tagOptions={tagNames}
+          onClose={() => setMergeOpen(false)}
+          pending={mergeMut.isPending}
+          offline={offline}
+          onRun={async (target) => {
+            const res = await mergeMut.mutateAsync({
+              sources: Array.from(selected),
+              target,
+            });
+            const anyFailed = res.some((r) => r.failed.length > 0);
+            if (!anyFailed) {
+              setMergeOpen(false);
+              clearSelection();
+            }
+            return res;
+          }}
+        />
+      ) : null}
     </div>
+  );
+}
+
+function TagRow({
+  tag,
+  selected,
+  onToggle,
+  onRename,
+  offline,
+}: {
+  tag: TagSummary;
+  selected: boolean;
+  onToggle(): void;
+  onRename(): void;
+  offline: boolean;
+}) {
+  return (
+    <li className="flex items-center gap-3 px-3 py-2 text-sm">
+      <input
+        type="checkbox"
+        checked={selected}
+        onChange={onToggle}
+        aria-label={`Select tag ${tag.name}`}
+        className="accent-accent"
+      />
+      <Link
+        to={`/notes?tag=${encodeURIComponent(tag.name)}`}
+        className="flex flex-1 items-baseline gap-2 text-fg hover:text-accent focus-visible:outline-2 focus-visible:outline-accent"
+      >
+        <span className="font-mono">#{tag.name}</span>
+        <span className="text-xs text-fg-dim">{tag.count}</span>
+      </Link>
+      <button
+        type="button"
+        onClick={onRename}
+        disabled={offline}
+        className="text-xs text-fg-muted hover:text-accent disabled:opacity-40"
+        aria-label={`Rename tag ${tag.name}`}
+      >
+        Rename
+      </button>
+    </li>
   );
 }
 
@@ -88,14 +221,14 @@ function filterAndSort(tags: TagSummary[], search: string, sort: SortMode): TagS
   return sorted;
 }
 
-function SkeletonChips() {
+function SkeletonRows() {
   return (
-    <div className="flex flex-wrap gap-2" aria-busy="true">
-      {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
-        <div
-          key={i}
-          className="h-8 w-24 animate-pulse rounded-full border border-border bg-card/60"
-        />
+    <div
+      className="divide-y divide-border rounded-md border border-border bg-card"
+      aria-busy="true"
+    >
+      {[0, 1, 2, 3, 4].map((i) => (
+        <div key={i} className="h-10 animate-pulse bg-card/60" />
       ))}
     </div>
   );

--- a/src/components/TagRenameDialog.tsx
+++ b/src/components/TagRenameDialog.tsx
@@ -1,0 +1,232 @@
+import { useToastStore } from "@/lib/toast/store";
+import { VaultAuthError } from "@/lib/vault/client";
+import type { TagMutationResult } from "@/lib/vault/tag-mutations";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+
+// Shared confirm-dialog for rename (one source → target) and merge
+// (many sources → target). Both operations share a partial-failure UX:
+// after a successful but imperfect run, we hold the dialog open to show
+// per-note errors rather than toast-and-close.
+
+interface Props {
+  mode: "rename" | "merge";
+  sources: string[];
+  tagOptions: string[];
+  onClose(): void;
+  onRun(target: string): Promise<TagMutationResult | TagMutationResult[]>;
+  pending: boolean;
+  offline: boolean;
+}
+
+export function TagRenameDialog({
+  mode,
+  sources,
+  tagOptions,
+  onClose,
+  onRun,
+  pending,
+  offline,
+}: Props) {
+  const pushToast = useToastStore((s) => s.push);
+  const datalistId = useId();
+  const [target, setTarget] = useState(mode === "rename" ? (sources[0] ?? "") : "");
+  const [err, setErr] = useState<string | null>(null);
+  const [results, setResults] = useState<TagMutationResult[] | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const cleanTarget = target.trim().replace(/^#/, "");
+  const canConfirm =
+    !pending &&
+    !offline &&
+    cleanTarget.length > 0 &&
+    !(mode === "rename" && cleanTarget === sources[0]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!canConfirm) return;
+    setErr(null);
+    try {
+      const res = await onRun(cleanTarget);
+      const arr = Array.isArray(res) ? res : [res];
+      const anyFailed = arr.some((r) => r.failed.length > 0);
+      if (anyFailed) {
+        setResults(arr);
+        return;
+      }
+      const total = arr.reduce((s, r) => s + r.succeeded, 0);
+      pushToast(
+        mode === "rename"
+          ? `Renamed on ${total} note${total === 1 ? "" : "s"}.`
+          : `Merged into #${cleanTarget} on ${total} note${total === 1 ? "" : "s"}.`,
+        "success",
+      );
+      onClose();
+    } catch (e) {
+      if (e instanceof VaultAuthError) {
+        setErr("Session expired. Reconnect to retry.");
+      } else {
+        setErr(e instanceof Error ? e.message : "Operation failed.");
+      }
+    }
+  }, [canConfirm, cleanTarget, mode, onClose, onRun, pushToast]);
+
+  const title = mode === "rename" ? "Rename tag" : `Merge ${sources.length} tags`;
+
+  return (
+    <dialog
+      open
+      aria-labelledby="tag-op-title"
+      className="fixed inset-0 z-40 m-0 flex h-full max-h-full w-full max-w-full items-center justify-center bg-black/60 p-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-md rounded-md border border-border bg-card p-6 shadow-xl">
+        <h2 id="tag-op-title" className="mb-2 font-serif text-xl text-fg">
+          {title}
+        </h2>
+        {results ? (
+          <PartialFailureBody results={results} mode={mode} onClose={onClose} />
+        ) : (
+          <>
+            <p className="mb-3 text-sm text-fg-muted">
+              {mode === "rename" ? (
+                <>
+                  Rename <Chip>{sources[0]}</Chip> on every note that carries it. Notes that already
+                  have the new tag will end up with one copy.
+                </>
+              ) : (
+                <>
+                  Combine{" "}
+                  {sources.map((s, i) => (
+                    <span key={s}>
+                      <Chip>{s}</Chip>
+                      {i < sources.length - 1 ? ", " : ""}
+                    </span>
+                  ))}{" "}
+                  into one tag. The originals are removed.
+                </>
+              )}{" "}
+              Changes apply now — there's no undo, but the operation is idempotent if you retry.
+            </p>
+            <label className="mb-3 block text-sm">
+              <span className="mb-1 block text-fg-muted">
+                {mode === "rename" ? "New tag name" : "Target tag"}
+              </span>
+              <input
+                ref={inputRef}
+                type="text"
+                value={target}
+                onChange={(e) => setTarget(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && canConfirm) void handleConfirm();
+                }}
+                list={datalistId}
+                aria-label={mode === "rename" ? "New tag name" : "Merge target tag"}
+                spellCheck={false}
+                autoCapitalize="none"
+                autoCorrect="off"
+                className="w-full rounded-md border border-border bg-bg/40 px-2.5 py-1.5 font-mono text-sm text-fg focus:border-accent focus:outline-none"
+                autoComplete="off"
+              />
+              <datalist id={datalistId}>
+                {tagOptions.map((t) => (
+                  <option key={t} value={t} />
+                ))}
+              </datalist>
+            </label>
+            {offline ? (
+              <p className="mb-3 text-sm text-amber-300">
+                Offline — tag operations need a live vault connection.
+              </p>
+            ) : null}
+            {err ? (
+              <p role="alert" className="mb-3 text-sm text-red-400">
+                {err}
+              </p>
+            ) : null}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-fg-muted hover:text-fg"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleConfirm()}
+                disabled={!canConfirm}
+                className="rounded-md bg-accent px-4 py-1.5 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-40"
+              >
+                {pending
+                  ? mode === "rename"
+                    ? "Renaming…"
+                    : "Merging…"
+                  : mode === "rename"
+                    ? "Rename"
+                    : "Merge"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </dialog>
+  );
+}
+
+function PartialFailureBody({
+  results,
+  mode,
+  onClose,
+}: {
+  results: TagMutationResult[];
+  mode: "rename" | "merge";
+  onClose(): void;
+}) {
+  const succeeded = results.reduce((s, r) => s + r.succeeded, 0);
+  const failed = results.flatMap((r) => r.failed);
+  return (
+    <>
+      <p className="mb-3 text-sm text-fg-muted">
+        {mode === "rename" ? "Rename" : "Merge"} finished with errors. {succeeded} note
+        {succeeded === 1 ? "" : "s"} updated, {failed.length} failed. Retrying is safe — the
+        successful notes won't be touched again.
+      </p>
+      <ul className="mb-3 max-h-48 space-y-1 overflow-y-auto rounded-md border border-border bg-bg/40 p-2 text-xs">
+        {failed.map((f, i) => (
+          <li key={`${f.noteId}-${i}`} className="font-mono text-red-400">
+            <span className="text-fg-muted">{f.path ?? f.noteId}:</span> {f.error}
+          </li>
+        ))}
+      </ul>
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md bg-accent px-4 py-1.5 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Close
+        </button>
+      </div>
+    </>
+  );
+}
+
+function Chip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="rounded bg-bg/60 px-1 py-0.5 font-mono text-xs text-fg">#{children}</span>
+  );
+}

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -182,6 +182,12 @@ export class VaultClient {
     return this.request<TagSummary[]>("/api/tags");
   }
 
+  async deleteTag(name: string): Promise<void> {
+    await this.request<undefined>(`/api/tags/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    });
+  }
+
   uploadStorageFile(
     file: File,
     opts: {

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -9,6 +9,7 @@ export * from "./probe";
 export * from "./queries";
 export * from "./storage";
 export * from "./store";
+export * from "./tag-mutations";
 export * from "./tag-roles";
 export * from "./types";
 export * from "./url";

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -14,6 +14,7 @@ import {
 import { type NoteQueryState, buildNoteQueryParams } from "./note-query";
 import { loadToken } from "./storage";
 import { useVaultStore } from "./store";
+import { type TagMutationResult, mergeTags, renameTag } from "./tag-mutations";
 import type { Note, NoteAttachment } from "./types";
 
 export function useActiveVaultClient(): VaultClient | null {
@@ -255,6 +256,45 @@ export function useDeleteAttachment() {
     },
     onSuccess: (args) => {
       qc.invalidateQueries({ queryKey: ["note", activeId, args.noteId] });
+    },
+  });
+}
+
+export function useRenameTag() {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (args: { oldName: string; newName: string }): Promise<TagMutationResult> => {
+      if (!client) throw new Error("No active vault");
+      return renameTag(client, args.oldName, args.newName);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["tags", activeId] });
+      qc.invalidateQueries({ queryKey: ["notes", activeId] });
+      qc.invalidateQueries({ queryKey: ["vaultInfo", activeId] });
+    },
+  });
+}
+
+export function useMergeTags() {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (args: {
+      sources: string[];
+      target: string;
+    }): Promise<TagMutationResult[]> => {
+      if (!client) throw new Error("No active vault");
+      return mergeTags(client, args.sources, args.target);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["tags", activeId] });
+      qc.invalidateQueries({ queryKey: ["notes", activeId] });
+      qc.invalidateQueries({ queryKey: ["vaultInfo", activeId] });
     },
   });
 }

--- a/src/lib/vault/tag-mutations.test.ts
+++ b/src/lib/vault/tag-mutations.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "vitest";
+import { VaultClient } from "./client";
+import { mergeTags, renameTag } from "./tag-mutations";
+import type { Note } from "./types";
+
+function fakeNote(id: string, tags: string[], path?: string): Note {
+  return {
+    id,
+    path,
+    tags,
+    createdAt: "2026-04-18T00:00:00Z",
+  };
+}
+
+function mockFetchSequence(responders: Array<(url: string, init: RequestInit) => Response>) {
+  let i = 0;
+  return vi.fn<typeof fetch>(async (input, init) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    const res = responders[i]?.(url, init ?? {});
+    i += 1;
+    if (!res) throw new Error(`No fetch responder for call #${i}`);
+    return res;
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+function errorResponse(status: number, message: string): Response {
+  return {
+    ok: false,
+    status,
+    json: async () => ({ message }),
+    text: async () => message,
+  } as Response;
+}
+
+describe("renameTag", () => {
+  it("swaps tag on every matching note and deletes the source row", async () => {
+    const notes = [fakeNote("n1", ["work"]), fakeNote("n2", ["work", "urgent"])];
+    const updateCalls: Array<{ url: string; body: unknown }> = [];
+    const fetchImpl = mockFetchSequence([
+      // list notes with tag=work
+      (url) => {
+        expect(url).toContain("tag=work");
+        return jsonResponse(notes);
+      },
+      // patch n1
+      (url, init) => {
+        updateCalls.push({ url, body: JSON.parse(init.body as string) });
+        return jsonResponse({ ...notes[0], tags: ["projects"] });
+      },
+      // patch n2
+      (url, init) => {
+        updateCalls.push({ url, body: JSON.parse(init.body as string) });
+        return jsonResponse({ ...notes[1], tags: ["projects", "urgent"] });
+      },
+      // delete /api/tags/work
+      (url, init) => {
+        expect(url).toContain("/api/tags/work");
+        expect(init.method).toBe("DELETE");
+        return jsonResponse(undefined, 204);
+      },
+    ]);
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl,
+    });
+
+    const result = await renameTag(client, "work", "projects");
+    expect(result).toEqual({ total: 2, succeeded: 2, failed: [], sourceDeleted: true });
+    expect(updateCalls).toHaveLength(2);
+    expect(updateCalls[0]?.body).toEqual({
+      tags: { add: ["projects"], remove: ["work"] },
+    });
+  });
+
+  it("strips leading # and trims whitespace from both tag names", async () => {
+    const fetchImpl = mockFetchSequence([
+      (url) => {
+        expect(url).toContain("tag=work");
+        return jsonResponse([]);
+      },
+    ]);
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl,
+    });
+
+    const result = await renameTag(client, "  #work  ", "#projects");
+    expect(result.total).toBe(0);
+    expect(result.sourceDeleted).toBe(false);
+  });
+
+  it("returns partial failure when a note PATCH errors and skips the tag delete", async () => {
+    const notes = [fakeNote("n1", ["work"]), fakeNote("n2", ["work"], "x.md")];
+    const fetchImpl = mockFetchSequence([
+      () => jsonResponse(notes),
+      () => jsonResponse({ ...notes[0], tags: ["projects"] }),
+      () => errorResponse(500, "boom"),
+    ]);
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl,
+    });
+
+    const result = await renameTag(client, "work", "projects");
+    expect(result.total).toBe(2);
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.noteId).toBe("n2");
+    expect(result.failed[0]?.path).toBe("x.md");
+    expect(result.sourceDeleted).toBe(false);
+  });
+
+  it("treats a 404 on the final tag delete as non-fatal", async () => {
+    const notes = [fakeNote("n1", ["work"])];
+    const fetchImpl = mockFetchSequence([
+      () => jsonResponse(notes),
+      () => jsonResponse({ ...notes[0], tags: ["projects"] }),
+      () => errorResponse(404, "gone"),
+    ]);
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl,
+    });
+
+    const result = await renameTag(client, "work", "projects");
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toHaveLength(0);
+    expect(result.sourceDeleted).toBe(false);
+  });
+
+  it("rejects when source and target are the same after normalization", async () => {
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl: vi.fn(),
+    });
+    await expect(renameTag(client, "work", "#work")).rejects.toThrow(/same/);
+  });
+
+  it("rejects empty tag names", async () => {
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl: vi.fn(),
+    });
+    await expect(renameTag(client, "   ", "new")).rejects.toThrow(/empty/i);
+    await expect(renameTag(client, "old", " # ")).rejects.toThrow(/empty/i);
+  });
+});
+
+describe("mergeTags", () => {
+  it("runs rename for each source and returns a result per source", async () => {
+    const fetchImpl = mockFetchSequence([
+      () => jsonResponse([fakeNote("a", ["alpha"])]),
+      () => jsonResponse({ id: "a", tags: ["greek"] }),
+      () => jsonResponse(undefined, 204),
+      () => jsonResponse([fakeNote("b", ["beta"]), fakeNote("c", ["beta"])]),
+      () => jsonResponse({ id: "b", tags: ["greek"] }),
+      () => jsonResponse({ id: "c", tags: ["greek"] }),
+      () => jsonResponse(undefined, 204),
+    ]);
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl,
+    });
+
+    const results = await mergeTags(client, ["alpha", "beta"], "greek");
+    expect(results).toHaveLength(2);
+    expect(results[0]?.total).toBe(1);
+    expect(results[1]?.total).toBe(2);
+  });
+
+  it("skips sources equal to the target after normalization", async () => {
+    const fetchImpl = mockFetchSequence([
+      () => jsonResponse([fakeNote("a", ["alpha"])]),
+      () => jsonResponse({ id: "a", tags: ["target"] }),
+      () => jsonResponse(undefined, 204),
+    ]);
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl,
+    });
+
+    const results = await mergeTags(client, ["alpha", "#target", "target"], "target");
+    expect(results).toHaveLength(1);
+  });
+
+  it("rejects when no valid source tags remain", async () => {
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl: vi.fn(),
+    });
+    await expect(mergeTags(client, ["target", "#target"], "target")).rejects.toThrow(/no source/i);
+  });
+
+  it("rejects an empty target", async () => {
+    const client = new VaultClient({
+      vaultUrl: "http://v",
+      accessToken: "t",
+      fetchImpl: vi.fn(),
+    });
+    await expect(mergeTags(client, ["a"], "  ")).rejects.toThrow(/empty/i);
+  });
+});

--- a/src/lib/vault/tag-mutations.ts
+++ b/src/lib/vault/tag-mutations.ts
@@ -1,0 +1,99 @@
+import type { VaultClient } from "./client";
+
+// Client-orchestrated tag rename/merge.
+//
+// The vault HTTP API has no "rename tag" or "merge tags" endpoint — tags are
+// inferred from notes, not first-class rows. So these helpers do the work from
+// the client: query every note carrying the source tag, PATCH each note to
+// swap tags, then drop the now-orphaned tag row.
+//
+// Trade-offs worth knowing at the call site:
+//   - N+1 PATCHes. A vault with 500 notes tagged "work" makes 500 round trips.
+//     Fine for a background-ish user action on an UI with a spinner; not fine
+//     as a hot path.
+//   - No atomicity. A failure halfway through leaves some notes retagged and
+//     some not. Callers should surface partial results and let the user retry
+//     — re-running the operation is idempotent because the remove delta is a
+//     no-op on notes that no longer carry the source tag.
+//   - Requires online. Callers must gate on navigator.onLine; there's no
+//     offline queue for tag-level ops because partial progress on reconnect
+//     would be even more confusing than a synchronous partial failure.
+
+export interface TagMutationResult {
+  total: number;
+  succeeded: number;
+  failed: Array<{ noteId: string; path?: string; error: string }>;
+  sourceDeleted: boolean;
+}
+
+function normalize(name: string): string {
+  return name.trim().replace(/^#/, "");
+}
+
+// Rename every occurrence of `oldName` to `newName`. If `newName` already
+// exists on some notes, those notes end up with only one copy (tags are a
+// set in the vault).
+export async function renameTag(
+  client: VaultClient,
+  oldName: string,
+  newName: string,
+): Promise<TagMutationResult> {
+  const source = normalize(oldName);
+  const target = normalize(newName);
+  if (!source) throw new Error("Source tag is empty.");
+  if (!target) throw new Error("Target tag is empty.");
+  if (source === target) throw new Error("Source and target tags are the same.");
+
+  const params = new URLSearchParams({ tag: source, limit: "10000" });
+  const notes = await client.queryNotes(params);
+
+  const failed: TagMutationResult["failed"] = [];
+  let succeeded = 0;
+  for (const note of notes) {
+    try {
+      await client.updateNote(note.id, {
+        tags: { add: [target], remove: [source] },
+      });
+      succeeded += 1;
+    } catch (e) {
+      failed.push({
+        noteId: note.id,
+        path: note.path,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  let sourceDeleted = false;
+  if (failed.length === 0 && notes.length > 0) {
+    try {
+      await client.deleteTag(source);
+      sourceDeleted = true;
+    } catch {
+      // Tag row drop is best-effort — the vault may have already pruned it
+      // once the last note was retagged. Not worth surfacing as a failure.
+    }
+  }
+
+  return { total: notes.length, succeeded, failed, sourceDeleted };
+}
+
+// Merge one or more source tags into a single target. Implemented as a
+// sequence of renames so the semantics match exactly and partial failures
+// are per-source.
+export async function mergeTags(
+  client: VaultClient,
+  sources: string[],
+  target: string,
+): Promise<TagMutationResult[]> {
+  const normTarget = normalize(target);
+  if (!normTarget) throw new Error("Target tag is empty.");
+  const normSources = sources.map(normalize).filter((s) => s && s !== normTarget);
+  if (normSources.length === 0) throw new Error("No source tags to merge.");
+
+  const results: TagMutationResult[] = [];
+  for (const source of normSources) {
+    results.push(await renameTag(client, source, normTarget));
+  }
+  return results;
+}


### PR DESCRIPTION
Closes #24.

## Summary
- `src/lib/vault/tag-mutations.ts` — `renameTag(client, old, new)` queries all notes with the source tag, PATCHes each with `tags: { add, remove }`, then DELETEs the now-empty tag row. `mergeTags` is a thin loop over rename.
- `VaultClient.deleteTag(name)` — new thin wrapper around `DELETE /api/tags/:name`.
- `useRenameTag` / `useMergeTags` hooks — invalidate `tags`, `notes`, and `vaultInfo` on success.
- Tags route — each row has a Rename button; multi-select checkboxes surface a "Merge into…" toolbar when 2+ are selected.
- `TagRenameDialog` — shared confirm dialog with datalist autocomplete, Escape-to-close, backdrop-to-close, and a partial-failure view that enumerates per-note errors with retry affordance.

## Why client-orchestrated
The vault HTTP API has no rename or merge endpoint — tags are inferred from notes. The delta shape on `UpdateNotePayload.tags` (`{ add, remove }`) is the key enabler: retrying after a partial failure is safe because remove-on-missing is a no-op.

Trade-offs to know:
- **N+1 PATCHes.** A tag on 500 notes = 500 round trips. Fine for an interactive dialog; not a hot path.
- **No atomicity.** Failures mid-run leave some notes retagged and some not. The dialog keeps the error list visible so the user can retry.
- **Online-only.** The rename/merge buttons disable when `isOnline` is false. Tag-level ops don't map cleanly to the per-note offline queue, and partial progress on reconnect would be more confusing than the current synchronous behavior.

## Test plan
- [x] `tag-mutations.test.ts` — happy path, normalization (#/whitespace), partial failure skips tag delete, 404 on tag delete is non-fatal, guards for same-name and empty inputs, merge loops correctly and skips target-as-source
- [x] `Tags.test.tsx` — rename dialog patches every matching note with the correct `{ add, remove }` body; merge button gates on ≥2 selections
- [x] typecheck, lint, 350/350 tests, build clean

## Follow-ups worth filing later (not in this PR)
- If vault ever ships a native rename endpoint, the client orchestrator becomes a fallback and we get atomicity for free.
- Progress bar + "cancel remaining" button for very large renames — current UI just shows a spinner on the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)