### PR TITLE
Add services.json registration and VITE_BASE_PATH support

### DIFF
--- a/scripts/notes-service-plugin.ts
+++ b/scripts/notes-service-plugin.ts
@@ -1,0 +1,58 @@
+import type { AddressInfo } from "node:net";
+import type { Plugin, PreviewServer, ViteDevServer } from "vite";
+import {
+  type ServiceEntry,
+  ServicesManifestError,
+  servicesManifestPath,
+  upsertService,
+} from "./services-manifest";
+
+interface PluginOptions {
+  name: string;
+  version: string;
+  basePath: string;
+}
+
+// Notes is an SPA — no long-running Node entrypoint that would otherwise own
+// the manifest write. Hook the Vite dev + preview servers instead so the
+// manifest reflects the actual listening port. We deliberately do NOT write
+// during `vite build` (no port to advertise; the CLI's expose tool registers
+// the served bundle).
+//
+// Best-effort: a manifest write failure (PARACHUTE_HOME unwritable, schema
+// drift, malformed pre-existing file) only logs a warning. Don't break dev.
+export function notesServicePlugin(options: PluginOptions): Plugin {
+  const { name, version, basePath } = options;
+  const healthPath = basePath.endsWith("/") ? basePath : `${basePath}/`;
+
+  function writeEntry(port: number): void {
+    const entry: ServiceEntry = {
+      name,
+      port,
+      paths: [healthPath],
+      health: healthPath,
+      version,
+    };
+    try {
+      upsertService(entry);
+    } catch (err) {
+      const msg = err instanceof ServicesManifestError ? err.message : String(err);
+      console.log(`  Warning: could not update ${servicesManifestPath()}: ${msg}`);
+    }
+  }
+
+  function attach(server: ViteDevServer | PreviewServer): void {
+    server.httpServer?.once("listening", () => {
+      const address = server.httpServer?.address();
+      const port = typeof address === "object" && address ? (address as AddressInfo).port : null;
+      if (port) writeEntry(port);
+    });
+  }
+
+  return {
+    name: "parachute-notes-service-manifest",
+    apply: (_config, env) => env.command === "serve",
+    configureServer: attach,
+    configurePreviewServer: attach,
+  };
+}

--- a/scripts/services-manifest.test.ts
+++ b/scripts/services-manifest.test.ts
@@ -1,0 +1,132 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  type ServiceEntry,
+  ServicesManifestError,
+  readManifest,
+  servicesManifestPath,
+  upsertService,
+} from "./services-manifest";
+
+function tempPath(): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pnotes-manifest-"));
+  const path = join(dir, "services.json");
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+const notes: ServiceEntry = {
+  name: "parachute-notes",
+  port: 5173,
+  paths: ["/"],
+  health: "/",
+  version: "0.0.1",
+};
+
+const vault: ServiceEntry = {
+  name: "parachute-vault",
+  port: 1940,
+  paths: ["/"],
+  health: "/health",
+  version: "0.2.4",
+};
+
+describe("services-manifest", () => {
+  it("readManifest returns empty when file missing", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      expect(readManifest(path)).toEqual({ services: [] });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("upsertService creates the file if missing", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      const m = upsertService(notes, path);
+      expect(m.services).toEqual([notes]);
+      expect(readManifest(path)).toEqual({ services: [notes] });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("upsertService updates by name and never duplicates", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      upsertService(notes, path);
+      const updated = { ...notes, port: 4200, version: "0.1.0" };
+      upsertService(updated, path);
+      const m = readManifest(path);
+      expect(m.services).toHaveLength(1);
+      expect(m.services[0]).toEqual(updated);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("upsertService preserves entries written by other services", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      writeFileSync(path, `${JSON.stringify({ services: [vault] }, null, 2)}\n`);
+      upsertService(notes, path);
+      const m = readManifest(path);
+      expect(m.services).toHaveLength(2);
+      expect(m.services.find((s) => s.name === "parachute-vault")).toEqual(vault);
+      expect(m.services.find((s) => s.name === "parachute-notes")).toEqual(notes);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("upsertService writes pretty-printed JSON with trailing newline", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      upsertService(notes, path);
+      const raw = readFileSync(path, "utf8");
+      expect(raw).toBe(`${JSON.stringify({ services: [notes] }, null, 2)}\n`);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("readManifest throws ServicesManifestError on malformed JSON", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      writeFileSync(path, "{ not json");
+      expect(() => readManifest(path)).toThrow(ServicesManifestError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("upsertService rejects an invalid entry without touching the file", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      writeFileSync(path, `${JSON.stringify({ services: [vault] }, null, 2)}\n`);
+      const bad = { ...notes, port: -1 };
+      expect(() => upsertService(bad as ServiceEntry, path)).toThrow(ServicesManifestError);
+      expect(readManifest(path)).toEqual({ services: [vault] });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("default path honors PARACHUTE_HOME set at runtime", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pnotes-home-"));
+    const prior = process.env.PARACHUTE_HOME;
+    process.env.PARACHUTE_HOME = dir;
+    try {
+      expect(servicesManifestPath()).toBe(join(dir, "services.json"));
+      upsertService(notes);
+      expect(readManifest()).toEqual({ services: [notes] });
+    } finally {
+      // biome-ignore lint/performance/noDelete: process.env coerces assignments to strings; only delete actually unsets the key
+      if (prior === undefined) delete process.env.PARACHUTE_HOME;
+      else process.env.PARACHUTE_HOME = prior;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/services-manifest.ts
+++ b/scripts/services-manifest.ts
@@ -1,0 +1,106 @@
+// Per-host service registry shared across the Parachute ecosystem. Vault and
+// scribe each carry their own copy of this helper rather than depending on
+// `@openparachute/cli`. Notes does the same so launch surfaces (CLI expose,
+// Funnel, dashboards) can find a running dev server without coordination.
+//
+// The schema (name/port/paths/health/version) and validation are locked by
+// `@openparachute/cli`'s `services-manifest.ts`. If you change them here,
+// keep them in sync there.
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export function servicesManifestPath(): string {
+  const root = process.env.PARACHUTE_HOME ?? join(homedir(), ".parachute");
+  return join(root, "services.json");
+}
+
+export interface ServiceEntry {
+  name: string;
+  port: number;
+  paths: string[];
+  health: string;
+  version: string;
+}
+
+export interface ServicesManifest {
+  services: ServiceEntry[];
+}
+
+export class ServicesManifestError extends Error {
+  override name = "ServicesManifestError";
+}
+
+function validateEntry(raw: unknown, where: string): ServiceEntry {
+  if (!raw || typeof raw !== "object") {
+    throw new ServicesManifestError(`${where}: expected object, got ${typeof raw}`);
+  }
+  const e = raw as Record<string, unknown>;
+  const { name, port, paths, health, version } = e;
+  if (typeof name !== "string" || name.length === 0) {
+    throw new ServicesManifestError(`${where}: "name" must be a non-empty string`);
+  }
+  if (typeof port !== "number" || !Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new ServicesManifestError(`${where}: "port" must be an integer 1..65535`);
+  }
+  if (!Array.isArray(paths) || paths.some((p) => typeof p !== "string")) {
+    throw new ServicesManifestError(`${where}: "paths" must be an array of strings`);
+  }
+  if (typeof health !== "string" || !health.startsWith("/")) {
+    throw new ServicesManifestError(`${where}: "health" must be a path starting with "/"`);
+  }
+  if (typeof version !== "string") {
+    throw new ServicesManifestError(`${where}: "version" must be a string`);
+  }
+  return { name, port, paths: paths as string[], health, version };
+}
+
+function validateManifest(raw: unknown, where: string): ServicesManifest {
+  if (!raw || typeof raw !== "object") {
+    throw new ServicesManifestError(`${where}: root must be an object`);
+  }
+  const services = (raw as Record<string, unknown>).services;
+  if (!Array.isArray(services)) {
+    throw new ServicesManifestError(`${where}: "services" must be an array`);
+  }
+  return {
+    services: services.map((s, i) => validateEntry(s, `${where} services[${i}]`)),
+  };
+}
+
+export function readManifest(path: string = servicesManifestPath()): ServicesManifest {
+  if (!existsSync(path)) return { services: [] };
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new ServicesManifestError(
+      `failed to parse ${path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return validateManifest(raw, path);
+}
+
+function writeManifest(manifest: ServicesManifest, path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+export function upsertService(
+  entry: ServiceEntry,
+  path: string = servicesManifestPath(),
+): ServicesManifest {
+  validateEntry(entry, "entry");
+  const current = readManifest(path);
+  const idx = current.services.findIndex((s) => s.name === entry.name);
+  if (idx >= 0) {
+    current.services[idx] = entry;
+  } else {
+    current.services.push(entry);
+  }
+  writeManifest(current, path);
+  return current;
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -24,7 +24,7 @@ export function App() {
   return (
     <QueryProvider>
       <SyncProvider>
-        <BrowserRouter>
+        <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "") || undefined}>
           <div className="min-h-dvh bg-bg text-fg">
             <Toaster />
             <UpdateBanner />

--- a/src/lib/vault/oauth.test.ts
+++ b/src/lib/vault/oauth.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { beginOAuth, completeOAuth } from "./oauth";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beginOAuth, completeOAuth, redirectUriForOrigin } from "./oauth";
 import { deriveCodeChallenge } from "./pkce";
 import { loadPendingOAuth, savePendingOAuth } from "./storage";
 import type { PendingOAuthState } from "./types";
@@ -70,6 +70,33 @@ describe("beginOAuth", () => {
     await beginOAuth("http://localhost:1940/api/", "full", fetchImpl);
     expect(fetchImpl.mock.calls[0]?.[0]).toBe(
       "http://localhost:1940/.well-known/oauth-authorization-server",
+    );
+  });
+});
+
+describe("redirectUriForOrigin under VITE_BASE_PATH", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("defaults to {origin}/oauth/callback when base is /", () => {
+    vi.stubEnv("BASE_URL", "/");
+    expect(redirectUriForOrigin("http://localhost:3000")).toBe(
+      "http://localhost:3000/oauth/callback",
+    );
+  });
+
+  it("includes the base path when Notes is mounted under a sub-path", () => {
+    vi.stubEnv("BASE_URL", "/notes/");
+    expect(redirectUriForOrigin("http://host.example")).toBe(
+      "http://host.example/notes/oauth/callback",
+    );
+  });
+
+  it("strips a single trailing slash on the origin and the base", () => {
+    vi.stubEnv("BASE_URL", "/notes/");
+    expect(redirectUriForOrigin("http://host.example/")).toBe(
+      "http://host.example/notes/oauth/callback",
     );
   });
 });

--- a/src/lib/vault/oauth.ts
+++ b/src/lib/vault/oauth.ts
@@ -6,8 +6,17 @@ import { normalizeVaultUrl } from "./url";
 
 const REDIRECT_PATH = "/oauth/callback";
 
+// Notes is mounted under `import.meta.env.BASE_URL` (defaults to `/`, can be
+// `/notes/` when the CLI's expose tooling path-routes us). The OAuth callback
+// must include that prefix so the authorization server bounces the browser
+// back to a URL the SPA actually serves.
+function basePathPrefix(): string {
+  const b = import.meta.env.BASE_URL ?? "/";
+  return b.replace(/\/$/, "");
+}
+
 export function redirectUriForOrigin(origin: string = window.location.origin): string {
-  return `${origin.replace(/\/$/, "")}${REDIRECT_PATH}`;
+  return `${origin.replace(/\/$/, "")}${basePathPrefix()}${REDIRECT_PATH}`;
 }
 
 /**

--- a/src/pwa-manifest.test.ts
+++ b/src/pwa-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { PWA_MANIFEST } from "./pwa-manifest";
+import { PWA_MANIFEST, buildPwaManifest } from "./pwa-manifest";
 
 describe("PWA_MANIFEST", () => {
   it("has the fields Chrome requires for installability", () => {
@@ -29,5 +29,19 @@ describe("PWA_MANIFEST", () => {
     expect(() => JSON.stringify(PWA_MANIFEST)).not.toThrow();
     const round = JSON.parse(JSON.stringify(PWA_MANIFEST));
     expect(round.name).toBe(PWA_MANIFEST.name);
+  });
+});
+
+describe("buildPwaManifest under a sub-path", () => {
+  it("threads the base into id, start_url, and scope so installed PWAs land on the right route", () => {
+    const m = buildPwaManifest("/notes/");
+    expect(m.id).toBe("/notes/");
+    expect(m.start_url).toBe("/notes/");
+    expect(m.scope).toBe("/notes/");
+  });
+
+  it("normalizes a base passed without a trailing slash", () => {
+    const m = buildPwaManifest("/notes");
+    expect(m.start_url).toBe("/notes/");
   });
 });

--- a/src/pwa-manifest.ts
+++ b/src/pwa-manifest.ts
@@ -1,26 +1,36 @@
 import type { ManifestOptions } from "vite-plugin-pwa";
 
-export const PWA_MANIFEST: Partial<ManifestOptions> = {
-  id: "/",
-  name: "Parachute Notes",
-  short_name: "Notes",
-  description:
-    "The default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
-  theme_color: "#4a7c59",
-  background_color: "#faf8f4",
-  display: "standalone",
-  orientation: "any",
-  start_url: "/",
-  scope: "/",
-  icons: [
-    { src: "pwa-64x64.png", sizes: "64x64", type: "image/png" },
-    { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
-    { src: "pwa-512x512.png", sizes: "512x512", type: "image/png", purpose: "any" },
-    {
-      src: "maskable-icon-512x512.png",
-      sizes: "512x512",
-      type: "image/png",
-      purpose: "maskable",
-    },
-  ],
-};
+// Build the PWA manifest at config-load time. `id`/`start_url`/`scope` must
+// reflect the deployed base path; otherwise an installed PWA would launch at
+// `/` and 404 when Notes is mounted under e.g. `/notes/`.
+export function buildPwaManifest(base = "/"): Partial<ManifestOptions> {
+  const normalized = base.endsWith("/") ? base : `${base}/`;
+  return {
+    id: normalized,
+    name: "Parachute Notes",
+    short_name: "Notes",
+    description:
+      "The default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
+    theme_color: "#4a7c59",
+    background_color: "#faf8f4",
+    display: "standalone",
+    orientation: "any",
+    start_url: normalized,
+    scope: normalized,
+    icons: [
+      { src: "pwa-64x64.png", sizes: "64x64", type: "image/png" },
+      { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
+      { src: "pwa-512x512.png", sizes: "512x512", type: "image/png", purpose: "any" },
+      {
+        src: "maskable-icon-512x512.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "maskable",
+      },
+    ],
+  };
+}
+
+// Default-base export retained as a convenience and for tests that exercise
+// the manifest shape without needing a base path argument.
+export const PWA_MANIFEST: Partial<ManifestOptions> = buildPwaManifest("/");

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -15,5 +15,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts", "vitest.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "scripts/**/*.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,24 +1,42 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
-import { PWA_MANIFEST } from "./src/pwa-manifest";
+import { notesServicePlugin } from "./scripts/notes-service-plugin";
+import { buildPwaManifest } from "./src/pwa-manifest";
 
 // Set VITE_EXPOSE=true to bind the dev server to all interfaces and accept any
 // Host header — useful when reaching the dev server over a tailnet. Off by default.
 const devExposure = process.env.VITE_EXPOSE === "true";
 
+// VITE_BASE_PATH lets the CLI's expose tooling serve Notes at a sub-path
+// (e.g. `/notes/`) without code changes. Defaults to `/` for stand-alone use.
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/");
+
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, "./package.json"), "utf8")) as {
+  version: string;
+};
+
+function normalizeBase(input: string): string {
+  let b = input.startsWith("/") ? input : `/${input}`;
+  if (!b.endsWith("/")) b += "/";
+  return b;
+}
+
 export default defineConfig({
+  base: basePath,
   plugins: [
     react(),
     tailwindcss(),
+    notesServicePlugin({ name: "parachute-notes", version: pkg.version, basePath }),
     VitePWA({
       registerType: "prompt",
       includeAssets: ["icon.svg", "apple-touch-icon-180x180.png", "favicon.ico"],
-      manifest: PWA_MANIFEST,
+      manifest: buildPwaManifest(basePath),
       workbox: {
-        navigateFallback: "/index.html",
+        navigateFallback: `${basePath}index.html`,
         // Keep vault API + OAuth off the nav fallback so they error cleanly offline.
         navigateFallbackDenylist: [/^\/api\//, /^\/oauth\//, /^\/\.well-known\//],
         globPatterns: ["**/*.{js,css,html,svg,png,ico,webmanifest}"],


### PR DESCRIPTION
## Summary
Two launch-grade CLI conformance integrations.

**`services.json` write.** A Vite plugin (`scripts/notes-service-plugin.ts`) upserts a `parachute-notes` entry into `$PARACHUTE_HOME/services.json` (defaulting to `~/.parachute/services.json`) when the dev or preview server starts, using the actual listening port. The validate/upsert helper in `scripts/services-manifest.ts` is duplicated inline from the locked CLI shape — vault and scribe each carry their own copy. No write on `vite build` (no port to advertise; the CLI's expose tool will register the served bundle when it serves it).

**`VITE_BASE_PATH` support.** Threaded `process.env.VITE_BASE_PATH ?? "/"` through:
- `vite.config.ts` `base`
- PWA manifest `id` / `start_url` / `scope` (factored `pwa-manifest.ts` into `buildPwaManifest(base)`)
- Workbox `navigateFallback` → `${base}index.html`
- React Router `<BrowserRouter basename={...}>`
- OAuth `redirectUriForOrigin` → `{origin}{base}/oauth/callback`

So if the CLI's expose tooling path-routes Notes at `/notes/`, an installed PWA still launches at `/notes/`, the SW serves `/notes/index.html` for nav fallback, the router treats `/notes` as its root, and OAuth bounces back to `/notes/oauth/callback`.

## Verification

- 458/458 tests pass (13 new — 9 services-manifest, 3 OAuth basePath, 2 PWA basePath)
- `bun run lint` / `bun run typecheck` clean
- `bun run build` clean (default base)
- `VITE_BASE_PATH=/notes/ bun run build` produces `dist/index.html` referencing `/notes/assets/...` and a webmanifest with `start_url: "/notes/"`
- Smoke: `PARACHUTE_HOME=/tmp/x bun run dev --port 5199` writes a valid `services.json` entry with `port: 5199`

## Out of scope
- Reverse-proxy integration (CLI's job)
- `/.well-known/parachute.json` (CLI's job, served from origin)
- UI for exposing/installing services (CLI's job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)