### PR TITLE
Add Cmd+K quick switch for notes, tags, and commands

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,5 @@
 import { Header } from "@/components/Header";
+import { QuickSwitchMount } from "@/components/QuickSwitchMount";
 import { Toaster } from "@/components/Toaster";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { QueryProvider } from "@/providers/QueryProvider";
@@ -26,6 +27,7 @@ export function App() {
             <Toaster />
             <UpdateBanner />
             <Header />
+            <QuickSwitchMount />
             <main>
               <Routes>
                 <Route path="/" element={<Home />} />

--- a/src/app/routes/NoteView.tsx
+++ b/src/app/routes/NoteView.tsx
@@ -2,6 +2,7 @@ import { DeleteNoteButton } from "@/components/DeleteNoteButton";
 import { MarkdownView, buildWikilinkResolver } from "@/components/MarkdownView";
 import { NeighborhoodGraph } from "@/components/NeighborhoodGraph";
 import { TranscriptionStatus } from "@/components/TranscriptionStatus";
+import { pushRecent } from "@/lib/quick-switch/recents";
 import { relativeTime } from "@/lib/time";
 import { useActiveVaultClient, useNote, useVaultStore } from "@/lib/vault";
 import { VaultAuthError } from "@/lib/vault/client";
@@ -14,6 +15,10 @@ export function NoteView() {
   const decodedId = id ? decodeURIComponent(id) : undefined;
   const activeVault = useVaultStore((s) => s.getActiveVault());
   const note = useNote(decodedId);
+
+  useEffect(() => {
+    if (activeVault && decodedId) pushRecent(activeVault.id, decodedId);
+  }, [activeVault, decodedId]);
 
   if (!activeVault) return <Navigate to="/" replace />;
 

--- a/src/components/QuickSwitch.test.tsx
+++ b/src/components/QuickSwitch.test.tsx
@@ -1,0 +1,217 @@
+import { QuickSwitch } from "@/components/QuickSwitch";
+import { QuickSwitchMount } from "@/components/QuickSwitchMount";
+import { pushRecent } from "@/lib/quick-switch/recents";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      v1: {
+        id: "v1",
+        url: "http://localhost:1940",
+        name: "default",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v1",
+  });
+  localStorage.setItem(
+    "lens:token:v1",
+    JSON.stringify({ accessToken: "t", scope: "full", vault: "default" }),
+  );
+}
+
+function installFetch(notes: unknown[], tags: unknown[] = []) {
+  const impl = vi.fn<typeof fetch>(async (input) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    if (url.includes("/api/tags")) {
+      return { ok: true, status: 200, json: async () => tags, text: async () => "" } as Response;
+    }
+    return { ok: true, status: 200, json: async () => notes, text: async () => "" } as Response;
+  });
+  vi.stubGlobal("fetch", impl);
+}
+
+function LocationSpy() {
+  const loc = useLocation();
+  return <div data-testid="location">{`${loc.pathname}${loc.search}`}</div>;
+}
+
+function Wrap({ children, initial = "/" }: { children: ReactNode; initial?: string }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return (
+    <MemoryRouter initialEntries={[initial]}>
+      <QueryClientProvider client={qc}>
+        <LocationSpy />
+        <Routes>
+          <Route path="*" element={children} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("QuickSwitch", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+
+  it("filters results as the user types and navigates on Enter", async () => {
+    installFetch([
+      { id: "canon", path: "Canon/Aaron.md", createdAt: "2026-04-18T00:00:00Z" },
+      { id: "journal", path: "Journal/Day.md", createdAt: "2026-04-18T00:00:00Z" },
+    ]);
+    render(
+      <Wrap>
+        <QuickSwitch onClose={() => {}} />
+      </Wrap>,
+    );
+
+    const input = screen.getByLabelText(/quick switch query/i);
+    // Wait for the notes fetch to populate.
+    await waitFor(() => expect(screen.queryByText(/loading notes/i)).not.toBeInTheDocument());
+
+    fireEvent.change(input, { target: { value: "aaron" } });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/notes/canon"));
+  });
+
+  it("arrow keys move the selection", async () => {
+    installFetch([
+      { id: "a", path: "Alpha.md", createdAt: "2026-04-18T00:00:00Z" },
+      { id: "b", path: "Alphabet.md", createdAt: "2026-04-18T00:00:00Z" },
+    ]);
+    render(
+      <Wrap>
+        <QuickSwitch onClose={() => {}} />
+      </Wrap>,
+    );
+    const input = screen.getByLabelText(/quick switch query/i);
+    fireEvent.change(input, { target: { value: "alpha" } });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+    // Second entry gets selected.
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/notes/b"));
+  });
+
+  it("Escape closes the switcher", async () => {
+    installFetch([]);
+    const onClose = vi.fn();
+    render(
+      <Wrap>
+        <QuickSwitch onClose={onClose} />
+      </Wrap>,
+    );
+    const input = screen.getByLabelText(/quick switch query/i);
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows recent notes as the empty-query starting list", async () => {
+    pushRecent("v1", "canon", 1);
+    installFetch([
+      { id: "canon", path: "Canon/Aaron.md", createdAt: "2026-04-18T00:00:00Z" },
+      { id: "other", path: "Other.md", createdAt: "2026-04-18T00:00:00Z" },
+    ]);
+    render(
+      <Wrap>
+        <QuickSwitch onClose={() => {}} />
+      </Wrap>,
+    );
+    await waitFor(() => {
+      const options = screen.getAllByRole("option");
+      expect(options[0]?.textContent).toContain("Aaron");
+    });
+  });
+
+  it("> prefix surfaces commands — typing '>new' jumps to /new on Enter", async () => {
+    installFetch([]);
+    render(
+      <Wrap>
+        <QuickSwitch onClose={() => {}} />
+      </Wrap>,
+    );
+    const input = screen.getByLabelText(/quick switch query/i);
+    fireEvent.change(input, { target: { value: ">new" } });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/new"));
+  });
+});
+
+describe("QuickSwitchMount", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+
+  it("opens on Cmd+K and closes on a second press", async () => {
+    installFetch([]);
+    render(
+      <Wrap>
+        <QuickSwitchMount />
+      </Wrap>,
+    );
+    expect(screen.queryByLabelText(/quick switch query/i)).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(screen.getByLabelText(/quick switch query/i)).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(screen.queryByLabelText(/quick switch query/i)).not.toBeInTheDocument();
+  });
+
+  it("also opens on Ctrl+K for non-Mac users", () => {
+    installFetch([]);
+    render(
+      <Wrap>
+        <QuickSwitchMount />
+      </Wrap>,
+    );
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(screen.getByLabelText(/quick switch query/i)).toBeInTheDocument();
+  });
+
+  it("does not hijack a plain 'k' keypress", () => {
+    installFetch([]);
+    render(
+      <Wrap>
+        <QuickSwitchMount />
+      </Wrap>,
+    );
+    fireEvent.keyDown(window, { key: "k" });
+    expect(screen.queryByLabelText(/quick switch query/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/QuickSwitch.tsx
+++ b/src/components/QuickSwitch.tsx
@@ -1,0 +1,244 @@
+import { loadRecents } from "@/lib/quick-switch/recents";
+import { type QuickSwitchEntry, computeResults } from "@/lib/quick-switch/results";
+import { useAllNotesForSwitcher, useTags, useVaultStore } from "@/lib/vault";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+
+// Cmd+K spotlight. Opens via a global keydown (see useQuickSwitchHotkey),
+// closes on Escape, click-outside, or selection. Modal renders inside a
+// <dialog open> so native a11y semantics and focus management help.
+//
+// The results list is a flat array — commands + notes + tags interleaved
+// and ranked. Flat keeps ↑/↓/Enter simple (one selected index, always a
+// real entry). Debounce is 150ms because the compute is cheap against the
+// already-fetched note list, but pressing keys in rapid succession still
+// gets smoother renders.
+
+interface Props {
+  onClose(): void;
+}
+
+const DEBOUNCE_MS = 150;
+
+export function QuickSwitch({ onClose }: Props) {
+  const activeVaultId = useVaultStore((s) => s.activeVaultId);
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const inputId = useId();
+  const listboxId = useId();
+
+  const [query, setQuery] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [selectedIdx, setSelectedIdx] = useState(0);
+
+  const notesQuery = useAllNotesForSwitcher(true);
+  const tagsQuery = useTags();
+  const recents = useMemo(() => (activeVaultId ? loadRecents(activeVaultId) : []), [activeVaultId]);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query), DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const results = useMemo<QuickSwitchEntry[]>(
+    () =>
+      computeResults({
+        query: debounced,
+        notes: notesQuery.data ?? [],
+        tags: tagsQuery.data ?? [],
+        recents,
+      }),
+    [debounced, notesQuery.data, tagsQuery.data, recents],
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset selection when list size changes
+  useEffect(() => {
+    setSelectedIdx(0);
+  }, [results.length]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const runEntry = useCallback(
+    (entry: QuickSwitchEntry) => {
+      if (entry.kind === "note") {
+        navigate(`/notes/${encodeURIComponent(entry.id)}`);
+      } else if (entry.kind === "tag") {
+        navigate(`/notes?tag=${encodeURIComponent(entry.name)}`);
+      } else {
+        navigate(entry.action.to);
+      }
+      onClose();
+    },
+    [navigate, onClose],
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIdx((i) => Math.min(results.length - 1, i + 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIdx((i) => Math.max(0, i - 1));
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        const entry = results[selectedIdx];
+        if (entry) runEntry(entry);
+        return;
+      }
+    },
+    [results, selectedIdx, runEntry, onClose],
+  );
+
+  useEffect(() => {
+    const selectedEl = listRef.current?.querySelector<HTMLElement>(
+      `[data-qs-idx="${selectedIdx}"]`,
+    );
+    // scrollIntoView is missing in jsdom; guard so tests don't throw.
+    selectedEl?.scrollIntoView?.({ block: "nearest" });
+  }, [selectedIdx]);
+
+  const loading = notesQuery.isPending;
+
+  return (
+    <dialog
+      open
+      aria-labelledby={inputId}
+      className="fixed inset-0 z-50 m-0 flex h-full max-h-full w-full max-w-full items-start justify-center bg-black/60 p-4 pt-[10vh]"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-xl rounded-md border border-border bg-card shadow-xl">
+        <input
+          id={inputId}
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Jump to… (type > for commands)"
+          aria-label="Quick switch query"
+          aria-controls={listboxId}
+          aria-activedescendant={results[selectedIdx] ? `qs-opt-${selectedIdx}` : undefined}
+          autoComplete="off"
+          spellCheck={false}
+          className="w-full rounded-t-md border-b border-border bg-transparent px-4 py-3 text-base text-fg placeholder:text-fg-dim focus:outline-none"
+        />
+        <div
+          id={listboxId}
+          ref={listRef}
+          // biome-ignore lint/a11y/useSemanticElements: combobox pattern (listbox paired with input above), not a native <select>
+          role="listbox"
+          tabIndex={-1}
+          aria-label="Quick switch results"
+          aria-live="polite"
+          className="max-h-[50vh] overflow-y-auto"
+        >
+          {loading && results.length === 0 ? (
+            <div className="px-4 py-3 text-sm text-fg-dim">Loading notes…</div>
+          ) : results.length === 0 ? (
+            <div className="px-4 py-3 text-sm text-fg-dim">
+              {query.trim().length === 0 ? "Start typing to search." : "No matches."}
+            </div>
+          ) : (
+            results.map((entry, i) => (
+              <ResultRow
+                key={entryKey(entry)}
+                entry={entry}
+                index={i}
+                selected={i === selectedIdx}
+                onPick={() => runEntry(entry)}
+                onHover={() => setSelectedIdx(i)}
+              />
+            ))
+          )}
+        </div>
+        <div className="flex items-center justify-between border-t border-border px-4 py-2 text-xs text-fg-dim">
+          <span>
+            <kbd className="rounded bg-bg/60 px-1">↑↓</kbd> navigate{" "}
+            <kbd className="rounded bg-bg/60 px-1">↵</kbd> open{" "}
+            <kbd className="rounded bg-bg/60 px-1">esc</kbd> close
+          </span>
+          <span>
+            {results.length > 0 ? `${results.length} result${results.length === 1 ? "" : "s"}` : ""}
+          </span>
+        </div>
+      </div>
+    </dialog>
+  );
+}
+
+function entryKey(e: QuickSwitchEntry): string {
+  if (e.kind === "note") return `note:${e.id}`;
+  if (e.kind === "tag") return `tag:${e.name}`;
+  return `cmd:${e.id}`;
+}
+
+function ResultRow({
+  entry,
+  index,
+  selected,
+  onPick,
+  onHover,
+}: {
+  entry: QuickSwitchEntry;
+  index: number;
+  selected: boolean;
+  onPick(): void;
+  onHover(): void;
+}) {
+  const bg = selected ? "bg-accent/10 text-fg" : "text-fg-muted";
+  return (
+    <div
+      id={`qs-opt-${index}`}
+      // biome-ignore lint/a11y/useSemanticElements: option-in-listbox combobox pattern, not a native <option>
+      role="option"
+      tabIndex={-1}
+      aria-selected={selected}
+      data-qs-idx={index}
+      onMouseEnter={onHover}
+      onMouseDown={(e) => {
+        // mouseDown (not click) so the input doesn't lose focus and close us
+        // via backdrop handling first.
+        e.preventDefault();
+        onPick();
+      }}
+      className={`flex cursor-pointer items-center gap-3 px-4 py-2 text-sm ${bg}`}
+    >
+      {entry.kind === "note" ? (
+        <>
+          <span className="text-xs uppercase tracking-wider text-fg-dim">note</span>
+          <span className="truncate font-medium">{entry.title}</span>
+          {entry.path ? (
+            <span className="ml-auto truncate font-mono text-xs text-fg-dim">{entry.path}</span>
+          ) : null}
+        </>
+      ) : entry.kind === "tag" ? (
+        <>
+          <span className="text-xs uppercase tracking-wider text-fg-dim">tag</span>
+          <span className="font-mono">#{entry.name}</span>
+          <span className="ml-auto text-xs text-fg-dim">{entry.count}</span>
+        </>
+      ) : (
+        <>
+          <span className="text-xs uppercase tracking-wider text-accent">cmd</span>
+          <span className="font-medium">{entry.label}</span>
+          <span className="ml-auto text-xs text-fg-dim">{entry.description}</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/QuickSwitchMount.tsx
+++ b/src/components/QuickSwitchMount.tsx
@@ -1,0 +1,29 @@
+import { QuickSwitch } from "@/components/QuickSwitch";
+import { useVaultStore } from "@/lib/vault";
+import { useEffect, useState } from "react";
+
+// Global Cmd/Ctrl+K listener + conditional mount of the switcher. Kept
+// separate from the switcher itself so tests can render just the dialog
+// without the global-listener side effects, and so the listener doesn't
+// have to re-run every time the switcher re-renders from inside.
+
+export function QuickSwitchMount() {
+  const [open, setOpen] = useState(false);
+  const hasActiveVault = useVaultStore((s) => s.activeVaultId !== null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      // Cmd+K on macOS, Ctrl+K elsewhere. K with no modifiers is a plain
+      // letter — should never open the switcher.
+      if (e.key === "k" && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  if (!open || !hasActiveVault) return null;
+  return <QuickSwitch onClose={() => setOpen(false)} />;
+}

--- a/src/lib/quick-switch/fuzzy.test.ts
+++ b/src/lib/quick-switch/fuzzy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { fuzzyScore } from "./fuzzy";
+
+describe("fuzzyScore", () => {
+  it("returns null when the query can't be found as a subsequence", () => {
+    expect(fuzzyScore("xyz", "abc")).toBeNull();
+    expect(fuzzyScore("ba", "abc")).toBeNull();
+  });
+
+  it("treats an empty query as a zero-score match", () => {
+    expect(fuzzyScore("", "anything")).toEqual({ score: 0, indices: [] });
+  });
+
+  it("rewards start-of-string matches over mid-string matches", () => {
+    const atStart = fuzzyScore("can", "canon/note")!;
+    const inMiddle = fuzzyScore("can", "x canon/note")!;
+    expect(atStart.score).toBeGreaterThan(inMiddle.score);
+  });
+
+  it("rewards word-boundary matches (after /, -, _, .)", () => {
+    const afterSlash = fuzzyScore("aa", "canon/alpha")!;
+    const plain = fuzzyScore("aa", "canonalpha")!;
+    // "canon/alpha" — 'a' in 'canon' (ti=1), 'a' in 'alpha' after /
+    // vs "canonalpha" — 'a' in 'canon' (ti=1), 'a' in 'alpha' (ti=5)
+    expect(afterSlash.score).toBeGreaterThan(plain.score);
+  });
+
+  it("rewards consecutive runs over scattered matches", () => {
+    const run = fuzzyScore("note", "note")!;
+    const scattered = fuzzyScore("note", "n-o-t-e")!;
+    expect(run.score).toBeGreaterThan(scattered.score);
+  });
+
+  it("is case-insensitive", () => {
+    expect(fuzzyScore("CANON", "canon/foo")).not.toBeNull();
+    expect(fuzzyScore("canon", "CANON/FOO")).not.toBeNull();
+  });
+
+  it("records the indices of the matched characters", () => {
+    const m = fuzzyScore("cno", "canon")!;
+    // c at 0, next n at 2, next o at 3 — greedy left-to-right.
+    expect(m.indices).toEqual([0, 2, 3]);
+  });
+
+  it("lightly penalizes very long targets so shorter files bubble up", () => {
+    const short = fuzzyScore("x", "x")!;
+    const long = fuzzyScore("x", `x${"a".repeat(200)}`)!;
+    expect(short.score).toBeGreaterThan(long.score);
+  });
+});

--- a/src/lib/quick-switch/fuzzy.ts
+++ b/src/lib/quick-switch/fuzzy.ts
@@ -1,0 +1,53 @@
+// Hand-rolled fuzzy scorer. Goals:
+//   - subsequence match (query chars appear in order in target, possibly with gaps)
+//   - higher score for matches at the start, at word boundaries, and in runs
+//   - returns null when no match, so callers can filter then sort by score desc
+//
+// Preferred over fuse.js because the bundle cost was unjustifiable for the
+// ~30-line scorer we actually need here.
+
+const WORD_BOUNDARY_CHARS = new Set([" ", "/", "-", "_", ".", "\\"]);
+
+export interface FuzzyMatch {
+  score: number;
+  indices: number[];
+}
+
+export function fuzzyScore(query: string, target: string): FuzzyMatch | null {
+  if (!query) return { score: 0, indices: [] };
+  if (!target) return null;
+
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+
+  let qi = 0;
+  let score = 0;
+  let lastMatchedAt = -2;
+  let prevCharBoundary = true;
+  const indices: number[] = [];
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti += 1) {
+    const tc = t[ti] ?? "";
+    if (tc === q[qi]) {
+      indices.push(ti);
+      // Start-of-string and word-boundary matches are worth more.
+      let bonus = 1;
+      if (ti === 0) bonus += 4;
+      else if (prevCharBoundary) bonus += 2;
+      // Consecutive matches build runs — weighted higher than word-boundary
+      // hops so tight substring matches outrank scattered ones.
+      if (lastMatchedAt === ti - 1) bonus += 3;
+      score += bonus;
+      lastMatchedAt = ti;
+      qi += 1;
+    }
+    prevCharBoundary = WORD_BOUNDARY_CHARS.has(tc);
+  }
+
+  if (qi < q.length) return null;
+
+  // Shorter targets beat longer ones for the same query — by a small amount.
+  score -= Math.floor(t.length / 20);
+
+  return { score, indices };
+}

--- a/src/lib/quick-switch/recents.test.ts
+++ b/src/lib/quick-switch/recents.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MAX_RECENTS, clearRecents, loadRecents, pushRecent } from "./recents";
+
+describe("recents storage", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("returns an empty array when nothing is stored", () => {
+    expect(loadRecents("v1")).toEqual([]);
+  });
+
+  it("pushes ids most-recent first", () => {
+    pushRecent("v1", "a", 100);
+    pushRecent("v1", "b", 200);
+    expect(loadRecents("v1").map((e) => e.id)).toEqual(["b", "a"]);
+  });
+
+  it("deduplicates by id — revisiting an id moves it to the front", () => {
+    pushRecent("v1", "a", 100);
+    pushRecent("v1", "b", 200);
+    pushRecent("v1", "a", 300);
+    expect(loadRecents("v1").map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("caps at MAX_RECENTS entries", () => {
+    for (let i = 0; i < MAX_RECENTS + 5; i += 1) {
+      pushRecent("v1", `n${i}`, i);
+    }
+    const got = loadRecents("v1");
+    expect(got).toHaveLength(MAX_RECENTS);
+    expect(got[0]?.id).toBe(`n${MAX_RECENTS + 4}`);
+  });
+
+  it("scopes per vaultId", () => {
+    pushRecent("v1", "a");
+    pushRecent("v2", "b");
+    expect(loadRecents("v1").map((e) => e.id)).toEqual(["a"]);
+    expect(loadRecents("v2").map((e) => e.id)).toEqual(["b"]);
+  });
+
+  it("tolerates malformed stored JSON", () => {
+    localStorage.setItem("lens:recents:v1", "not-json{");
+    expect(loadRecents("v1")).toEqual([]);
+  });
+
+  it("ignores stored entries that don't match the shape", () => {
+    localStorage.setItem(
+      "lens:recents:v1",
+      JSON.stringify([{ id: "a", viewedAt: 1 }, "bad", { id: 42 }, { id: "b", viewedAt: 2 }]),
+    );
+    expect(loadRecents("v1").map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("clearRecents removes the entry", () => {
+    pushRecent("v1", "a");
+    clearRecents("v1");
+    expect(loadRecents("v1")).toEqual([]);
+  });
+});

--- a/src/lib/quick-switch/recents.ts
+++ b/src/lib/quick-switch/recents.ts
@@ -1,0 +1,57 @@
+// Per-vault "recently viewed notes" track, used as the empty-state of the
+// Cmd+K switcher. localStorage-backed, capped so it never balloons.
+//
+// Storage shape: `lens:recents:<vaultId>` → JSON array of {id, viewedAt}.
+// Most-recent first; older entries fall off when the cap is hit.
+
+export const MAX_RECENTS = 10;
+const STORAGE_PREFIX = "lens:recents:";
+
+export interface RecentEntry {
+  id: string;
+  viewedAt: number;
+}
+
+function keyFor(vaultId: string): string {
+  return STORAGE_PREFIX + vaultId;
+}
+
+export function loadRecents(vaultId: string): RecentEntry[] {
+  try {
+    const raw = localStorage.getItem(keyFor(vaultId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (e): e is RecentEntry =>
+          typeof e === "object" &&
+          e !== null &&
+          typeof (e as RecentEntry).id === "string" &&
+          typeof (e as RecentEntry).viewedAt === "number",
+      )
+      .slice(0, MAX_RECENTS);
+  } catch {
+    return [];
+  }
+}
+
+// Push an id to the top, removing any earlier entry with the same id so the
+// list stays deduplicated.
+export function pushRecent(vaultId: string, id: string, now: number = Date.now()): void {
+  try {
+    const current = loadRecents(vaultId).filter((e) => e.id !== id);
+    const next: RecentEntry[] = [{ id, viewedAt: now }, ...current].slice(0, MAX_RECENTS);
+    localStorage.setItem(keyFor(vaultId), JSON.stringify(next));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+export function clearRecents(vaultId: string): void {
+  try {
+    localStorage.removeItem(keyFor(vaultId));
+  } catch {
+    // best-effort
+  }
+}

--- a/src/lib/quick-switch/results.test.ts
+++ b/src/lib/quick-switch/results.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { COMMANDS, computeResults } from "./results";
+
+const note = (
+  id: string,
+  extras: Partial<Parameters<typeof computeResults>[0]["notes"][number]> = {},
+) => ({
+  id,
+  createdAt: "2026-04-18T00:00:00Z",
+  ...extras,
+});
+
+describe("computeResults", () => {
+  it("returns recent notes then commands when query is empty", () => {
+    const notes = [note("n1", { path: "Canon/Aaron.md" }), note("n2", { path: "Journal/Day.md" })];
+    const results = computeResults({
+      query: "",
+      notes,
+      tags: [],
+      recents: [{ id: "n1", viewedAt: 100 }],
+    });
+    expect(results[0]).toMatchObject({ kind: "note", id: "n1" });
+    // commands after recents
+    const commandIds = results
+      .filter((r) => r.kind === "command")
+      .map((r) => (r.kind === "command" ? r.id : null));
+    expect(commandIds).toContain("new");
+    expect(commandIds).toContain("capture");
+  });
+
+  it("drops recent ids whose notes are no longer in the vault", () => {
+    const results = computeResults({
+      query: "",
+      notes: [note("n1")],
+      tags: [],
+      recents: [
+        { id: "missing", viewedAt: 200 },
+        { id: "n1", viewedAt: 100 },
+      ],
+    });
+    const noteEntries = results.filter((r) => r.kind === "note");
+    expect(noteEntries).toHaveLength(1);
+    expect(noteEntries[0]?.kind === "note" && noteEntries[0].id).toBe("n1");
+  });
+
+  it("fuzzy-matches notes by title, path, and tags", () => {
+    const notes = [
+      note("n1", { path: "Canon/Aaron.md", content: "# Aaron" }),
+      note("n2", { path: "Journal/Day.md", tags: ["daily"] }),
+      note("n3", { path: "Ideas/Music.md", content: "Notes on synths" }),
+    ];
+    const results = computeResults({ query: "aar", notes, tags: [], recents: [] });
+    expect(results[0]?.kind).toBe("note");
+    expect(results[0]?.kind === "note" && results[0].id).toBe("n1");
+  });
+
+  it("ranks title matches above path-only matches when everything else is equal", () => {
+    const notes = [
+      note("pathOnly", { path: "alpha/daily.md", content: "# Unrelated" }),
+      note("titleWins", { path: "other.md", content: "# daily" }),
+    ];
+    const results = computeResults({ query: "daily", notes, tags: [], recents: [] });
+    expect(results[0]?.kind === "note" && results[0].id).toBe("titleWins");
+  });
+
+  it("includes tag matches below note matches", () => {
+    const results = computeResults({
+      query: "daily",
+      notes: [note("n1", { path: "Daily.md" })],
+      tags: [{ name: "daily", count: 12 }],
+      recents: [],
+    });
+    expect(results.some((r) => r.kind === "tag" && r.name === "daily")).toBe(true);
+  });
+
+  it("in command mode (> prefix) surfaces only commands", () => {
+    const results = computeResults({
+      query: "> new",
+      notes: [note("n1", { path: "newborn.md" })],
+      tags: [],
+      recents: [],
+    });
+    expect(results.every((r) => r.kind === "command")).toBe(true);
+    expect(results[0]?.kind === "command" && results[0].id).toBe("new");
+  });
+
+  it("command mode 'g' picks graph as the top hit", () => {
+    const results = computeResults({ query: ">graph", notes: [], tags: [], recents: [] });
+    expect(results[0]?.kind === "command" && results[0].id).toBe("graph");
+  });
+
+  it("caps the total at 20 results", () => {
+    const notes = Array.from({ length: 50 }, (_, i) => note(`n${i}`, { path: `match${i}.md` }));
+    const results = computeResults({ query: "match", notes, tags: [], recents: [] });
+    expect(results.length).toBeLessThanOrEqual(20);
+  });
+
+  it("returns an empty list for a query that matches nothing", () => {
+    expect(
+      computeResults({
+        query: "zxqwv",
+        notes: [note("n1", { path: "a.md" })],
+        tags: [],
+        recents: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("exposes the static command list so tests can drive by id", () => {
+    expect(COMMANDS.map((c) => c.id)).toEqual(["new", "capture", "graph", "tags", "notes"]);
+  });
+});

--- a/src/lib/quick-switch/results.ts
+++ b/src/lib/quick-switch/results.ts
@@ -1,0 +1,183 @@
+import type { Note, TagSummary } from "@/lib/vault/types";
+import { fuzzyScore } from "./fuzzy";
+import type { RecentEntry } from "./recents";
+import { noteTitle } from "./title";
+
+// The switcher returns a heterogeneous list: commands first when a query
+// matches one, then notes by score, then a trailing tag section for pure-tag
+// jumps. Keeping all three in one ordered list (rather than separate sections
+// on the same view) keeps keyboard nav with ↑/↓/Enter trivial — the selected
+// index always points at a real entry.
+
+export type QuickSwitchEntry =
+  | { kind: "note"; id: string; title: string; path?: string; score: number }
+  | { kind: "tag"; name: string; count: number; score: number }
+  | {
+      kind: "command";
+      id: string;
+      label: string;
+      description: string;
+      action: { type: "navigate"; to: string };
+      score: number;
+    };
+
+export const MAX_RESULTS = 20;
+
+export const COMMANDS: Array<{
+  id: string;
+  label: string;
+  description: string;
+  keywords: string[];
+  action: { type: "navigate"; to: string };
+}> = [
+  {
+    id: "new",
+    label: "New note",
+    description: "Open the note editor",
+    keywords: ["new", "create", "compose"],
+    action: { type: "navigate", to: "/new" },
+  },
+  {
+    id: "capture",
+    label: "Capture",
+    description: "Voice or typed quick note",
+    keywords: ["capture", "voice", "memo"],
+    action: { type: "navigate", to: "/capture" },
+  },
+  {
+    id: "graph",
+    label: "Graph",
+    description: "Full-vault graph view",
+    keywords: ["graph", "map", "visualize"],
+    action: { type: "navigate", to: "/graph" },
+  },
+  {
+    id: "tags",
+    label: "Tags",
+    description: "Browse all tags",
+    keywords: ["tags"],
+    action: { type: "navigate", to: "/tags" },
+  },
+  {
+    id: "notes",
+    label: "Notes",
+    description: "All notes list",
+    keywords: ["notes", "all"],
+    action: { type: "navigate", to: "/notes" },
+  },
+];
+
+function matchesAny(keywords: string[], q: string): number | null {
+  let best: number | null = null;
+  for (const k of keywords) {
+    const m = fuzzyScore(q, k);
+    if (m && (best === null || m.score > best)) best = m.score;
+  }
+  return best;
+}
+
+// Score a note against the query using the best of (title, path, tags).
+// Path counts too so "daily/2026" jumps directly.
+function scoreNote(note: Note, q: string): number | null {
+  const title = noteTitle(note);
+  const titleMatch = fuzzyScore(q, title);
+  const pathMatch = note.path ? fuzzyScore(q, note.path) : null;
+  let best: number | null = null;
+  if (titleMatch) best = titleMatch.score + 2; // small title bias
+  if (pathMatch && (best === null || pathMatch.score > best)) best = pathMatch.score;
+  for (const tag of note.tags ?? []) {
+    const m = fuzzyScore(q, tag);
+    if (m && (best === null || m.score > best)) best = m.score;
+  }
+  return best;
+}
+
+interface Inputs {
+  query: string;
+  notes: Note[];
+  tags: TagSummary[];
+  recents: RecentEntry[];
+}
+
+export function computeResults(inputs: Inputs): QuickSwitchEntry[] {
+  const rawQuery = inputs.query.trim();
+  const isCommandMode = rawQuery.startsWith(">");
+  const q = (isCommandMode ? rawQuery.slice(1) : rawQuery).trim();
+
+  // Empty-query empty state: recent notes, then commands.
+  if (rawQuery.length === 0) {
+    const byId = new Map(inputs.notes.map((n) => [n.id, n]));
+    const recentEntries: QuickSwitchEntry[] = [];
+    for (const r of inputs.recents) {
+      const n = byId.get(r.id);
+      if (!n) continue;
+      recentEntries.push({
+        kind: "note",
+        id: n.id,
+        title: noteTitle(n),
+        path: n.path,
+        score: 0,
+      });
+    }
+    const commandEntries: QuickSwitchEntry[] = COMMANDS.map((c) => ({
+      kind: "command",
+      id: c.id,
+      label: c.label,
+      description: c.description,
+      action: c.action,
+      score: 0,
+    }));
+    return [...recentEntries, ...commandEntries].slice(0, MAX_RESULTS);
+  }
+
+  const commandMatches: QuickSwitchEntry[] = COMMANDS.flatMap((c) => {
+    const s = matchesAny([c.label, ...c.keywords], q);
+    if (s === null) return [];
+    return [
+      {
+        kind: "command" as const,
+        id: c.id,
+        label: c.label,
+        description: c.description,
+        action: c.action,
+        score: s + (isCommandMode ? 1000 : 0),
+      },
+    ];
+  });
+
+  // In command mode, show only commands.
+  if (isCommandMode) {
+    return commandMatches.sort((a, b) => b.score - a.score).slice(0, MAX_RESULTS);
+  }
+
+  const noteMatches: QuickSwitchEntry[] = inputs.notes.flatMap((n) => {
+    const s = scoreNote(n, q);
+    if (s === null) return [];
+    return [
+      {
+        kind: "note" as const,
+        id: n.id,
+        title: noteTitle(n),
+        path: n.path,
+        score: s,
+      },
+    ];
+  });
+
+  const tagMatches: QuickSwitchEntry[] = inputs.tags.flatMap((t) => {
+    const m = fuzzyScore(q, t.name);
+    if (!m) return [];
+    return [
+      {
+        kind: "tag" as const,
+        name: t.name,
+        count: t.count,
+        score: m.score,
+      },
+    ];
+  });
+
+  return [...commandMatches, ...noteMatches, ...tagMatches]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_RESULTS);
+}

--- a/src/lib/quick-switch/title.test.ts
+++ b/src/lib/quick-switch/title.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { noteTitle } from "./title";
+
+describe("noteTitle", () => {
+  it("uses the first non-empty line of content", () => {
+    expect(noteTitle({ id: "a", content: "Hello world\n\nmore text" })).toBe("Hello world");
+  });
+
+  it("strips leading markdown heading hashes", () => {
+    expect(noteTitle({ id: "a", content: "# Canon/Aaron" })).toBe("Canon/Aaron");
+    expect(noteTitle({ id: "a", content: "### Deep" })).toBe("Deep");
+  });
+
+  it("skips leading blank lines", () => {
+    expect(noteTitle({ id: "a", content: "\n\n\nfirst real line" })).toBe("first real line");
+  });
+
+  it("falls back to the last path segment without .md", () => {
+    expect(noteTitle({ id: "abc", path: "Canon/Aaron.md" })).toBe("Aaron");
+    expect(noteTitle({ id: "abc", path: "notes/journal/day.md" })).toBe("day");
+  });
+
+  it("strips .md case-insensitively", () => {
+    expect(noteTitle({ id: "abc", path: "Foo.MD" })).toBe("Foo");
+  });
+
+  it("falls back to id when there is nothing else", () => {
+    expect(noteTitle({ id: "abc" })).toBe("abc");
+  });
+
+  it("prefers content over path when both exist", () => {
+    expect(noteTitle({ id: "x", path: "Some/Path.md", content: "Content wins" })).toBe(
+      "Content wins",
+    );
+  });
+});

--- a/src/lib/quick-switch/title.ts
+++ b/src/lib/quick-switch/title.ts
@@ -1,0 +1,21 @@
+import type { Note, NoteSummary } from "@/lib/vault/types";
+
+// Extracts a human-readable title for a note. Prefers the first non-empty
+// line of content (stripped of markdown heading `#`s), falling back to the
+// last segment of the path without a `.md` suffix, then the id. Matches the
+// label the vault UI uses in list views.
+export function noteTitle(note: Pick<Note, "id" | "path" | "content"> | NoteSummary): string {
+  const content = (note as { content?: string }).content;
+  if (typeof content === "string") {
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim().replace(/^#+\s*/, "");
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  if (note.path) {
+    const segments = note.path.split("/");
+    const last = segments[segments.length - 1] ?? note.path;
+    return last.replace(/\.md$/i, "");
+  }
+  return note.id;
+}

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -57,6 +57,26 @@ export function useNotes(queryState: NoteQueryState) {
 // pagination/sampling is a future PR.
 export const VAULT_GRAPH_NOTE_CAP = 5000;
 
+// Lightweight variant for the Cmd+K switcher: no links, no content — just
+// enough to render a title/path/tags line per entry. Capped at the same N
+// as the graph so huge vaults degrade gracefully (pagination is a later PR).
+export function useAllNotesForSwitcher(enabled: boolean) {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+
+  return useQuery({
+    queryKey: ["allNotesForSwitcher", activeId],
+    enabled: !!client && enabled,
+    queryFn: () => {
+      const params = new URLSearchParams();
+      params.set("include_content", "true");
+      params.set("limit", String(VAULT_GRAPH_NOTE_CAP));
+      return client!.queryNotes(params);
+    },
+    staleTime: 60_000,
+  });
+}
+
 export function useAllNotesWithLinks() {
   const client = useActiveVaultClient();
   const activeId = useVaultStore((s) => s.activeVaultId);


### PR DESCRIPTION
Closes #26.

## Summary
- Global Cmd/Ctrl+K spotlight opens a dialog with a flat ranked list; ↑/↓ navigate, Enter opens, Esc closes.
- Entries interleave: recent notes (when query empty), fuzzy note matches, tag jumps, and command actions (`New note`, `Capture`, `Graph`, `Tags`, `Notes`). Typing `>` filters to command mode.
- Fuzzy matcher scores by subsequence with word-boundary and consecutive-run bonuses; titles derive from first non-empty content line, else path basename, else id.
- Recents persist per-vault in `localStorage` (`lens:recents:<vaultId>`, capped at 10) and update on every NoteView render.
- Notes fetched once via a new `useAllNotesForSwitcher` (60s staleTime, capped at 5000 like the graph) so the compute stays client-side.

## Why a flat list
One selected index always points at a real entry — keyboard nav stays trivial. Mixing sections would mean skipping inert headers on ↑/↓.

## Test plan
- [x] Typecheck / lint / 379 tests / build all green.
- [ ] Dev-server smoke: press Cmd+K, type a note title, Enter opens it; `>new` opens editor; `>` + letters filters commands; hover updates selection; Esc and backdrop click close; second Cmd+K toggles closed.
- [ ] Verify recents appear in the empty-state list after viewing a few notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)