### PR TITLE
Add saved views stored as UI/Views/* notes

### DIFF
--- a/src/app/routes/Notes.test.tsx
+++ b/src/app/routes/Notes.test.tsx
@@ -61,8 +61,12 @@ function Wrapper({ children }: { children: ReactNode }) {
 }
 
 function lastNotesUrl(fetchImpl: ReturnType<typeof installFetch>): string {
+  // The saved-views sidebar also queries /api/notes (tag=view & views path
+  // prefix). Filter those out so assertions target the primary list query.
   const calls = fetchImpl.mock.calls.map((c) => String(c[0]));
-  const noteCalls = calls.filter((u) => u.includes("/api/notes"));
+  const noteCalls = calls.filter(
+    (u) => u.includes("/api/notes") && !u.includes("path_prefix=UI%2FViews%2F"),
+  );
   return noteCalls[noteCalls.length - 1] ?? "";
 }
 
@@ -72,6 +76,9 @@ describe("Notes route", () => {
     sessionStorage.clear();
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
     seedStore();
+    // BrowserRouter reads from window.history, which persists across tests.
+    // Reset so URL-driven filter state doesn't leak between cases.
+    window.history.replaceState({}, "", "/notes");
   });
 
   afterEach(() => {

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -1,5 +1,14 @@
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useSaveView, useSavedViews } from "@/lib/saved-views/queries";
+import {
+  type SavedView,
+  type SavedViewFilters,
+  filtersToSearchParams,
+  isFiltersNonEmpty,
+  searchParamsToFilters,
+} from "@/lib/saved-views/spec";
 import { relativeTime } from "@/lib/time";
+import { useToastStore } from "@/lib/toast/store";
 import {
   DEFAULT_NOTE_QUERY,
   DEFAULT_PAGE_SIZE,
@@ -12,7 +21,7 @@ import {
 } from "@/lib/vault";
 import { VaultAuthError } from "@/lib/vault/client";
 import type { Note, TagSummary } from "@/lib/vault/types";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useSearchParams } from "react-router";
 
 export type NotesPreset = "pinned" | "archived";
@@ -25,19 +34,57 @@ const PRESET_TITLES: Record<NotesPreset, string> = {
 export function Notes({ preset }: { preset?: NotesPreset } = {}) {
   const activeVault = useVaultStore((s) => s.getActiveVault());
   const { roles } = useTagRoles(activeVault?.id ?? null);
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const [search, setSearch] = useState("");
-  const [pathPrefix, setPathPrefix] = useState("");
-  const initialTags = useMemo(() => searchParams.getAll("tag"), [searchParams]);
-  const [selectedTags, setSelectedTags] = useState<string[]>(initialTags);
-  const [tagMatch, setTagMatch] = useState<"any" | "all">("any");
-  const [sort, setSort] = useState<"asc" | "desc">("desc");
+  // Hydrate filter state from URL on mount and when the URL changes
+  // externally (clicking a saved view rewrites params). Sync direction is
+  // local-state → URL; we track the last-known URL signature to avoid an
+  // immediate echo loop after a user edit.
+  const initial = useMemo(() => searchParamsToFilters(searchParams), [searchParams]);
+  const [search, setSearch] = useState(initial.search ?? "");
+  const [pathPrefix, setPathPrefix] = useState(initial.pathPrefix ?? "");
+  const [selectedTags, setSelectedTags] = useState<string[]>(initial.tags ?? []);
+  const [tagMatch, setTagMatch] = useState<"any" | "all">(initial.tagMatch ?? "any");
+  const [sort, setSort] = useState<"asc" | "desc">(initial.sort ?? "desc");
+  const [showArchived, setShowArchived] = useState(initial.showArchived ?? false);
   const [offset, setOffset] = useState(0);
-  const [showArchived, setShowArchived] = useState(false);
+
+  // Re-sync from URL when navigating between saved views without remount.
+  // Keyed on the params signature so updates from local state (which write
+  // back to the URL) don't loop.
+  const urlSignature = useMemo(() => searchParams.toString(), [searchParams]);
+  useEffect(() => {
+    const f = searchParamsToFilters(new URLSearchParams(urlSignature));
+    setSearch(f.search ?? "");
+    setPathPrefix(f.pathPrefix ?? "");
+    setSelectedTags(f.tags ?? []);
+    setTagMatch(f.tagMatch ?? "any");
+    setSort(f.sort ?? "desc");
+    setShowArchived(f.showArchived ?? false);
+  }, [urlSignature]);
 
   const debouncedSearch = useDebouncedValue(search, 300);
   const debouncedPrefix = useDebouncedValue(pathPrefix, 300);
+
+  // Push the current filter state back to the URL so it's shareable and so
+  // saved-view linking is symmetric. Skip on preset routes (/pinned,
+  // /archived) — those have their own canonical URL.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: writes only when filter dimensions change
+  useEffect(() => {
+    if (preset) return;
+    const next: SavedViewFilters = {
+      search: debouncedSearch,
+      tags: selectedTags,
+      tagMatch,
+      pathPrefix: debouncedPrefix,
+      sort,
+      showArchived,
+    };
+    const desired = filtersToSearchParams(next).toString();
+    if (desired !== urlSignature) {
+      setSearchParams(filtersToSearchParams(next), { replace: true });
+    }
+  }, [preset, debouncedSearch, debouncedPrefix, selectedTags, tagMatch, sort, showArchived]);
 
   // Merge the preset role tag into the query so vault-side filter does the
   // narrowing. User can add more tags on top via TagFilter.
@@ -70,6 +117,35 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
 
   const notes = useNotes(queryState);
   const tags = useTags();
+  const savedViews = useSavedViews(roles.view);
+  const saveView = useSaveView(roles.view);
+  const pushToast = useToastStore((s) => s.push);
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+
+  const currentFilters: SavedViewFilters = useMemo(
+    () => ({
+      search: debouncedSearch,
+      tags: selectedTags,
+      tagMatch,
+      pathPrefix: debouncedPrefix,
+      sort,
+      showArchived,
+    }),
+    [debouncedSearch, debouncedPrefix, selectedTags, tagMatch, sort, showArchived],
+  );
+
+  const onSaveView = useCallback(
+    async (name: string) => {
+      try {
+        await saveView.mutateAsync({ name, filters: currentFilters });
+        pushToast(`Saved view "${name}".`, "success");
+        setShowSaveDialog(false);
+      } catch (err) {
+        pushToast(`Could not save view: ${(err as Error).message}`, "error");
+      }
+    },
+    [saveView, currentFilters, pushToast],
+  );
 
   // Client-side post-process: hide archived on default list unless toggled, and
   // pinned-first stable sort on default list. Preset views skip both.
@@ -97,9 +173,10 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
   const pageLast = offset + (displayNotes?.length ?? 0);
   const hasPrev = offset > 0;
   const hasNext = (notes.data?.length ?? 0) === DEFAULT_PAGE_SIZE;
+  const filteringActive = isFiltersNonEmpty(currentFilters);
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-10">
+    <div className="mx-auto max-w-6xl px-6 py-10">
       <header className="mb-6 flex items-baseline justify-between gap-4">
         <div>
           <p className="text-xs uppercase tracking-wider text-fg-dim">{activeVault.name}</p>
@@ -133,77 +210,218 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
         </div>
       </header>
 
-      <div className="mb-6 space-y-3">
-        <input
-          type="search"
-          placeholder="Search…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-fg focus:border-accent focus:outline-none"
-          aria-label="Search notes"
-        />
-        <div className="flex flex-wrap items-start gap-3">
-          <input
-            type="text"
-            placeholder="Path starts with…"
-            value={pathPrefix}
-            onChange={(e) => setPathPrefix(e.target.value)}
-            className="flex-1 min-w-48 rounded-md border border-border bg-card px-3 py-2 font-mono text-sm text-fg focus:border-accent focus:outline-none"
-            aria-label="Filter by path prefix"
+      <div className={preset ? "" : "grid gap-6 md:grid-cols-[14rem_1fr]"}>
+        {!preset ? (
+          <SavedViewsSidebar
+            views={savedViews.data}
+            isPending={savedViews.isPending}
+            error={savedViews.error}
           />
-          <TagFilter
-            tags={tags.data ?? []}
-            selected={selectedTags}
-            onToggle={(name) =>
-              setSelectedTags((cur) =>
-                cur.includes(name) ? cur.filter((t) => t !== name) : [...cur, name],
-              )
-            }
-            tagMatch={tagMatch}
-            onTagMatchChange={setTagMatch}
-            onClear={() => setSelectedTags([])}
-          />
+        ) : null}
+
+        <div>
+          <div className="mb-6 space-y-3">
+            <input
+              type="search"
+              placeholder="Search…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-fg focus:border-accent focus:outline-none"
+              aria-label="Search notes"
+            />
+            <div className="flex flex-wrap items-start gap-3">
+              <input
+                type="text"
+                placeholder="Path starts with…"
+                value={pathPrefix}
+                onChange={(e) => setPathPrefix(e.target.value)}
+                className="flex-1 min-w-48 rounded-md border border-border bg-card px-3 py-2 font-mono text-sm text-fg focus:border-accent focus:outline-none"
+                aria-label="Filter by path prefix"
+              />
+              <TagFilter
+                tags={tags.data ?? []}
+                selected={selectedTags}
+                onToggle={(name) =>
+                  setSelectedTags((cur) =>
+                    cur.includes(name) ? cur.filter((t) => t !== name) : [...cur, name],
+                  )
+                }
+                tagMatch={tagMatch}
+                onTagMatchChange={setTagMatch}
+                onClear={() => setSelectedTags([])}
+              />
+              {!preset && filteringActive ? (
+                <button
+                  type="button"
+                  onClick={() => setShowSaveDialog(true)}
+                  className="rounded-md border border-accent/60 bg-accent/10 px-3 py-2 text-sm text-accent hover:bg-accent/20"
+                >
+                  Save view…
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          {notes.isPending ? (
+            <SkeletonRows />
+          ) : notes.isError ? (
+            <ErrorBlock error={notes.error} />
+          ) : displayNotes && displayNotes.length > 0 ? (
+            <ol className="divide-y divide-border rounded-md border border-border bg-card">
+              {displayNotes.map((n) => (
+                <NoteRow
+                  key={n.id}
+                  note={n}
+                  pinnedTag={roles.pinned}
+                  archivedTag={roles.archived}
+                />
+              ))}
+            </ol>
+          ) : (
+            <EmptyBlock filtering={isFilteringActive(queryState) || !!preset} />
+          )}
+
+          <div className="mt-6 flex items-center justify-between text-sm text-fg-dim">
+            <span>
+              {notes.data && notes.data.length > 0
+                ? `Showing ${pageFirst}–${pageLast}`
+                : notes.isFetching
+                  ? "Loading…"
+                  : ""}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={!hasPrev}
+                onClick={() => setOffset((o) => Math.max(0, o - DEFAULT_PAGE_SIZE))}
+                className="rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted enabled:hover:text-accent disabled:opacity-40"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                disabled={!hasNext}
+                onClick={() => setOffset((o) => o + DEFAULT_PAGE_SIZE)}
+                className="rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted enabled:hover:text-accent disabled:opacity-40"
+              >
+                Next
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
-      {notes.isPending ? (
-        <SkeletonRows />
-      ) : notes.isError ? (
-        <ErrorBlock error={notes.error} />
-      ) : displayNotes && displayNotes.length > 0 ? (
-        <ol className="divide-y divide-border rounded-md border border-border bg-card">
-          {displayNotes.map((n) => (
-            <NoteRow key={n.id} note={n} pinnedTag={roles.pinned} archivedTag={roles.archived} />
-          ))}
-        </ol>
-      ) : (
-        <EmptyBlock filtering={isFilteringActive(queryState) || !!preset} />
-      )}
+      {showSaveDialog ? (
+        <SaveViewDialog
+          existing={savedViews.data ?? []}
+          isSaving={saveView.isPending}
+          onCancel={() => setShowSaveDialog(false)}
+          onSave={onSaveView}
+        />
+      ) : null}
+    </div>
+  );
+}
 
-      <div className="mt-6 flex items-center justify-between text-sm text-fg-dim">
-        <span>
-          {notes.data && notes.data.length > 0
-            ? `Showing ${pageFirst}–${pageLast}`
-            : notes.isFetching
-              ? "Loading…"
-              : ""}
-        </span>
-        <div className="flex gap-2">
+function SavedViewsSidebar({
+  views,
+  isPending,
+  error,
+}: {
+  views: SavedView[] | undefined;
+  isPending: boolean;
+  error: Error | null;
+}) {
+  return (
+    <aside className="md:sticky md:top-6 md:self-start">
+      <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">Saved views</h2>
+      {isPending ? (
+        <p className="text-xs text-fg-dim">Loading…</p>
+      ) : error ? (
+        <p className="text-xs text-red-400">Could not load views.</p>
+      ) : !views || views.length === 0 ? (
+        <p className="text-xs text-fg-dim">
+          None yet. Apply a filter and click “Save view” to add one.
+        </p>
+      ) : (
+        <ul className="space-y-1" aria-label="Saved views">
+          {views.map((v) => (
+            <li key={v.id}>
+              <Link
+                to={`/notes?${filtersToSearchParams(v.filters).toString()}`}
+                className="block truncate rounded-md border border-transparent px-2 py-1 text-sm text-fg-muted hover:border-border hover:bg-card hover:text-accent"
+              >
+                {v.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}
+
+function SaveViewDialog({
+  existing,
+  isSaving,
+  onCancel,
+  onSave,
+}: {
+  existing: SavedView[];
+  isSaving: boolean;
+  onCancel: () => void;
+  onSave: (name: string) => void;
+}) {
+  const [name, setName] = useState("");
+  const trimmed = name.trim();
+  const collides = existing.some((v) => v.name.toLowerCase() === trimmed.toLowerCase());
+  const canSave = trimmed.length > 0 && !collides && !isSaving;
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
+      // biome-ignore lint/a11y/useSemanticElements: native <dialog> requires imperative showModal()/close(); we want declarative open=showSaveDialog
+      role="dialog"
+      aria-modal="true"
+      aria-label="Save view"
+    >
+      <div className="w-full max-w-sm rounded-md border border-border bg-card p-5">
+        <h3 className="mb-3 font-serif text-lg text-fg">Save view</h3>
+        <label className="block text-sm">
+          <span className="mb-1 block text-fg-muted">Name</span>
+          <input
+            type="text"
+            value={name}
+            // biome-ignore lint/a11y/noAutofocus: dialog focus
+            autoFocus
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canSave) onSave(trimmed);
+              if (e.key === "Escape") onCancel();
+            }}
+            placeholder="e.g. Daily journal"
+            aria-label="View name"
+            className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg focus:border-accent focus:outline-none"
+          />
+        </label>
+        {collides ? (
+          <p className="mt-2 text-xs text-red-400">A view with that name already exists.</p>
+        ) : null}
+        <div className="mt-4 flex justify-end gap-2">
           <button
             type="button"
-            disabled={!hasPrev}
-            onClick={() => setOffset((o) => Math.max(0, o - DEFAULT_PAGE_SIZE))}
-            className="rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted enabled:hover:text-accent disabled:opacity-40"
+            onClick={onCancel}
+            className="rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted hover:text-accent"
           >
-            Previous
+            Cancel
           </button>
           <button
             type="button"
-            disabled={!hasNext}
-            onClick={() => setOffset((o) => o + DEFAULT_PAGE_SIZE)}
-            className="rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted enabled:hover:text-accent disabled:opacity-40"
+            onClick={() => canSave && onSave(trimmed)}
+            disabled={!canSave}
+            className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-40"
           >
-            Next
+            {isSaving ? "Saving…" : "Save"}
           </button>
         </div>
       </div>

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -230,6 +230,10 @@ const ROLE_LABELS: Record<TagRoleKey, { title: string; help: string }> = {
     title: "Text capture",
     help: "Default tag for quick typed notes.",
   },
+  view: {
+    title: "Saved view",
+    help: "Tag the /notes saved-view notes carry. Used to list them.",
+  },
 };
 
 function TagRolesSection({ vaultId }: { vaultId: string }) {

--- a/src/lib/saved-views/queries.ts
+++ b/src/lib/saved-views/queries.ts
@@ -1,0 +1,71 @@
+import { useActiveVaultClient } from "@/lib/vault/queries";
+import { useVaultStore } from "@/lib/vault/store";
+import type { Note } from "@/lib/vault/types";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type SavedView,
+  type SavedViewFilters,
+  VIEWS_PATH_PREFIX,
+  decodeView,
+  encodeFiltersMetadata,
+  pathForName,
+} from "./spec";
+
+// Listing strategy: ask the vault for notes tagged with the role's view tag,
+// then filter to the conventional UI/Views/ prefix and decode metadata. The
+// path filter is the safety net — a stray "view"-tagged note outside that
+// folder shouldn't crash the sidebar.
+export function useSavedViews(viewTag: string) {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+
+  return useQuery({
+    queryKey: ["savedViews", activeId, viewTag],
+    enabled: !!client && !!viewTag,
+    queryFn: async (): Promise<SavedView[]> => {
+      const params = new URLSearchParams();
+      params.set("tag", viewTag);
+      params.set("path_prefix", VIEWS_PATH_PREFIX);
+      params.set("sort", "asc");
+      const notes = await client!.queryNotes(params);
+      return notes
+        .map((n) => decodeView(n))
+        .filter((v): v is SavedView => v !== null)
+        .sort((a, b) => a.name.localeCompare(b.name));
+    },
+    staleTime: 30_000,
+  });
+}
+
+interface SaveArgs {
+  name: string;
+  filters: SavedViewFilters;
+  description?: string;
+}
+
+// Creates a fresh saved-view note. Existing-name conflicts surface as the
+// vault's normal create error; this PR doesn't auto-overwrite — the dialog
+// asks the user for a different name.
+export function useSaveView(viewTag: string) {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (args: SaveArgs): Promise<Note> => {
+      if (!client) throw new Error("No active vault");
+      return client.createNote({
+        path: pathForName(args.name),
+        content: args.description ?? "",
+        tags: [viewTag],
+        metadata: encodeFiltersMetadata(args.filters),
+      });
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["savedViews", activeId] });
+      qc.invalidateQueries({ queryKey: ["notes", activeId] });
+      qc.invalidateQueries({ queryKey: ["tags", activeId] });
+      qc.invalidateQueries({ queryKey: ["vaultInfo", activeId] });
+    },
+  });
+}

--- a/src/lib/saved-views/spec.test.ts
+++ b/src/lib/saved-views/spec.test.ts
@@ -1,0 +1,158 @@
+import type { Note } from "@/lib/vault/types";
+import { describe, expect, it } from "vitest";
+import {
+  SAVED_VIEW_KIND,
+  VIEWS_PATH_PREFIX,
+  decodeView,
+  encodeFiltersMetadata,
+  filtersToSearchParams,
+  isFiltersNonEmpty,
+  nameFromPath,
+  pathForName,
+  searchParamsToFilters,
+} from "./spec";
+
+describe("encodeFiltersMetadata", () => {
+  it("emits kind and only the non-empty filter fields", () => {
+    expect(encodeFiltersMetadata({ search: "  hello  ", tags: [] })).toEqual({
+      kind: SAVED_VIEW_KIND,
+      filters: { search: "hello" },
+    });
+  });
+
+  it("includes tagMatch only when more than one tag is selected", () => {
+    expect(encodeFiltersMetadata({ tags: ["a"], tagMatch: "all" })).toEqual({
+      kind: SAVED_VIEW_KIND,
+      filters: { tags: ["a"] },
+    });
+    expect(encodeFiltersMetadata({ tags: ["a", "b"], tagMatch: "all" })).toEqual({
+      kind: SAVED_VIEW_KIND,
+      filters: { tags: ["a", "b"], tagMatch: "all" },
+    });
+  });
+
+  it("preserves sort, pathPrefix, and showArchived when set", () => {
+    const out = encodeFiltersMetadata({
+      pathPrefix: "Projects/",
+      sort: "asc",
+      showArchived: true,
+    });
+    expect(out.filters).toEqual({
+      pathPrefix: "Projects/",
+      sort: "asc",
+      showArchived: true,
+    });
+  });
+});
+
+describe("decodeView", () => {
+  const baseNote = (extras: Partial<Note> = {}): Note => ({
+    id: "v1",
+    path: "UI/Views/Daily.md",
+    createdAt: "2026-04-19T00:00:00Z",
+    metadata: { kind: SAVED_VIEW_KIND, filters: { search: "x", tags: ["a"] } },
+    ...extras,
+  });
+
+  it("returns null when metadata isn't a saved view", () => {
+    expect(decodeView({ ...baseNote(), metadata: undefined })).toBeNull();
+    expect(decodeView({ ...baseNote(), metadata: { kind: "note" } })).toBeNull();
+  });
+
+  it("decodes a well-formed saved view", () => {
+    const v = decodeView(baseNote());
+    expect(v).not.toBeNull();
+    expect(v?.id).toBe("v1");
+    expect(v?.name).toBe("Daily");
+    expect(v?.filters.search).toBe("x");
+    expect(v?.filters.tags).toEqual(["a"]);
+  });
+
+  it("falls back to id when path is outside the views folder", () => {
+    const v = decodeView(baseNote({ path: "Random/Note.md" }));
+    expect(v?.name).toBe("v1");
+  });
+
+  it("ignores junk values for sort, tagMatch, and showArchived", () => {
+    const v = decodeView(
+      baseNote({
+        metadata: {
+          kind: SAVED_VIEW_KIND,
+          filters: { sort: "bogus", tagMatch: "wat", showArchived: "yes" },
+        },
+      }),
+    );
+    expect(v?.filters.sort).toBeUndefined();
+    expect(v?.filters.tagMatch).toBeUndefined();
+    expect(v?.filters.showArchived).toBe(false);
+  });
+
+  it("filters non-string entries out of tags", () => {
+    const v = decodeView(
+      baseNote({
+        metadata: { kind: SAVED_VIEW_KIND, filters: { tags: ["a", 7, null, "b"] } },
+      }),
+    );
+    expect(v?.filters.tags).toEqual(["a", "b"]);
+  });
+});
+
+describe("nameFromPath / pathForName", () => {
+  it("nameFromPath strips the prefix and trailing .md", () => {
+    expect(nameFromPath("UI/Views/Daily.md")).toBe("Daily");
+    expect(nameFromPath("UI/Views/Untagged")).toBe("Untagged");
+    expect(nameFromPath("Other/Path.md")).toBeNull();
+    expect(nameFromPath(undefined)).toBeNull();
+  });
+
+  it("pathForName slots the name into the prefix and rejects slashes", () => {
+    expect(pathForName("Daily")).toBe(`${VIEWS_PATH_PREFIX}Daily`);
+    expect(pathForName("  Daily  ")).toBe(`${VIEWS_PATH_PREFIX}Daily`);
+    expect(pathForName("a/b")).toBe(`${VIEWS_PATH_PREFIX}a-b`);
+  });
+});
+
+describe("filtersToSearchParams round-trip", () => {
+  it("encodes every filter dimension and parses it back identically", () => {
+    const filters = {
+      search: "draft",
+      tags: ["alpha", "beta"],
+      tagMatch: "all" as const,
+      pathPrefix: "Projects/",
+      sort: "asc" as const,
+      showArchived: true,
+    };
+    const params = filtersToSearchParams(filters);
+    expect(params.get("search")).toBe("draft");
+    expect(params.getAll("tag")).toEqual(["alpha", "beta"]);
+    expect(params.get("tag_match")).toBe("all");
+    expect(params.get("path_prefix")).toBe("Projects/");
+    expect(params.get("sort")).toBe("asc");
+    expect(params.get("show_archived")).toBe("1");
+
+    const back = searchParamsToFilters(params);
+    expect(back).toEqual(filters);
+  });
+
+  it("omits empty fields from the URL", () => {
+    expect(filtersToSearchParams({ search: "  " }).toString()).toBe("");
+  });
+
+  it("searchParamsToFilters tolerates an empty URL", () => {
+    expect(searchParamsToFilters(new URLSearchParams()).tags).toBeUndefined();
+  });
+});
+
+describe("isFiltersNonEmpty", () => {
+  it("returns true when any of search, tags, or pathPrefix is present", () => {
+    expect(isFiltersNonEmpty({ search: "x" })).toBe(true);
+    expect(isFiltersNonEmpty({ tags: ["a"] })).toBe(true);
+    expect(isFiltersNonEmpty({ pathPrefix: "P/" })).toBe(true);
+  });
+
+  it("returns false for sort/showArchived alone — they don't make a meaningful saved view", () => {
+    expect(isFiltersNonEmpty({ sort: "asc" })).toBe(false);
+    expect(isFiltersNonEmpty({ showArchived: true })).toBe(false);
+    expect(isFiltersNonEmpty({})).toBe(false);
+  });
+});

--- a/src/lib/saved-views/spec.ts
+++ b/src/lib/saved-views/spec.ts
@@ -1,0 +1,119 @@
+import type { Note } from "@/lib/vault/types";
+
+// A saved view is a regular vault note with `kind: saved-view` in metadata.
+// Storing filter state in the vault (rather than localStorage) means views
+// follow you across devices and stay agent-readable. The conventional path
+// is `UI/Views/<name>` and the role-tagged tag (default `view`) lets the
+// list query filter cheaply.
+
+export const VIEWS_PATH_PREFIX = "UI/Views/";
+export const SAVED_VIEW_KIND = "saved-view";
+
+export interface SavedViewFilters {
+  search?: string;
+  tags?: string[];
+  tagMatch?: "any" | "all";
+  pathPrefix?: string;
+  sort?: "asc" | "desc";
+  showArchived?: boolean;
+}
+
+export interface SavedView {
+  id: string;
+  name: string;
+  filters: SavedViewFilters;
+  description?: string;
+}
+
+// Build the canonical metadata blob the vault stores. Only emit fields
+// that are actually set so a view note round-trips minimally.
+export function encodeFiltersMetadata(filters: SavedViewFilters): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (filters.search?.trim()) out.search = filters.search.trim();
+  if (filters.tags && filters.tags.length > 0) out.tags = [...filters.tags];
+  if (filters.tags && filters.tags.length > 1 && filters.tagMatch) out.tagMatch = filters.tagMatch;
+  if (filters.pathPrefix?.trim()) out.pathPrefix = filters.pathPrefix.trim();
+  if (filters.sort) out.sort = filters.sort;
+  if (filters.showArchived) out.showArchived = true;
+  return { kind: SAVED_VIEW_KIND, filters: out };
+}
+
+// Inverse: pull a typed SavedView out of a vault Note. Returns null when the
+// note's metadata doesn't carry the saved-view shape.
+export function decodeView(note: Note): SavedView | null {
+  const meta = note.metadata as { kind?: unknown; filters?: unknown } | undefined;
+  if (!meta || meta.kind !== SAVED_VIEW_KIND) return null;
+  const f = (meta.filters ?? {}) as Record<string, unknown>;
+  const name = nameFromPath(note.path) ?? note.id;
+  return {
+    id: note.id,
+    name,
+    filters: {
+      search: typeof f.search === "string" ? f.search : undefined,
+      tags: Array.isArray(f.tags)
+        ? f.tags.filter((x): x is string => typeof x === "string")
+        : undefined,
+      tagMatch: f.tagMatch === "all" ? "all" : f.tagMatch === "any" ? "any" : undefined,
+      pathPrefix: typeof f.pathPrefix === "string" ? f.pathPrefix : undefined,
+      sort: f.sort === "asc" ? "asc" : f.sort === "desc" ? "desc" : undefined,
+      showArchived: f.showArchived === true,
+    },
+  };
+}
+
+// Pull the bare display name from a `UI/Views/<name>` path. Strips the
+// prefix and the trailing `.md` if the vault appended one.
+export function nameFromPath(path: string | undefined): string | null {
+  if (!path) return null;
+  if (!path.startsWith(VIEWS_PATH_PREFIX)) return null;
+  const rest = path.slice(VIEWS_PATH_PREFIX.length);
+  return rest.replace(/\.md$/i, "") || null;
+}
+
+// Construct the path the vault will store the view under. Names are not
+// allowed to contain slashes — that would create nested folders, which
+// confuses the list query and the rename UI we don't have yet.
+export function pathForName(name: string): string {
+  const safe = name.trim().replace(/[/\\]/g, "-");
+  return `${VIEWS_PATH_PREFIX}${safe}`;
+}
+
+// Encode the current filter state as URL search params for the /notes
+// route. Same shape as buildNoteQueryParams except we also pass the
+// non-server params (tagMatch always — even single tag — so applying a
+// view round-trips exactly; show_archived; sort).
+export function filtersToSearchParams(filters: SavedViewFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (filters.search?.trim()) params.set("search", filters.search.trim());
+  for (const t of filters.tags ?? []) params.append("tag", t);
+  if (filters.tagMatch) params.set("tag_match", filters.tagMatch);
+  if (filters.pathPrefix?.trim()) params.set("path_prefix", filters.pathPrefix.trim());
+  if (filters.sort) params.set("sort", filters.sort);
+  if (filters.showArchived) params.set("show_archived", "1");
+  return params;
+}
+
+// Inverse: read URL search params (from /notes?...) into a filter spec so
+// the route can hydrate its local state from the URL on mount.
+export function searchParamsToFilters(params: URLSearchParams): SavedViewFilters {
+  const tags = params.getAll("tag");
+  const tagMatch = params.get("tag_match");
+  const sort = params.get("sort");
+  return {
+    search: params.get("search") ?? undefined,
+    tags: tags.length > 0 ? tags : undefined,
+    tagMatch: tagMatch === "all" ? "all" : tagMatch === "any" ? "any" : undefined,
+    pathPrefix: params.get("path_prefix") ?? undefined,
+    sort: sort === "asc" ? "asc" : sort === "desc" ? "desc" : undefined,
+    showArchived: params.get("show_archived") === "1",
+  };
+}
+
+// True when at least one filter dimension is set. Used to gate the
+// "Save view" button — saving an empty view is meaningless.
+export function isFiltersNonEmpty(filters: SavedViewFilters): boolean {
+  if (filters.search?.trim()) return true;
+  if (filters.tags && filters.tags.length > 0) return true;
+  if (filters.pathPrefix?.trim()) return true;
+  return false;
+}

--- a/src/lib/vault/tag-roles.test.ts
+++ b/src/lib/vault/tag-roles.test.ts
@@ -19,12 +19,14 @@ describe("tag roles storage", () => {
       archived: "done",
       captureVoice: "memo",
       captureText: "inbox",
+      view: "preset",
     });
     expect(loadTagRoles("v1")).toEqual({
       pinned: "favs",
       archived: "done",
       captureVoice: "memo",
       captureText: "inbox",
+      view: "preset",
     });
   });
 
@@ -41,12 +43,14 @@ describe("tag roles storage", () => {
       archived: "#done",
       captureVoice: " voice ",
       captureText: "#quick",
+      view: "#preset ",
     });
     expect(loadTagRoles("v1")).toEqual({
       pinned: "starred",
       archived: "done",
       captureVoice: "voice",
       captureText: "quick",
+      view: "preset",
     });
   });
 
@@ -56,6 +60,7 @@ describe("tag roles storage", () => {
       archived: "",
       captureVoice: "#",
       captureText: "keep",
+      view: "",
     });
     const out = loadTagRoles("v1");
     expect(out.pinned).toBe(DEFAULT_TAG_ROLES.pinned);
@@ -71,6 +76,7 @@ describe("tag roles storage", () => {
     expect(out.archived).toBe(DEFAULT_TAG_ROLES.archived);
     expect(out.captureVoice).toBe(DEFAULT_TAG_ROLES.captureVoice);
     expect(out.captureText).toBe(DEFAULT_TAG_ROLES.captureText);
+    expect(out.view).toBe(DEFAULT_TAG_ROLES.view);
   });
 
   it("returns defaults on malformed JSON", () => {

--- a/src/lib/vault/tag-roles.ts
+++ b/src/lib/vault/tag-roles.ts
@@ -13,6 +13,7 @@ export interface TagRoles {
   archived: string;
   captureVoice: string;
   captureText: string;
+  view: string;
 }
 
 export const DEFAULT_TAG_ROLES: TagRoles = {
@@ -20,9 +21,10 @@ export const DEFAULT_TAG_ROLES: TagRoles = {
   archived: "archived",
   captureVoice: "voice",
   captureText: "quick",
+  view: "view",
 };
 
-export const TAG_ROLE_KEYS = ["pinned", "archived", "captureVoice", "captureText"] as const;
+export const TAG_ROLE_KEYS = ["pinned", "archived", "captureVoice", "captureText", "view"] as const;
 export type TagRoleKey = (typeof TAG_ROLE_KEYS)[number];
 
 const STORAGE_PREFIX = "lens:tag-roles:";
@@ -47,6 +49,7 @@ export function loadTagRoles(vaultId: string): TagRoles {
       archived: normalizeTag(parsed.archived, DEFAULT_TAG_ROLES.archived),
       captureVoice: normalizeTag(parsed.captureVoice, DEFAULT_TAG_ROLES.captureVoice),
       captureText: normalizeTag(parsed.captureText, DEFAULT_TAG_ROLES.captureText),
+      view: normalizeTag(parsed.view, DEFAULT_TAG_ROLES.view),
     };
   } catch {
     return { ...DEFAULT_TAG_ROLES };
@@ -59,6 +62,7 @@ export function saveTagRoles(vaultId: string, roles: TagRoles): void {
     archived: normalizeTag(roles.archived, DEFAULT_TAG_ROLES.archived),
     captureVoice: normalizeTag(roles.captureVoice, DEFAULT_TAG_ROLES.captureVoice),
     captureText: normalizeTag(roles.captureText, DEFAULT_TAG_ROLES.captureText),
+    view: normalizeTag(roles.view, DEFAULT_TAG_ROLES.view),
   };
   try {
     localStorage.setItem(keyFor(vaultId), JSON.stringify(normalized));


### PR DESCRIPTION
## Summary
- Save the current /notes filter set into the vault as a regular note tagged with the per-vault `view` role tag and `kind: saved-view` metadata. Storing views in the vault means they sync across devices and stay agent-readable.
- /notes filter state is now URL-driven (`?search=...&tag=...&path_prefix=...&sort=...&show_archived=1`), so each saved view is a shareable link and applying a view is just navigation. Sidebar renders saved views; "Save view" button captures the current state when at least one of search/tags/path is set.
- Added a fifth tag role `view` (default `view`) so users can rename the view-marker tag in Settings without touching code; consistent with the project's per-vault customization primitive.

Closes #59 (v0.3 #29).

## Test plan
- [x] `bun run test` — 445/445 passing (15 new in `saved-views/spec.test.ts`, 9 in updated `Notes.test.tsx`, +1 `view` role coverage in `tag-roles.test.ts`)
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run build` clean
- [ ] Manual smoke: filter notes, click Save view, name it, see it appear in sidebar; click sidebar link → URL & filters re-hydrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)