### PR TITLE
Add pinned and archived views

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -32,6 +32,8 @@ export function App() {
               <Routes>
                 <Route path="/" element={<Home />} />
                 <Route path="/notes" element={<Notes />} />
+                <Route path="/pinned" element={<Notes preset="pinned" />} />
+                <Route path="/archived" element={<Notes preset="archived" />} />
                 <Route path="/tags" element={<Tags />} />
                 <Route path="/new" element={<NoteNew />} />
                 <Route path="/capture" element={<Capture />} />

--- a/src/app/routes/NoteEditor.tsx
+++ b/src/app/routes/NoteEditor.tsx
@@ -5,6 +5,7 @@ import type { CodeMirrorEditorHandle } from "@/components/CodeMirrorEditor";
 import { CodeMirrorEditor } from "@/components/CodeMirrorEditor";
 import { DeleteNoteButton } from "@/components/DeleteNoteButton";
 import { MarkdownView, buildWikilinkResolver } from "@/components/MarkdownView";
+import { PinArchiveButtons } from "@/components/PinArchiveButtons";
 import { RemoveAttachmentButton } from "@/components/RemoveAttachmentButton";
 import { TagEditor, normalizeTag } from "@/components/TagEditor";
 import { useAttachmentUploader } from "@/components/useAttachmentUploader";
@@ -194,7 +195,8 @@ function EditorSurface({ note }: { note: Note }) {
               <span className="text-xs text-fg-dim">saved {relativeTime(note.updatedAt)}</span>
             )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <PinArchiveButtons note={note} />
             <DeleteNoteButton note={note} />
             <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
             <button

--- a/src/app/routes/NoteView.test.tsx
+++ b/src/app/routes/NoteView.test.tsx
@@ -1,7 +1,7 @@
 import { NoteView } from "@/app/routes/NoteView";
 import { useVaultStore } from "@/lib/vault/store";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,7 +11,7 @@ interface FetchMap {
 }
 
 function installFetch(map: FetchMap) {
-  const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
     for (const matcher of Object.keys(map)) {
       if (url.includes(matcher)) {
@@ -261,5 +261,86 @@ describe("NoteView route", () => {
     renderAt("/notes/any");
     expect(await screen.findByText(/session expired/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /reconnect/i })).toHaveAttribute("href", "/add");
+  });
+
+  it("clicking Pin PATCHes the note with the pinned role tag", async () => {
+    const fetchImpl = installFetch({
+      "/api/notes": {
+        body: {
+          id: "abc-123",
+          path: "some/note",
+          createdAt: "2026-04-16T04:30:54.177Z",
+          updatedAt: "2026-04-17T00:05:07.721Z",
+          content: "body",
+          tags: [],
+          links: [],
+          attachments: [],
+        },
+      },
+    });
+    renderAt("/notes/abc-123");
+
+    const pinBtn = await screen.findByRole("button", { name: /^☆ Pin$/ });
+    fireEvent.click(pinBtn);
+
+    await waitFor(() => {
+      const patchCall = fetchImpl.mock.calls.find((c) => {
+        const init = c[1] as RequestInit | undefined;
+        return init?.method === "PATCH";
+      });
+      expect(patchCall).toBeDefined();
+      const body = JSON.parse((patchCall![1] as RequestInit).body as string);
+      expect(body.tags).toEqual({ add: ["pinned"] });
+    });
+  });
+
+  it("shows the Pinned state and Unarchive label based on current tags", async () => {
+    installFetch({
+      "/api/notes": {
+        body: {
+          id: "n",
+          path: "note",
+          createdAt: "2026-04-16T04:30:54.177Z",
+          content: "body",
+          tags: ["pinned", "archived"],
+          links: [],
+          attachments: [],
+        },
+      },
+    });
+    renderAt("/notes/n");
+
+    expect(await screen.findByRole("button", { name: /★ Pinned/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Archived$/ })).toBeInTheDocument();
+  });
+
+  it("pressing P toggles the pinned tag", async () => {
+    const fetchImpl = installFetch({
+      "/api/notes": {
+        body: {
+          id: "k",
+          path: "keyboard",
+          createdAt: "2026-04-16T04:30:54.177Z",
+          content: "body",
+          tags: [],
+          links: [],
+          attachments: [],
+        },
+      },
+    });
+    renderAt("/notes/k");
+
+    await screen.findByRole("button", { name: /^☆ Pin$/ });
+    fireEvent.keyDown(window, { key: "p" });
+
+    await waitFor(() => {
+      const patchCall = fetchImpl.mock.calls.find((c) => {
+        const init = c[1] as RequestInit | undefined;
+        return init?.method === "PATCH";
+      });
+      expect(patchCall).toBeDefined();
+      const body = JSON.parse((patchCall![1] as RequestInit).body as string);
+      expect(body.tags).toEqual({ add: ["pinned"] });
+    });
   });
 });

--- a/src/app/routes/NoteView.tsx
+++ b/src/app/routes/NoteView.tsx
@@ -1,6 +1,7 @@
 import { DeleteNoteButton } from "@/components/DeleteNoteButton";
 import { MarkdownView, buildWikilinkResolver } from "@/components/MarkdownView";
 import { NeighborhoodGraph } from "@/components/NeighborhoodGraph";
+import { PinArchiveButtons } from "@/components/PinArchiveButtons";
 import { TranscriptionStatus } from "@/components/TranscriptionStatus";
 import { pushRecent } from "@/lib/quick-switch/recents";
 import { relativeTime } from "@/lib/time";
@@ -76,13 +77,14 @@ function NoteBody({ note }: { note: Note }) {
             {note.path ? pathTitle(note.path) : note.id}
           </h1>
           {summary ? <p className="mt-3 text-fg-muted">{summary}</p> : null}
-          <div className="mt-4 flex items-center gap-2">
+          <div className="mt-4 flex flex-wrap items-center gap-2">
             <Link
               to={`/notes/${encodeURIComponent(note.id)}/edit`}
               className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-fg-muted hover:text-accent"
             >
               Edit
             </Link>
+            <PinArchiveButtons note={note} keyboard />
             <DeleteNoteButton note={note} />
           </div>
         </header>

--- a/src/app/routes/Notes.test.tsx
+++ b/src/app/routes/Notes.test.tsx
@@ -1,7 +1,7 @@
 import { Notes } from "@/app/routes/Notes";
 import { useVaultStore } from "@/lib/vault/store";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { BrowserRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -165,5 +165,94 @@ describe("Notes route", () => {
     });
 
     expect(await screen.findByText(/no notes match these filters/i)).toBeInTheDocument();
+  });
+
+  it("pinned-first stable sort on default /notes", async () => {
+    installFetch({
+      notes: [
+        {
+          id: "a",
+          path: "plain-one",
+          tags: [],
+          createdAt: "2026-04-18T10:00:00.000Z",
+          updatedAt: "2026-04-18T11:00:00.000Z",
+        },
+        {
+          id: "b",
+          path: "pinned-note",
+          tags: ["pinned"],
+          createdAt: "2026-04-18T09:00:00.000Z",
+          updatedAt: "2026-04-18T09:00:00.000Z",
+        },
+        {
+          id: "c",
+          path: "plain-two",
+          tags: [],
+          createdAt: "2026-04-18T08:00:00.000Z",
+          updatedAt: "2026-04-18T08:00:00.000Z",
+        },
+      ],
+      tags: [],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    await screen.findByText("pinned-note");
+    const rows = screen.getAllByRole("listitem");
+    const firstRow = within(rows[0]!);
+    expect(firstRow.getByText("pinned-note")).toBeInTheDocument();
+    // Pin indicator visible on the pinned row.
+    expect(firstRow.getByLabelText(/pinned/i)).toBeInTheDocument();
+  });
+
+  it("hides archived notes by default and shows them when toggled on", async () => {
+    installFetch({
+      notes: [
+        {
+          id: "a",
+          path: "live-note",
+          tags: [],
+          createdAt: "2026-04-18T10:00:00.000Z",
+        },
+        {
+          id: "b",
+          path: "archived-note",
+          tags: ["archived"],
+          createdAt: "2026-04-18T09:00:00.000Z",
+        },
+      ],
+      tags: [],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    await screen.findByText("live-note");
+    expect(screen.queryByText("archived-note")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/show archived/i));
+    await waitFor(() => {
+      expect(screen.getByText("archived-note")).toBeInTheDocument();
+    });
+  });
+
+  it("preset=pinned sends the pinned role tag and hides the show-archived toggle", async () => {
+    const fetchImpl = installFetch({ notes: [], tags: [] });
+    render(<Notes preset="pinned" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(lastNotesUrl(fetchImpl)).toContain("tag=pinned");
+    });
+    expect(screen.queryByLabelText(/show archived/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Pinned" })).toBeInTheDocument();
+  });
+
+  it("preset=archived sends the archived role tag", async () => {
+    const fetchImpl = installFetch({ notes: [], tags: [] });
+    render(<Notes preset="archived" />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(lastNotesUrl(fetchImpl)).toContain("tag=archived");
+    });
+    expect(screen.getByRole("heading", { name: "Archived" })).toBeInTheDocument();
   });
 });

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -6,6 +6,7 @@ import {
   type NoteQueryState,
   isFilteringActive,
   useNotes,
+  useTagRoles,
   useTags,
   useVaultStore,
 } from "@/lib/vault";
@@ -14,8 +15,16 @@ import type { Note, TagSummary } from "@/lib/vault/types";
 import { useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useSearchParams } from "react-router";
 
-export function Notes() {
+export type NotesPreset = "pinned" | "archived";
+
+const PRESET_TITLES: Record<NotesPreset, string> = {
+  pinned: "Pinned",
+  archived: "Archived",
+};
+
+export function Notes({ preset }: { preset?: NotesPreset } = {}) {
   const activeVault = useVaultStore((s) => s.getActiveVault());
+  const { roles } = useTagRoles(activeVault?.id ?? null);
   const [searchParams] = useSearchParams();
 
   const [search, setSearch] = useState("");
@@ -25,36 +34,67 @@ export function Notes() {
   const [tagMatch, setTagMatch] = useState<"any" | "all">("any");
   const [sort, setSort] = useState<"asc" | "desc">("desc");
   const [offset, setOffset] = useState(0);
+  const [showArchived, setShowArchived] = useState(false);
 
   const debouncedSearch = useDebouncedValue(search, 300);
   const debouncedPrefix = useDebouncedValue(pathPrefix, 300);
+
+  // Merge the preset role tag into the query so vault-side filter does the
+  // narrowing. User can add more tags on top via TagFilter.
+  const effectiveTags = useMemo(() => {
+    if (preset === "pinned") return Array.from(new Set([roles.pinned, ...selectedTags]));
+    if (preset === "archived") return Array.from(new Set([roles.archived, ...selectedTags]));
+    return selectedTags;
+  }, [preset, roles.pinned, roles.archived, selectedTags]);
+
+  const effectiveTagMatch: "any" | "all" = preset ? "all" : tagMatch;
 
   // Any filter change resets pagination.
   // biome-ignore lint/correctness/useExhaustiveDependencies: offset is the target, not a trigger
   useEffect(() => {
     setOffset(0);
-  }, [debouncedSearch, debouncedPrefix, selectedTags, tagMatch, sort]);
+  }, [debouncedSearch, debouncedPrefix, effectiveTags, effectiveTagMatch, sort, showArchived]);
 
   const queryState: NoteQueryState = useMemo(
     () => ({
       ...DEFAULT_NOTE_QUERY,
       search: debouncedSearch,
       pathPrefix: debouncedPrefix,
-      tags: selectedTags,
-      tagMatch,
+      tags: effectiveTags,
+      tagMatch: effectiveTagMatch,
       sort,
       offset,
     }),
-    [debouncedSearch, debouncedPrefix, selectedTags, tagMatch, sort, offset],
+    [debouncedSearch, debouncedPrefix, effectiveTags, effectiveTagMatch, sort, offset],
   );
 
   const notes = useNotes(queryState);
   const tags = useTags();
 
+  // Client-side post-process: hide archived on default list unless toggled, and
+  // pinned-first stable sort on default list. Preset views skip both.
+  const displayNotes = useMemo(() => {
+    if (!notes.data) return notes.data;
+    let list = notes.data;
+    if (!preset && !showArchived) {
+      list = list.filter((n) => !(n.tags ?? []).includes(roles.archived));
+    }
+    if (!preset) {
+      const pinnedTag = roles.pinned;
+      list = [...list].sort((a, b) => {
+        const ap = (a.tags ?? []).includes(pinnedTag) ? 0 : 1;
+        const bp = (b.tags ?? []).includes(pinnedTag) ? 0 : 1;
+        return ap - bp;
+      });
+    }
+    return list;
+  }, [notes.data, preset, showArchived, roles.archived, roles.pinned]);
+
   if (!activeVault) return <Navigate to="/" replace />;
 
+  const title = preset ? PRESET_TITLES[preset] : "Notes";
   const pageFirst = offset + 1;
-  const pageLast = offset + (notes.data?.length ?? 0);
+  const pageLast = offset + (displayNotes?.length ?? 0);
   const hasPrev = offset > 0;
   const hasNext = (notes.data?.length ?? 0) === DEFAULT_PAGE_SIZE;
 
@@ -63,9 +103,19 @@ export function Notes() {
       <header className="mb-6 flex items-baseline justify-between gap-4">
         <div>
           <p className="text-xs uppercase tracking-wider text-fg-dim">{activeVault.name}</p>
-          <h1 className="font-serif text-3xl tracking-tight">Notes</h1>
+          <h1 className="font-serif text-3xl tracking-tight">{title}</h1>
         </div>
         <div className="flex items-center gap-4">
+          {!preset ? (
+            <label className="flex items-center gap-1.5 text-sm text-fg-muted hover:text-accent">
+              <input
+                type="checkbox"
+                checked={showArchived}
+                onChange={(e) => setShowArchived(e.target.checked)}
+              />
+              Show archived
+            </label>
+          ) : null}
           <button
             type="button"
             onClick={() => setSort((s) => (s === "desc" ? "asc" : "desc"))}
@@ -120,14 +170,14 @@ export function Notes() {
         <SkeletonRows />
       ) : notes.isError ? (
         <ErrorBlock error={notes.error} />
-      ) : notes.data && notes.data.length > 0 ? (
+      ) : displayNotes && displayNotes.length > 0 ? (
         <ol className="divide-y divide-border rounded-md border border-border bg-card">
-          {notes.data.map((n) => (
-            <NoteRow key={n.id} note={n} />
+          {displayNotes.map((n) => (
+            <NoteRow key={n.id} note={n} pinnedTag={roles.pinned} archivedTag={roles.archived} />
           ))}
         </ol>
       ) : (
-        <EmptyBlock filtering={isFilteringActive(queryState)} />
+        <EmptyBlock filtering={isFilteringActive(queryState) || !!preset} />
       )}
 
       <div className="mt-6 flex items-center justify-between text-sm text-fg-dim">
@@ -161,17 +211,30 @@ export function Notes() {
   );
 }
 
-function NoteRow({ note }: { note: Note }) {
+function NoteRow({
+  note,
+  pinnedTag,
+  archivedTag,
+}: { note: Note; pinnedTag: string; archivedTag: string }) {
   const label = note.path ?? note.id;
   const stamp = note.updatedAt ?? note.createdAt;
+  const isPinned = (note.tags ?? []).includes(pinnedTag);
+  const isArchived = (note.tags ?? []).includes(archivedTag);
   return (
-    <li>
+    <li className={isArchived ? "opacity-60 italic" : undefined}>
       <Link
         to={`/notes/${encodeURIComponent(note.id)}`}
         className="block px-4 py-3 hover:bg-bg/60 focus:bg-bg/60 focus:outline-none"
       >
         <div className="flex items-baseline justify-between gap-4">
-          <span className="truncate font-mono text-sm text-fg">{label}</span>
+          <span className="flex min-w-0 items-baseline gap-1.5">
+            {isPinned ? (
+              <span className="shrink-0 text-accent" aria-label="pinned" title="pinned">
+                ★
+              </span>
+            ) : null}
+            <span className="truncate font-mono text-sm text-fg">{label}</span>
+          </span>
           <span className="shrink-0 text-xs text-fg-dim">{relativeTime(stamp)}</span>
         </div>
         {note.preview ? (

--- a/src/components/PinArchiveButtons.tsx
+++ b/src/components/PinArchiveButtons.tsx
@@ -1,0 +1,99 @@
+import { useToastStore } from "@/lib/toast/store";
+import { useTagRoles, useUpdateNote, useVaultStore } from "@/lib/vault";
+import { VaultAuthError } from "@/lib/vault/client";
+import type { Note } from "@/lib/vault/types";
+import { useCallback, useEffect } from "react";
+
+interface Props {
+  note: Note;
+  keyboard?: boolean;
+}
+
+export function PinArchiveButtons({ note, keyboard = false }: Props) {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const { roles } = useTagRoles(activeVault?.id ?? null);
+  const pushToast = useToastStore((s) => s.push);
+  const mutation = useUpdateNote(note.id);
+
+  const isPinned = note.tags?.includes(roles.pinned) ?? false;
+  const isArchived = note.tags?.includes(roles.archived) ?? false;
+
+  const toggle = useCallback(
+    (role: "pinned" | "archived") => {
+      if (mutation.isPending) return;
+      const tag = roles[role];
+      const has = note.tags?.includes(tag) ?? false;
+      mutation.mutate(
+        { tags: has ? { remove: [tag] } : { add: [tag] } },
+        {
+          onSuccess: () => {
+            pushToast(
+              role === "pinned" ? (has ? "Unpinned" : "Pinned") : has ? "Unarchived" : "Archived",
+              "success",
+            );
+          },
+          onError: (err) => {
+            if (err instanceof VaultAuthError) pushToast("Session expired. Reconnect.", "error");
+            else pushToast(err instanceof Error ? err.message : "Update failed", "error");
+          },
+        },
+      );
+    },
+    [mutation, note.tags, pushToast, roles],
+  );
+
+  useEffect(() => {
+    if (!keyboard) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      const t = e.target as HTMLElement | null;
+      if (t) {
+        const tag = t.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || t.isContentEditable) return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "p" || e.key === "P") {
+        e.preventDefault();
+        toggle("pinned");
+      } else if (e.key === "a" || e.key === "A") {
+        e.preventDefault();
+        toggle("archived");
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [keyboard, toggle]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => toggle("pinned")}
+        disabled={mutation.isPending}
+        aria-pressed={isPinned}
+        title={isPinned ? `Unpin (${roles.pinned})` : `Pin as #${roles.pinned} (P)`}
+        className={
+          isPinned
+            ? "rounded-md border border-accent/60 bg-accent/10 px-3 py-1.5 text-sm text-accent hover:bg-accent/20 disabled:opacity-40"
+            : "rounded-md border border-border bg-card px-3 py-1.5 text-sm text-fg-muted hover:text-accent disabled:opacity-40"
+        }
+      >
+        {isPinned ? "★ Pinned" : "☆ Pin"}
+      </button>
+      <button
+        type="button"
+        onClick={() => toggle("archived")}
+        disabled={mutation.isPending}
+        aria-pressed={isArchived}
+        title={isArchived ? `Unarchive (${roles.archived})` : `Archive as #${roles.archived} (A)`}
+        className={
+          isArchived
+            ? "rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-sm text-amber-500 hover:bg-amber-500/20 disabled:opacity-40"
+            : "rounded-md border border-border bg-card px-3 py-1.5 text-sm text-fg-muted hover:text-accent disabled:opacity-40"
+        }
+      >
+        {isArchived ? "Archived" : "Archive"}
+      </button>
+    </>
+  );
+}

--- a/src/lib/quick-switch/results.test.ts
+++ b/src/lib/quick-switch/results.test.ts
@@ -107,6 +107,14 @@ describe("computeResults", () => {
   });
 
   it("exposes the static command list so tests can drive by id", () => {
-    expect(COMMANDS.map((c) => c.id)).toEqual(["new", "capture", "graph", "tags", "notes"]);
+    expect(COMMANDS.map((c) => c.id)).toEqual([
+      "new",
+      "capture",
+      "graph",
+      "tags",
+      "notes",
+      "pinned",
+      "archived",
+    ]);
   });
 });

--- a/src/lib/quick-switch/results.ts
+++ b/src/lib/quick-switch/results.ts
@@ -65,6 +65,20 @@ export const COMMANDS: Array<{
     keywords: ["notes", "all"],
     action: { type: "navigate", to: "/notes" },
   },
+  {
+    id: "pinned",
+    label: "Pinned",
+    description: "Notes tagged as pinned",
+    keywords: ["pinned", "star", "favorites"],
+    action: { type: "navigate", to: "/pinned" },
+  },
+  {
+    id: "archived",
+    label: "Archived",
+    description: "Notes tagged as archived",
+    keywords: ["archived", "archive"],
+    action: { type: "navigate", to: "/archived" },
+  },
 ];
 
 function matchesAny(keywords: string[], q: string): number | null {


### PR DESCRIPTION
Closes #55 (v0.3 #25).

## Summary
- Pin/Archive buttons land on `NoteView` and `NoteEditor`, applying the per-vault `pinned`/`archived` role tag via `useUpdateNote` (so each vault keeps its own convention).
- `NoteView` exposes `P` and `A` keyboard shortcuts (suppressed when typing in inputs/textareas/contenteditable).
- Default `/notes`: archived notes are hidden behind a "Show archived" toggle, and the visible page stable-sorts pinned notes first.
- New `/pinned` and `/archived` routes reuse `<Notes preset="…" />` with the role tag pre-applied — sort and search still work.
- Visual indicators on the list: `★` accent prefix for pinned, `opacity-60 italic` row for archived.
- Quick switcher gains **Pinned** and **Archived** jumps.

## Design notes
- Pin/archive sort + filter are client-side over the current page. v1: if a vault has more pinned notes than fit on one page (50), some land on page 2. Acceptable for now; promote to server-side if it becomes a pain.
- Keyboard shortcuts are bound at the page level (only on `NoteView`). On `NoteEditor` the buttons are visible but no shortcut, since the editor owns the keyboard.
- Remapping the pin/archive role tag in Settings does not retag existing notes (consistent with the role-roles primitive — the role just points at the new tag going forward).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (398 pass)
- [x] `bun run build`
- [ ] Manual: pin a note, verify it jumps to top of `/notes` and shows ★
- [ ] Manual: archive a note, verify it hides from `/notes` and reappears with toggle
- [ ] Manual: `/pinned` and `/archived` show only the matching set
- [ ] Manual: press `P`/`A` on a note view to toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)