### PR TITLE
Add /today and /calendar chronological surfaces

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { QueryProvider } from "@/providers/QueryProvider";
 import { SyncProvider } from "@/providers/SyncProvider";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { AddVault } from "./routes/AddVault";
+import { Calendar } from "./routes/Calendar";
 import { Capture } from "./routes/Capture";
 import { Home } from "./routes/Home";
 import { NoteEditor } from "./routes/NoteEditor";
@@ -15,6 +16,7 @@ import { Notes } from "./routes/Notes";
 import { OAuthCallback } from "./routes/OAuthCallback";
 import { Settings } from "./routes/Settings";
 import { Tags } from "./routes/Tags";
+import { Today } from "./routes/Today";
 import { VaultGraph } from "./routes/VaultGraph";
 import { Vaults } from "./routes/Vaults";
 
@@ -38,6 +40,8 @@ export function App() {
                 <Route path="/new" element={<NoteNew />} />
                 <Route path="/capture" element={<Capture />} />
                 <Route path="/graph" element={<VaultGraph />} />
+                <Route path="/today" element={<Today />} />
+                <Route path="/calendar" element={<Calendar />} />
                 <Route path="/notes/:id" element={<NoteView />} />
                 <Route path="/notes/:id/edit" element={<NoteEditor />} />
                 <Route path="/add" element={<AddVault />} />

--- a/src/app/routes/Calendar.test.tsx
+++ b/src/app/routes/Calendar.test.tsx
@@ -1,0 +1,190 @@
+import { Calendar } from "@/app/routes/Calendar";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface Row {
+  id: string;
+  path: string;
+  createdAt: string;
+}
+
+function installFetch(notes: Row[]) {
+  const impl = vi.fn<typeof fetch>(async () => {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => notes,
+      text: async () => "",
+    } as Response;
+  });
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      v1: {
+        id: "v1",
+        url: "http://localhost:1940",
+        name: "default",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v1",
+  });
+  localStorage.setItem(
+    "lens:token:v1",
+    JSON.stringify({ accessToken: "t", scope: "full", vault: "default" }),
+  );
+}
+
+function LocationSpy() {
+  const loc = useLocation();
+  return <div data-testid="location">{`${loc.pathname}${loc.search}`}</div>;
+}
+
+function Wrap({ children, initial = "/calendar" }: { children: ReactNode; initial?: string }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return (
+    <MemoryRouter initialEntries={[initial]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/calendar" element={children} />
+          <Route path="/today" element={<LocationSpy />} />
+          <Route path="/" element={<LocationSpy />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function localIso(year: number, month: number, day: number, hour = 12): string {
+  return new Date(year, month - 1, day, hour).toISOString();
+}
+
+describe("Calendar route", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 3, 18, 12, 0, 0));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+
+  it("renders the long month header for the requested month", async () => {
+    installFetch([]);
+    render(
+      <Wrap initial="/calendar?month=2026-04">
+        <Calendar />
+      </Wrap>,
+    );
+    expect(await screen.findByRole("heading", { name: /april 2026/i })).toBeInTheDocument();
+  });
+
+  it("renders 42 day cells (6 weeks)", async () => {
+    installFetch([]);
+    render(
+      <Wrap initial="/calendar?month=2026-04">
+        <Calendar />
+      </Wrap>,
+    );
+    const cells = await screen.findAllByRole("link", { name: /\d{4}-\d{2}-\d{2} — \d+ notes/ });
+    expect(cells.length).toBe(42);
+  });
+
+  it("aggregates note counts by createdAt local-day key", async () => {
+    installFetch([
+      { id: "n1", path: "a", createdAt: localIso(2026, 4, 18, 9) },
+      { id: "n2", path: "b", createdAt: localIso(2026, 4, 18, 14) },
+      { id: "n3", path: "c", createdAt: localIso(2026, 4, 19, 9) },
+    ]);
+    render(
+      <Wrap initial="/calendar?month=2026-04">
+        <Calendar />
+      </Wrap>,
+    );
+    const cell18 = await screen.findByLabelText(/2026-04-18 — 2 notes/i);
+    expect(cell18).toBeInTheDocument();
+    expect(screen.getByLabelText(/2026-04-19 — 1 notes/i)).toBeInTheDocument();
+    // Days with no notes still get an aria-label with "0 notes".
+    expect(screen.getByLabelText(/2026-04-01 — 0 notes/i)).toBeInTheDocument();
+  });
+
+  it("shows '+N more' when a day exceeds the visible-dot cap", async () => {
+    const day = 18;
+    const notes = Array.from({ length: 8 }, (_, i) => ({
+      id: `n${i}`,
+      path: `n${i}`,
+      createdAt: localIso(2026, 4, day, i),
+    }));
+    installFetch(notes);
+    render(
+      <Wrap initial="/calendar?month=2026-04">
+        <Calendar />
+      </Wrap>,
+    );
+    await screen.findByLabelText(/2026-04-18 — 8 notes/i);
+    // 8 notes - 5 visible dots = +3 more.
+    expect(screen.getByText("+3")).toBeInTheDocument();
+  });
+
+  it("prev/next month links use shifted YYYY-MM keys", async () => {
+    installFetch([]);
+    render(
+      <Wrap initial="/calendar?month=2026-01">
+        <Calendar />
+      </Wrap>,
+    );
+    await screen.findByRole("heading", { name: /january 2026/i });
+    expect(screen.getByRole("link", { name: /previous month/i })).toHaveAttribute(
+      "href",
+      "/calendar?month=2025-12",
+    );
+    expect(screen.getByRole("link", { name: /next month/i })).toHaveAttribute(
+      "href",
+      "/calendar?month=2026-02",
+    );
+  });
+
+  it("clicking a day navigates to /today?date=<key>", async () => {
+    installFetch([]);
+    render(
+      <Wrap initial="/calendar?month=2026-04">
+        <Calendar />
+      </Wrap>,
+    );
+    const cell = await screen.findByLabelText(/2026-04-15 — 0 notes/i);
+    cell.click();
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toBe("/today?date=2026-04-15");
+    });
+  });
+
+  it("redirects home when no active vault", async () => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    installFetch([]);
+    render(
+      <Wrap>
+        <Calendar />
+      </Wrap>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toBe("/");
+    });
+  });
+});

--- a/src/app/routes/Calendar.tsx
+++ b/src/app/routes/Calendar.tsx
@@ -1,0 +1,182 @@
+import {
+  currentMonthKey,
+  formatLongMonth,
+  monthGrid,
+  pad2,
+  parseMonthKey,
+  shiftMonth,
+  toDateKey,
+  todayKey,
+} from "@/lib/dates";
+import { useNotesForDateViews, useVaultStore } from "@/lib/vault";
+import { VaultAuthError } from "@/lib/vault/client";
+import { useMemo } from "react";
+import { Link, Navigate, useSearchParams } from "react-router";
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+// Cap visible dots per cell; overflow shows as "+N more".
+const MAX_DOTS_PER_DAY = 5;
+
+export function Calendar() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const [searchParams] = useSearchParams();
+  const monthParam = searchParams.get("month");
+  const parsed = parseMonthKey(monthParam) ?? parseMonthKey(currentMonthKey())!;
+  const notes = useNotesForDateViews();
+  const today = todayKey();
+
+  const days = useMemo(() => monthGrid(parsed.year, parsed.month), [parsed.year, parsed.month]);
+
+  // Bucket notes by local date key. We tally by createdAt; if you want edited
+  // activity instead, switch to updatedAt — but for a calendar, "when was this
+  // authored" reads more naturally than "when was it last touched".
+  const countsByDay = useMemo(() => {
+    const map = new Map<string, number>();
+    if (!notes.data) return map;
+    for (const n of notes.data) {
+      const k = toDateKey(n.createdAt);
+      if (!k) continue;
+      map.set(k, (map.get(k) ?? 0) + 1);
+    }
+    return map;
+  }, [notes.data]);
+
+  if (!activeVault) return <Navigate to="/" replace />;
+
+  const prev = shiftMonth(parsed.year, parsed.month, -1);
+  const next = shiftMonth(parsed.year, parsed.month, 1);
+  const prevKey = `${prev.year}-${pad2(prev.month)}`;
+  const nextKey = `${next.year}-${pad2(next.month)}`;
+  const currentKey = currentMonthKey();
+  const isCurrent = `${parsed.year}-${pad2(parsed.month)}` === currentKey;
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-6 flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-fg-dim">Calendar</p>
+          <h1 className="font-serif text-3xl tracking-tight">
+            {formatLongMonth(parsed.year, parsed.month)}
+          </h1>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <Link
+            to={`/calendar?month=${prevKey}`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-fg-muted hover:text-accent"
+            aria-label="Previous month"
+          >
+            ← {prevKey}
+          </Link>
+          {!isCurrent ? (
+            <Link
+              to="/calendar"
+              className="rounded-md border border-border bg-card px-3 py-1.5 text-fg-muted hover:text-accent"
+            >
+              This month
+            </Link>
+          ) : null}
+          <Link
+            to={`/calendar?month=${nextKey}`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-fg-muted hover:text-accent"
+            aria-label="Next month"
+          >
+            {nextKey} →
+          </Link>
+          <Link
+            to={`/today?date=${today}`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-fg-muted hover:text-accent"
+          >
+            Today
+          </Link>
+        </div>
+      </header>
+
+      {notes.isError ? (
+        <ErrorBlock error={notes.error} />
+      ) : (
+        <div className="rounded-md border border-border bg-card" aria-busy={notes.isPending}>
+          <div className="grid grid-cols-7 border-b border-border text-xs uppercase tracking-wider text-fg-dim">
+            {WEEKDAYS.map((w) => (
+              <div key={w} className="px-2 py-2 text-center">
+                {w}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7">
+            {days.map((d) => {
+              const key = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+              const inMonth = d.getMonth() + 1 === parsed.month;
+              const count = countsByDay.get(key) ?? 0;
+              const isToday = key === today;
+              return (
+                <Link
+                  key={key}
+                  to={`/today?date=${key}`}
+                  className={`flex min-h-20 flex-col border-b border-r border-border p-1.5 text-xs hover:bg-bg/60 focus:bg-bg/60 focus:outline-none ${
+                    inMonth ? "" : "opacity-40"
+                  }`}
+                  aria-label={`${key} — ${count} notes`}
+                >
+                  <span
+                    className={`mb-1 inline-flex h-6 w-6 items-center justify-center rounded-full ${
+                      isToday ? "bg-accent text-white" : "text-fg"
+                    }`}
+                  >
+                    {d.getDate()}
+                  </span>
+                  {count > 0 ? (
+                    <DayDots count={count} />
+                  ) : (
+                    <span className="sr-only">no notes</span>
+                  )}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <p className="mt-3 text-xs text-fg-dim">
+        Each dot is a note created on that day. Click any day to open /today.
+      </p>
+    </div>
+  );
+}
+
+function DayDots({ count }: { count: number }) {
+  const dots = Math.min(count, MAX_DOTS_PER_DAY);
+  const more = count > MAX_DOTS_PER_DAY ? count - MAX_DOTS_PER_DAY : 0;
+  return (
+    <span className="flex flex-wrap items-center gap-0.5">
+      {Array.from({ length: dots }).map((_, i) => (
+        <span
+          // biome-ignore lint/suspicious/noArrayIndexKey: dot count only, no identity
+          key={i}
+          className="h-1.5 w-1.5 rounded-full bg-accent"
+          aria-hidden="true"
+        />
+      ))}
+      {more > 0 ? <span className="ml-0.5 text-[10px] text-fg-dim">+{more}</span> : null}
+    </span>
+  );
+}
+
+function ErrorBlock({ error }: { error: Error }) {
+  const isAuth = error instanceof VaultAuthError;
+  return (
+    <div className="rounded-md border border-red-500/30 bg-red-500/5 p-6">
+      <p className="mb-2 font-medium text-red-400">
+        {isAuth ? "Session expired" : "Could not load notes"}
+      </p>
+      <p className="mb-4 text-sm text-fg-muted">{error.message}</p>
+      {isAuth ? (
+        <Link
+          to="/add"
+          className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Reconnect vault
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/routes/Today.test.tsx
+++ b/src/app/routes/Today.test.tsx
@@ -1,0 +1,208 @@
+import { Today } from "@/app/routes/Today";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface Row {
+  id: string;
+  path: string;
+  createdAt: string;
+  updatedAt?: string;
+  tags?: string[];
+  preview?: string;
+}
+
+function installFetch(notes: Row[]) {
+  const impl = vi.fn<typeof fetch>(async () => {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => notes,
+      text: async () => "",
+    } as Response;
+  });
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      v1: {
+        id: "v1",
+        url: "http://localhost:1940",
+        name: "default",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v1",
+  });
+  localStorage.setItem(
+    "lens:token:v1",
+    JSON.stringify({ accessToken: "t", scope: "full", vault: "default" }),
+  );
+}
+
+function LocationSpy() {
+  const loc = useLocation();
+  return <div data-testid="location">{`${loc.pathname}${loc.search}`}</div>;
+}
+
+function Wrap({ children, initial = "/today" }: { children: ReactNode; initial?: string }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return (
+    <MemoryRouter initialEntries={[initial]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/today" element={children} />
+          <Route path="/" element={<LocationSpy />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+// Local-time ISO for a date key. Tests fake the clock, so build ISOs from
+// Date so host-timezone drift doesn't flip buckets.
+function localIso(year: number, month: number, day: number, hour = 12): string {
+  return new Date(year, month - 1, day, hour).toISOString();
+}
+
+describe("Today route", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+    // Pin clock so todayKey() is stable across hosts.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 3, 18, 12, 0, 0));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+
+  it("buckets notes into 'created today' and 'edited today' sections", async () => {
+    installFetch([
+      {
+        id: "n1",
+        path: "Morning.md",
+        createdAt: localIso(2026, 4, 18, 9),
+        updatedAt: localIso(2026, 4, 18, 9),
+      },
+      {
+        id: "n2",
+        path: "Earlier.md",
+        createdAt: localIso(2026, 4, 15, 10),
+        updatedAt: localIso(2026, 4, 18, 14),
+      },
+      {
+        id: "n3",
+        path: "Unrelated.md",
+        createdAt: localIso(2026, 4, 10, 10),
+      },
+    ]);
+    render(
+      <Wrap>
+        <Today />
+      </Wrap>,
+    );
+
+    await screen.findByText("Morning.md");
+    expect(screen.getByText(/created today \(1\)/i)).toBeInTheDocument();
+    expect(screen.getByText("Earlier.md")).toBeInTheDocument();
+    expect(screen.getByText(/edited today \(1\)/i)).toBeInTheDocument();
+    expect(screen.queryByText("Unrelated.md")).not.toBeInTheDocument();
+  });
+
+  it("renders 'On <date>' header with date param", async () => {
+    installFetch([
+      {
+        id: "n1",
+        path: "Past.md",
+        createdAt: localIso(2026, 4, 10, 9),
+      },
+    ]);
+    render(
+      <Wrap initial="/today?date=2026-04-10">
+        <Today />
+      </Wrap>,
+    );
+    await screen.findByText("Past.md");
+    expect(screen.getByText(/created on 2026-04-10 \(1\)/i)).toBeInTheDocument();
+    // "Today" jump button is visible when not on today.
+    expect(screen.getByRole("link", { name: /^today$/i })).toBeInTheDocument();
+  });
+
+  it("shows empty state with capture link when today is empty", async () => {
+    installFetch([]);
+    render(
+      <Wrap>
+        <Today />
+      </Wrap>,
+    );
+    expect(await screen.findByText(/nothing yet today — start capturing/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open capture/i })).toBeInTheDocument();
+  });
+
+  it("shows dated empty copy (no capture button) for a past day", async () => {
+    installFetch([]);
+    render(
+      <Wrap initial="/today?date=2026-04-10">
+        <Today />
+      </Wrap>,
+    );
+    expect(await screen.findByText(/nothing on 2026-04-10/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /open capture/i })).not.toBeInTheDocument();
+  });
+
+  it("prev/next links point to the neighbouring day", async () => {
+    installFetch([]);
+    render(
+      <Wrap initial="/today?date=2026-04-10">
+        <Today />
+      </Wrap>,
+    );
+    await screen.findByText(/nothing on 2026-04-10/i);
+    expect(screen.getByRole("link", { name: /previous day/i })).toHaveAttribute(
+      "href",
+      "/today?date=2026-04-09",
+    );
+    expect(screen.getByRole("link", { name: /next day/i })).toHaveAttribute(
+      "href",
+      "/today?date=2026-04-11",
+    );
+  });
+
+  it("renders an error block for invalid date param", async () => {
+    installFetch([]);
+    render(
+      <Wrap initial="/today?date=not-a-date">
+        <Today />
+      </Wrap>,
+    );
+    expect(await screen.findByText(/invalid date in url: not-a-date/i)).toBeInTheDocument();
+  });
+
+  it("redirects home when no active vault", async () => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    installFetch([]);
+    render(
+      <Wrap>
+        <Today />
+      </Wrap>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toBe("/");
+    });
+  });
+});

--- a/src/app/routes/Today.tsx
+++ b/src/app/routes/Today.tsx
@@ -1,0 +1,203 @@
+import { formatLongDate, pad2, parseDateKey, toDateKey, todayKey } from "@/lib/dates";
+import { relativeTime } from "@/lib/time";
+import { useNotesForDateViews, useVaultStore } from "@/lib/vault";
+import { VaultAuthError } from "@/lib/vault/client";
+import type { Note } from "@/lib/vault/types";
+import { useMemo } from "react";
+import { Link, Navigate, useSearchParams } from "react-router";
+
+export function Today() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const [searchParams] = useSearchParams();
+  const dateParam = searchParams.get("date");
+  const todayStr = todayKey();
+  const targetKey = dateParam ?? todayStr;
+  const parsed = parseDateKey(targetKey);
+
+  const notes = useNotesForDateViews();
+
+  const buckets = useMemo(() => {
+    const created: Note[] = [];
+    const edited: Note[] = [];
+    if (!notes.data || !parsed) return { created, edited };
+    for (const n of notes.data) {
+      const ck = toDateKey(n.createdAt);
+      const uk = toDateKey(n.updatedAt ?? n.createdAt);
+      if (ck === targetKey) created.push(n);
+      if (uk === targetKey && ck !== targetKey) edited.push(n);
+    }
+    return { created, edited };
+  }, [notes.data, parsed, targetKey]);
+
+  if (!activeVault) return <Navigate to="/" replace />;
+  if (!parsed) {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <p className="text-sm text-red-400">Invalid date in URL: {targetKey}</p>
+        <Link to="/today" className="text-sm text-accent hover:underline">
+          Back to today
+        </Link>
+      </div>
+    );
+  }
+
+  const isToday = targetKey === todayStr;
+  const prev = shiftDay(targetKey, -1);
+  const next = shiftDay(targetKey, 1);
+  const monthKey = targetKey.slice(0, 7);
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-6 flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-fg-dim">{isToday ? "Today" : "On"}</p>
+          <h1 className="font-serif text-3xl tracking-tight">{formatLongDate(targetKey)}</h1>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <Link
+            to={`/today?date=${prev}`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-fg-muted hover:text-accent"
+            aria-label="Previous day"
+          >
+            ← {prev}
+          </Link>
+          {!isToday ? (
+            <Link
+              to="/today"
+              className="rounded-md border border-border bg-card px-3 py-1.5 text-fg-muted hover:text-accent"
+            >
+              Today
+            </Link>
+          ) : null}
+          <Link
+            to={`/today?date=${next}`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-fg-muted hover:text-accent"
+            aria-label="Next day"
+          >
+            {next} →
+          </Link>
+          <Link
+            to={`/calendar?month=${monthKey}`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-fg-muted hover:text-accent"
+          >
+            Calendar
+          </Link>
+          <Link
+            to="/capture"
+            className="rounded-md bg-accent px-3 py-1.5 font-medium text-white hover:bg-accent-hover"
+          >
+            + Capture
+          </Link>
+        </div>
+      </header>
+
+      {notes.isPending ? (
+        <Skeleton />
+      ) : notes.isError ? (
+        <ErrorBlock error={notes.error} />
+      ) : buckets.created.length === 0 && buckets.edited.length === 0 ? (
+        <EmptyBlock isToday={isToday} targetKey={targetKey} />
+      ) : (
+        <div className="space-y-8">
+          {buckets.created.length > 0 ? (
+            <Section
+              title={isToday ? "Created today" : `Created on ${targetKey}`}
+              notes={buckets.created}
+            />
+          ) : null}
+          {buckets.edited.length > 0 ? (
+            <Section
+              title={isToday ? "Edited today" : `Edited on ${targetKey}`}
+              notes={buckets.edited}
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function shiftDay(key: string, delta: number): string {
+  const d = parseDateKey(key);
+  if (!d) return key;
+  d.setDate(d.getDate() + delta);
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+function Section({ title, notes }: { title: string; notes: Note[] }) {
+  return (
+    <section>
+      <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">
+        {title} ({notes.length})
+      </h2>
+      <ol className="divide-y divide-border rounded-md border border-border bg-card">
+        {notes.map((n) => (
+          <li key={n.id}>
+            <Link
+              to={`/notes/${encodeURIComponent(n.id)}`}
+              className="block px-4 py-3 hover:bg-bg/60 focus:bg-bg/60 focus:outline-none"
+            >
+              <div className="flex items-baseline justify-between gap-4">
+                <span className="truncate font-mono text-sm text-fg">{n.path ?? n.id}</span>
+                <span className="shrink-0 text-xs text-fg-dim">
+                  {relativeTime(n.updatedAt ?? n.createdAt)}
+                </span>
+              </div>
+              {n.preview ? (
+                <p className="mt-1 truncate text-sm text-fg-muted">{n.preview}</p>
+              ) : null}
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function EmptyBlock({ isToday, targetKey }: { isToday: boolean; targetKey: string }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-10 text-center">
+      <p className="mb-4 text-fg-muted">
+        {isToday ? "Nothing yet today — start capturing." : `Nothing on ${targetKey}.`}
+      </p>
+      {isToday ? (
+        <Link
+          to="/capture"
+          className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Open capture
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div className="space-y-3" aria-busy="true">
+      {[0, 1, 2, 3].map((i) => (
+        <div key={i} className="h-14 animate-pulse rounded-md bg-border/30" />
+      ))}
+    </div>
+  );
+}
+
+function ErrorBlock({ error }: { error: Error }) {
+  const isAuth = error instanceof VaultAuthError;
+  return (
+    <div className="rounded-md border border-red-500/30 bg-red-500/5 p-6">
+      <p className="mb-2 font-medium text-red-400">
+        {isAuth ? "Session expired" : "Could not load notes"}
+      </p>
+      <p className="mb-4 text-sm text-fg-muted">{error.message}</p>
+      {isAuth ? (
+        <Link
+          to="/add"
+          className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Reconnect vault
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  currentMonthKey,
+  formatLongMonth,
+  monthGrid,
+  pad2,
+  parseDateKey,
+  parseMonthKey,
+  shiftMonth,
+  toDateKey,
+  todayKey,
+} from "./dates";
+
+describe("pad2", () => {
+  it("zero-pads single digits", () => {
+    expect(pad2(0)).toBe("00");
+    expect(pad2(9)).toBe("09");
+  });
+  it("leaves double digits alone", () => {
+    expect(pad2(10)).toBe("10");
+    expect(pad2(99)).toBe("99");
+  });
+});
+
+describe("todayKey", () => {
+  it("formats a Date as YYYY-MM-DD in local time", () => {
+    // Local-time Jan 5, 2026 — regardless of host TZ, both sides use local.
+    const d = new Date(2026, 0, 5);
+    expect(todayKey(d)).toBe("2026-01-05");
+  });
+  it("zero-pads month and day", () => {
+    expect(todayKey(new Date(2026, 2, 9))).toBe("2026-03-09");
+  });
+});
+
+describe("toDateKey", () => {
+  it("returns null for null/undefined/invalid input", () => {
+    expect(toDateKey(null)).toBeNull();
+    expect(toDateKey(undefined)).toBeNull();
+    expect(toDateKey("not-a-date")).toBeNull();
+  });
+  it("converts an ISO string to the local date key", () => {
+    // Build an ISO that matches a known local moment so the assertion is
+    // stable across timezones.
+    const local = new Date(2026, 3, 18, 12, 0, 0);
+    expect(toDateKey(local.toISOString())).toBe("2026-04-18");
+  });
+});
+
+describe("parseDateKey", () => {
+  it("returns null for malformed keys", () => {
+    expect(parseDateKey(null)).toBeNull();
+    expect(parseDateKey("")).toBeNull();
+    expect(parseDateKey("2026/04/18")).toBeNull();
+    expect(parseDateKey("2026-4-18")).toBeNull();
+  });
+  it("parses a valid key into a Date in local time", () => {
+    const d = parseDateKey("2026-04-18");
+    expect(d).not.toBeNull();
+    expect(d?.getFullYear()).toBe(2026);
+    expect(d?.getMonth()).toBe(3);
+    expect(d?.getDate()).toBe(18);
+  });
+});
+
+describe("currentMonthKey", () => {
+  it("formats YYYY-MM from a Date", () => {
+    expect(currentMonthKey(new Date(2026, 0, 15))).toBe("2026-01");
+    expect(currentMonthKey(new Date(2026, 11, 1))).toBe("2026-12");
+  });
+});
+
+describe("parseMonthKey", () => {
+  it("rejects invalid months and malformed input", () => {
+    expect(parseMonthKey(null)).toBeNull();
+    expect(parseMonthKey("2026-13")).toBeNull();
+    expect(parseMonthKey("2026-00")).toBeNull();
+    expect(parseMonthKey("26-04")).toBeNull();
+  });
+  it("parses valid YYYY-MM", () => {
+    expect(parseMonthKey("2026-04")).toEqual({ year: 2026, month: 4 });
+  });
+});
+
+describe("shiftMonth", () => {
+  it("shifts forward across a year boundary", () => {
+    expect(shiftMonth(2026, 12, 1)).toEqual({ year: 2027, month: 1 });
+  });
+  it("shifts backward across a year boundary", () => {
+    expect(shiftMonth(2026, 1, -1)).toEqual({ year: 2025, month: 12 });
+  });
+  it("handles multi-month shifts", () => {
+    expect(shiftMonth(2026, 4, 14)).toEqual({ year: 2027, month: 6 });
+    expect(shiftMonth(2026, 4, -16)).toEqual({ year: 2024, month: 12 });
+  });
+});
+
+describe("monthGrid", () => {
+  it("returns 42 cells (6 weeks of 7 days)", () => {
+    expect(monthGrid(2026, 4).length).toBe(42);
+  });
+  it("starts on the Sunday on or before the 1st", () => {
+    // April 2026: 1st is a Wednesday (getDay() === 3), so grid starts Sun Mar 29.
+    const grid = monthGrid(2026, 4);
+    expect(grid[0]?.getDay()).toBe(0);
+    expect(grid[0]?.getFullYear()).toBe(2026);
+    expect(grid[0]?.getMonth()).toBe(2); // March
+    expect(grid[0]?.getDate()).toBe(29);
+  });
+  it("includes trailing days from the next month when needed", () => {
+    const grid = monthGrid(2026, 4);
+    const last = grid[grid.length - 1]!;
+    // 29 + 41 days after Mar 29 lands in early May.
+    expect(last.getMonth()).toBe(4);
+  });
+});
+
+describe("formatLongMonth", () => {
+  it("returns a human-readable year+month string", () => {
+    const s = formatLongMonth(2026, 4);
+    expect(s).toMatch(/2026/);
+    expect(s).toMatch(/April/i);
+  });
+});

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,0 +1,79 @@
+// All date keys are local-time "YYYY-MM-DD" strings. Calendar and /today are
+// user-facing chronological surfaces — UTC dates would show "today" from the
+// vault's clock rather than the user's, which is almost never what they want.
+// The cost is that notes authored in a different timezone may land on a
+// different day than the author expected, but that's the correct trade for a
+// personal-notes app rendered in the user's browser.
+
+export function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+export function todayKey(now: Date = new Date()): string {
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`;
+}
+
+export function toDateKey(iso: string | undefined | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return todayKey(d);
+}
+
+export function parseDateKey(s: string | null | undefined): Date | null {
+  if (!s || !/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
+  const [y, m, d] = s.split("-").map(Number) as [number, number, number];
+  const date = new Date(y, m - 1, d);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function currentMonthKey(now: Date = new Date()): string {
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}`;
+}
+
+export function parseMonthKey(
+  s: string | null | undefined,
+): { year: number; month: number } | null {
+  if (!s || !/^\d{4}-\d{2}$/.test(s)) return null;
+  const [y, m] = s.split("-").map(Number) as [number, number];
+  if (m < 1 || m > 12) return null;
+  return { year: y, month: m };
+}
+
+export function shiftMonth(
+  year: number,
+  month: number,
+  delta: number,
+): { year: number; month: number } {
+  const idx = year * 12 + (month - 1) + delta;
+  return { year: Math.floor(idx / 12), month: (idx % 12) + 1 };
+}
+
+// Grid of 42 cells (6 weeks) for the given month, starting on Sunday and
+// including trailing days from prior/next month so rows are always complete.
+export function monthGrid(year: number, month: number): Date[] {
+  const firstOfMonth = new Date(year, month - 1, 1);
+  const startDay = firstOfMonth.getDay(); // 0 = Sunday
+  const gridStart = new Date(year, month - 1, 1 - startDay);
+  const days: Date[] = [];
+  for (let i = 0; i < 42; i++) {
+    days.push(new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i));
+  }
+  return days;
+}
+
+export function formatLongDate(key: string): string {
+  const d = parseDateKey(key);
+  if (!d) return key;
+  return d.toLocaleDateString(undefined, {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function formatLongMonth(year: number, month: number): string {
+  const d = new Date(year, month - 1, 1);
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "long" });
+}

--- a/src/lib/quick-switch/results.test.ts
+++ b/src/lib/quick-switch/results.test.ts
@@ -111,6 +111,8 @@ describe("computeResults", () => {
       "new",
       "capture",
       "graph",
+      "today",
+      "calendar",
       "tags",
       "notes",
       "pinned",

--- a/src/lib/quick-switch/results.ts
+++ b/src/lib/quick-switch/results.ts
@@ -52,6 +52,20 @@ export const COMMANDS: Array<{
     action: { type: "navigate", to: "/graph" },
   },
   {
+    id: "today",
+    label: "Today",
+    description: "Notes created or edited today",
+    keywords: ["today", "now", "daily"],
+    action: { type: "navigate", to: "/today" },
+  },
+  {
+    id: "calendar",
+    label: "Calendar",
+    description: "Month grid of note activity",
+    keywords: ["calendar", "month", "date"],
+    action: { type: "navigate", to: "/calendar" },
+  },
+  {
     id: "tags",
     label: "Tags",
     description: "Browse all tags",

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -78,6 +78,27 @@ export function useAllNotesForSwitcher(enabled: boolean) {
   });
 }
 
+// Fetches a capped window of recent notes (by vault's default sort, desc) for
+// date-grouped surfaces like /today and /calendar. The vault has no date-range
+// filter, so we client-side bucket. A vault with more than the cap gets the
+// most-recent N — older days on the calendar show empty.
+export function useNotesForDateViews() {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+
+  return useQuery({
+    queryKey: ["notesForDateViews", activeId],
+    enabled: !!client,
+    queryFn: () => {
+      const params = new URLSearchParams();
+      params.set("sort", "desc");
+      params.set("limit", String(VAULT_GRAPH_NOTE_CAP));
+      return client!.queryNotes(params);
+    },
+    staleTime: 60_000,
+  });
+}
+
 export function useAllNotesWithLinks() {
   const client = useActiveVaultClient();
   const activeId = useVaultStore((s) => s.activeVaultId);


### PR DESCRIPTION
## Summary
- **`/today?date=YYYY-MM-DD`** — shows notes created or edited on a given date (defaults to today), with prev/next day links, a jump-to-today shortcut, and a link out to the month calendar. Empty state on "today" offers an `Open capture` shortcut.
- **`/calendar?month=YYYY-MM`** — 7×6 month grid (Sunday-start) with a dot per note created on each day, capped at 5 visible plus a `+N` overflow. Clicking a cell opens `/today?date=…`.
- Adds `today` and `calendar` entries to the Cmd+K command list.

Date keys are local-time `YYYY-MM-DD` strings — a personal-notes app rendered in the user's browser wants days by the user's clock, not the vault's. The vault has no date-range filter, so both views reuse `useNotesForDateViews()` (a capped `sort=desc, limit=5000` window) and bucket client-side. Vaults beyond the cap miss older days on the calendar; documented as a v1 tradeoff — pagination/sampling is a later PR.

Calendar tallies by `createdAt` — "when was this authored" reads more naturally than "when was it last touched" for a month-grid view.

Closes #57

## Test plan
- [x] `bun run test` — 430/430 passing (including 18 new date-helper tests, 7 Today route tests, 7 Calendar route tests)
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)