### PR TITLE
Rebrand Parachute Lens to Parachute Notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# parachute-lens
+# parachute-notes
 
 ## Tag roles — the per-vault customization primitive
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Parachute Lens
+# Parachute Notes
 
-A lightweight web UI for any [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault).
+The default frontend for [Parachute](https://parachute.computer). Browse, edit, and capture in any [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault), from any device.
 
-Lens is a static single-page app that speaks directly to your vault over its HTTP API. Point it at any vault URL, do OAuth, and browse, edit, create, and visualize your notes. No opinion about how you organize your vault — just a good lens onto what's there.
+Parachute Notes is a static single-page app that speaks directly to your vault over its HTTP API. Point it at any vault URL, do OAuth, and browse, edit, create, and visualize your notes. No opinion about how you organize your vault — just a good lens onto what's there.
 
 ## Status
 
 v1 shipped; v0.2 in progress — offline-capable PWA.
 
-## Install Parachute Lens
+## Install Parachute Notes
 
-Lens is installable as a Progressive Web App. Once installed, it runs in its own window, launches from your home screen or dock, and (from v0.2 onward) keeps working when you're offline.
+Parachute Notes is installable as a Progressive Web App. Once installed, it runs in its own window, launches from your home screen or dock, and (from v0.2 onward) keeps working when you're offline.
 
-- **Desktop Chrome / Edge** — visit your hosted Lens, click **Install app** in the header, or use the browser's install icon in the address bar.
+- **Desktop Chrome / Edge** — visit your hosted Parachute Notes, click **Install app** in the header, or use the browser's install icon in the address bar.
 - **Android Chrome** — tap **Install app**, or use the browser menu → **Install app**.
-- **iOS Safari** — tap the Share icon, then **Add to Home Screen**. (Safari doesn't expose a JS install prompt, so Lens shows a hint with the steps.)
+- **iOS Safari** — tap the Share icon, then **Add to Home Screen**. (Safari doesn't expose a JS install prompt, so Parachute Notes shows a hint with the steps.)
 
 A few iOS quirks worth knowing:
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@openparachute/lens",
+      "name": "@openparachute/notes",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
     <meta name="color-scheme" content="light dark" />
     <meta
       name="description"
-      content="Parachute Lens — a lightweight web UI for any Parachute Vault."
+      content="Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault."
     />
-    <title>Parachute Lens</title>
+    <title>Parachute Notes</title>
     <script>
       (function () {
         try {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@openparachute/lens",
+  "name": "@openparachute/notes",
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "description": "A lightweight web UI for any Parachute Vault.",
+  "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParachuteComputer/parachute-lens.git"
+    "url": "https://github.com/ParachuteComputer/parachute-notes.git"
   },
   "scripts": {
     "dev": "vite",

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <title>Parachute Lens</title>
+  <title>Parachute Notes</title>
   <rect width="512" height="512" rx="96" ry="96" fill="#4a7c59" />
   <circle cx="256" cy="256" r="130" fill="none" stroke="#faf8f4" stroke-width="32" />
   <circle cx="256" cy="256" r="44" fill="#faf8f4" />

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -8,9 +8,9 @@ describe("App", () => {
     sessionStorage.clear();
   });
 
-  it("renders the Lens wordmark and the connect CTA when no vaults exist", () => {
+  it("renders the Parachute Notes wordmark and the connect CTA when no vaults exist", () => {
     render(<App />);
-    expect(screen.getByRole("link", { name: /parachute lens/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /parachute notes/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /connect a vault/i })).toBeInTheDocument();
     expect(screen.getByText(/no vault connected/i)).toBeInTheDocument();
   });

--- a/src/app/routes/AddVault.tsx
+++ b/src/app/routes/AddVault.tsx
@@ -54,7 +54,8 @@ export function AddVault() {
     <div className="mx-auto max-w-xl px-6 py-16">
       <h1 className="mb-2 font-serif text-4xl tracking-tight">Connect a vault</h1>
       <p className="mb-8 text-fg-muted">
-        Paste the URL of a Parachute Vault. You'll be taken to its consent page to authorize Lens.
+        Paste the URL of a Parachute Vault. You'll be taken to its consent page to authorize
+        Parachute Notes.
       </p>
 
       <form onSubmit={onSubmit} className="space-y-4">

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -14,9 +14,9 @@ export function Home() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-20 text-center">
       <p className="mb-8 font-serif text-xl italic text-fg-muted">
-        A lens onto any Parachute Vault.
+        The default frontend for Parachute.
       </p>
-      <h1 className="mb-4 font-serif text-5xl tracking-tight">Lens</h1>
+      <h1 className="mb-4 font-serif text-5xl tracking-tight">Notes</h1>
 
       {foundOrigin ? (
         <>

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -55,7 +55,7 @@ function InstallStateSection() {
         <span className="mr-2 inline-block rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-300">
           Installed
         </span>
-        Parachute Lens is running as an installed app on this device.
+        Parachute Notes is running as an installed app on this device.
       </p>
     </section>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,7 +27,7 @@ export function Header() {
     <header className="sticky top-0 z-10 border-b border-border bg-bg/90 backdrop-blur">
       <nav className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-5">
         <Link to="/" className="font-serif text-xl tracking-tight text-fg hover:text-accent">
-          Parachute Lens
+          Parachute Notes
         </Link>
 
         <div className="flex items-center gap-3">

--- a/src/components/InstallPrompt.test.tsx
+++ b/src/components/InstallPrompt.test.tsx
@@ -74,7 +74,7 @@ describe("InstallPrompt", () => {
     await act(async () => {
       fireEvent.click(btn);
     });
-    expect(screen.getByText(/add lens to your home screen/i)).toBeInTheDocument();
+    expect(screen.getByText(/add parachute notes to your home screen/i)).toBeInTheDocument();
     expect(screen.getByText(/share icon/i)).toBeInTheDocument();
   });
 });

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -57,14 +57,14 @@ export function InstallPrompt() {
           className="fixed inset-0 z-50 m-auto max-w-sm rounded-md border border-border bg-card p-6 text-fg shadow-lg backdrop:bg-black/40"
         >
           <h2 id="ios-install-title" className="mb-3 font-serif text-xl">
-            Add Lens to your home screen
+            Add Parachute Notes to your home screen
           </h2>
           <ol className="mb-5 list-decimal space-y-2 pl-5 text-sm text-fg-muted">
             <li>Tap the Share icon in Safari's toolbar.</li>
             <li>
               Choose <strong className="text-fg">Add to Home Screen</strong>.
             </li>
-            <li>Tap Add. Lens will open standalone from your home screen.</li>
+            <li>Tap Add. Parachute Notes will open standalone from your home screen.</li>
           </ol>
           <div className="flex justify-end">
             <button

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -19,7 +19,7 @@ export function UpdateBanner() {
 
   return (
     <output className="fixed inset-x-0 bottom-4 z-40 mx-auto flex max-w-sm items-center justify-between gap-3 rounded-md border border-border bg-card px-4 py-3 shadow-lg">
-      <p className="text-sm text-fg">A new version of Lens is available.</p>
+      <p className="text-sm text-fg">A new version of Parachute Notes is available.</p>
       <div className="flex gap-2">
         <button
           type="button"

--- a/src/lib/vault/discovery.test.ts
+++ b/src/lib/vault/discovery.test.ts
@@ -68,7 +68,7 @@ describe("registerClient", () => {
       {
         json: {
           client_id: "abc-123",
-          client_name: "Parachute Lens",
+          client_name: "Parachute Notes",
           redirect_uris: ["http://localhost/oauth/callback"],
         },
       },
@@ -86,7 +86,7 @@ describe("registerClient", () => {
     expect(init.method).toBe("POST");
     const body = JSON.parse(init.body as string);
     expect(body.redirect_uris).toEqual(["http://localhost/oauth/callback"]);
-    expect(body.client_name).toBe("Parachute Lens");
+    expect(body.client_name).toBe("Parachute Notes");
   });
 
   it("throws on non-OK response", async () => {

--- a/src/lib/vault/discovery.ts
+++ b/src/lib/vault/discovery.ts
@@ -55,7 +55,7 @@ export async function registerClient(
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
     body: JSON.stringify({
-      client_name: "Parachute Lens",
+      client_name: "Parachute Notes",
       redirect_uris: [redirectUri],
       grant_types: ["authorization_code"],
       response_types: ["code"],

--- a/src/lib/vault/oauth.test.ts
+++ b/src/lib/vault/oauth.test.ts
@@ -18,7 +18,7 @@ const validMetadata = {
 
 const clientReg = {
   client_id: "client-123",
-  client_name: "Parachute Lens",
+  client_name: "Parachute Notes",
   redirect_uris: ["http://localhost:3000/oauth/callback"],
 };
 

--- a/src/pwa-manifest.ts
+++ b/src/pwa-manifest.ts
@@ -2,9 +2,10 @@ import type { ManifestOptions } from "vite-plugin-pwa";
 
 export const PWA_MANIFEST: Partial<ManifestOptions> = {
   id: "/",
-  name: "Parachute Lens",
-  short_name: "Lens",
-  description: "A lightweight web UI for any Parachute Vault.",
+  name: "Parachute Notes",
+  short_name: "Notes",
+  description:
+    "The default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
   theme_color: "#4a7c59",
   background_color: "#faf8f4",
   display: "standalone",


### PR DESCRIPTION
Per Aaron's greenlight, flipping the web-facing surface to the new name. GitHub repo is already `parachute-notes`; this PR updates everything a user sees.

## Summary
- Wordmark (Header, Home h1), `<title>` + meta description, PWA manifest (`name: "Parachute Notes"`, `short_name: "Notes"`), SVG app icon title, update banner, iOS install prompt, AddVault copy, Settings "installed" blurb, Home tagline.
- OAuth `client_name: "Parachute Notes"` — this is what the vault shows on the consent screen during new registrations. Existing client_ids keep working.
- `package.json` → `@openparachute/notes` + new repo URL + new description.
- README rewritten with team-lead's positioning: "The default frontend for Parachute. Browse, edit, and capture in any Parachute Vault, from any device."
- `CLAUDE.md` heading renamed; body (tag-roles primitive docs) unchanged.

## What intentionally did NOT change
- IndexedDB name `parachute-lens` (`src/lib/sync/db.ts`): renaming would drop every user's offline queue on upgrade without a migration.
- `lens:*` localStorage keys (theme, tokens, recents, tag-roles, scribe): same reason — user data.
- On-disk directory `parachute-lens` and the `lens` tentacle name: team-internal, rename later at a natural pause.
- Internal comments and file paths using "lens" (e.g. `discovery.ts` comment): internal identifiers.

## short_name rationale
Chose `"Notes"` over `"Parachute"`. Specific to this product, and leaves room for future Parachute PWAs (Daily, others) to own their own home-screen presence without collision.

## Test plan
- [x] Typecheck / lint / build green.
- [x] 391 tests pass (updated `App.test.tsx`, `InstallPrompt.test.tsx`, `discovery.test.ts`, `oauth.test.ts` for literal-string assertions).
- [ ] Dev-server smoke: header shows "Parachute Notes"; install dialog shows "Add Parachute Notes"; connecting a vault shows "Parachute Notes" on the consent screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)