### PR TITLE
Add collapsible folder tree to /notes sidebar (#60)

### DIFF
--- a/src/app/routes/Notes.test.tsx
+++ b/src/app/routes/Notes.test.tsx
@@ -262,4 +262,112 @@ describe("Notes route", () => {
     });
     expect(screen.getByRole("heading", { name: "Archived" })).toBeInTheDocument();
   });
+
+  it("renders the path tree once the auto threshold is met", async () => {
+    // Five distinct top-level folders trips AUTO_TOP_LEVEL_MIN.
+    installFetch({
+      notes: ["A", "B", "C", "D", "E"].map((root, i) => ({
+        id: `n${i}`,
+        path: `${root}/note-${i}.md`,
+        createdAt: "2026-04-18T10:00:00.000Z",
+        updatedAt: "2026-04-18T10:00:00.000Z",
+        tags: [],
+      })),
+      tags: [],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    expect(await screen.findByRole("complementary", { name: /path tree/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^A\b/ })).toBeInTheDocument();
+  });
+
+  it("hides the path tree when auto threshold is not met", async () => {
+    installFetch({
+      notes: [
+        {
+          id: "n1",
+          path: "Solo/note.md",
+          createdAt: "2026-04-18T10:00:00.000Z",
+          tags: [],
+        },
+      ],
+      tags: [],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    await screen.findByText("Solo/note.md");
+    expect(screen.queryByRole("complementary", { name: /path tree/i })).toBeNull();
+  });
+
+  it("mode=always renders the tree even on a tag-flat vault", async () => {
+    localStorage.setItem("lens:path-tree:dev", JSON.stringify({ mode: "always" }));
+    installFetch({
+      notes: [
+        {
+          id: "n1",
+          path: "Solo/note.md",
+          createdAt: "2026-04-18T10:00:00.000Z",
+          tags: [],
+        },
+      ],
+      tags: [],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+    expect(await screen.findByRole("complementary", { name: /path tree/i })).toBeInTheDocument();
+  });
+
+  it("mode=never skips the path-tree fetch and hides the tree", async () => {
+    localStorage.setItem("lens:path-tree:dev", JSON.stringify({ mode: "never" }));
+    const fetchImpl = installFetch({
+      notes: ["A", "B", "C", "D", "E"].map((root, i) => ({
+        id: `n${i}`,
+        path: `${root}/note.md`,
+        createdAt: "2026-04-18T10:00:00.000Z",
+        tags: [],
+      })),
+      tags: [],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(fetchImpl.mock.calls.some((c) => String(c[0]).includes("/api/notes"))).toBe(true);
+    });
+    // Two /api/notes queries fire when the tree is enabled (one filtered, one
+    // capped). When `never`, only the filtered list query goes out — so the
+    // unfiltered limit=5000 capped query should be absent.
+    const treeCall = fetchImpl.mock.calls.find((c) => {
+      const u = String(c[0]);
+      return u.includes("/api/notes") && u.includes("limit=5000");
+    });
+    expect(treeCall).toBeUndefined();
+    expect(screen.queryByRole("complementary", { name: /path tree/i })).toBeNull();
+  });
+
+  it("clicking a tree folder writes path_prefix to the URL", async () => {
+    const fetchImpl = installFetch({
+      notes: ["Canon", "B", "C", "D", "E"].map((root, i) => ({
+        id: `n${i}`,
+        path: `${root}/note-${i}.md`,
+        createdAt: "2026-04-18T10:00:00.000Z",
+        tags: [],
+      })),
+      tags: [],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    const canonNode = await screen.findByRole("button", { name: /^Canon\b/ });
+    fireEvent.click(canonNode);
+
+    await waitFor(() => {
+      expect(window.location.search).toContain("path_prefix=Canon");
+    });
+    await waitFor(() => {
+      expect(lastNotesUrl(fetchImpl)).toContain("path_prefix=Canon");
+    });
+  });
 });

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -1,4 +1,6 @@
+import { PathTree } from "@/components/PathTree";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { meetsAutoThreshold, usePathTreeMode } from "@/lib/path-tree";
 import { useSaveView, useSavedViews } from "@/lib/saved-views/queries";
 import {
   type SavedView,
@@ -15,6 +17,7 @@ import {
   type NoteQueryState,
   isFilteringActive,
   useNotes,
+  useNotesForPathTree,
   useTagRoles,
   useTags,
   useVaultStore,
@@ -121,6 +124,18 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
   const saveView = useSaveView(roles.view);
   const pushToast = useToastStore((s) => s.push);
   const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // Path tree: independent capped fetch (separate from the filtered list) so
+  // the tree stays stable as the user narrows results. Disabled on preset
+  // routes (no sidebar) and when the user has set the mode to `never`.
+  const { mode: pathTreeMode } = usePathTreeMode(activeVault?.id ?? null);
+  const treeEnabled = !preset && pathTreeMode !== "never";
+  const treeNotes = useNotesForPathTree(treeEnabled);
+  const treePaths = useMemo(() => (treeNotes.data ?? []).map((n) => n.path), [treeNotes.data]);
+  const showPathTree =
+    treeEnabled &&
+    (pathTreeMode === "always" || (pathTreeMode === "auto" && meetsAutoThreshold(treePaths)));
 
   const currentFilters: SavedViewFilters = useMemo(
     () => ({
@@ -212,11 +227,38 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
 
       <div className={preset ? "" : "grid gap-6 md:grid-cols-[14rem_1fr]"}>
         {!preset ? (
-          <SavedViewsSidebar
-            views={savedViews.data}
-            isPending={savedViews.isPending}
-            error={savedViews.error}
-          />
+          <div className="space-y-3 md:space-y-6">
+            <button
+              type="button"
+              onClick={() => setSidebarOpen((o) => !o)}
+              className="flex w-full items-center justify-between rounded-md border border-border bg-card px-3 py-1.5 text-left text-sm text-fg-muted hover:text-accent md:hidden"
+              aria-expanded={sidebarOpen}
+              aria-controls="notes-sidebar"
+            >
+              <span>Folders & saved views</span>
+              <span aria-hidden="true" className="font-mono text-xs">
+                {sidebarOpen ? "▾" : "▸"}
+              </span>
+            </button>
+            <div
+              id="notes-sidebar"
+              className={`space-y-6 md:sticky md:top-6 md:self-start ${sidebarOpen ? "" : "hidden md:block"}`}
+            >
+              {showPathTree ? (
+                <PathTree
+                  paths={treePaths}
+                  vaultId={activeVault.id}
+                  currentPrefix={pathPrefix}
+                  onSelect={(p) => setPathPrefix(p)}
+                />
+              ) : null}
+              <SavedViewsSidebar
+                views={savedViews.data}
+                isPending={savedViews.isPending}
+                error={savedViews.error}
+              />
+            </div>
+          </div>
         ) : null}
 
         <div>
@@ -333,7 +375,7 @@ function SavedViewsSidebar({
   error: Error | null;
 }) {
   return (
-    <aside className="md:sticky md:top-6 md:self-start">
+    <aside>
       <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">Saved views</h2>
       {isPending ? (
         <p className="text-xs text-fg-dim">Loading…</p>

--- a/src/app/routes/Settings.test.tsx
+++ b/src/app/routes/Settings.test.tsx
@@ -165,6 +165,24 @@ describe("Settings route", () => {
     expect(stored.archived).toBe("archived");
   });
 
+  it("renders the path-tree section and persists mode changes", async () => {
+    renderSettings();
+    const section = screen
+      .getByRole("heading", { name: /folder tree/i })
+      .closest("section") as HTMLElement;
+    const auto = within(section).getByLabelText(/^auto/i) as HTMLInputElement;
+    expect(auto.checked).toBe(true);
+
+    const always = within(section).getByLabelText(/^always/i);
+    await act(async () => {
+      fireEvent.click(always);
+    });
+    const stored = JSON.parse(localStorage.getItem("lens:path-tree:dev") ?? "{}") as {
+      mode?: string;
+    };
+    expect(stored.mode).toBe("always");
+  });
+
   it("reset-to-defaults wipes the stored tag roles", async () => {
     localStorage.setItem(
       "lens:tag-roles:dev",

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -1,3 +1,4 @@
+import { PATH_TREE_MODES, type PathTreeMode, usePathTreeMode } from "@/lib/path-tree";
 import { isStandalone } from "@/lib/pwa";
 import { type ScribeSettings, scribeHealth, useScribeSettings } from "@/lib/scribe";
 import { useToastStore } from "@/lib/toast/store";
@@ -35,6 +36,7 @@ export function Settings() {
       </header>
 
       <ScribeSettingsSection vaultId={activeVault.id} />
+      <PathTreeSection vaultId={activeVault.id} />
       <TagRolesSection vaultId={activeVault.id} />
       <InstallStateSection />
     </div>
@@ -209,6 +211,55 @@ function ScribeSettingsSection({ vaultId }: { vaultId: string }) {
         CORS error in the browser console, run scribe behind a reverse proxy that shares your
         vault's origin.
       </p>
+    </section>
+  );
+}
+
+const PATH_TREE_MODE_LABELS: Record<PathTreeMode, { title: string; help: string }> = {
+  auto: {
+    title: "Auto",
+    help: "Show the tree only when the vault has enough folders to make it worth the space.",
+  },
+  always: {
+    title: "Always",
+    help: "Always show the tree, even on a tag-flat vault.",
+  },
+  never: {
+    title: "Never",
+    help: "Hide the tree. The path-prefix text input still works.",
+  },
+};
+
+function PathTreeSection({ vaultId }: { vaultId: string }) {
+  const { mode, setMode } = usePathTreeMode(vaultId);
+  return (
+    <section className="mt-6 space-y-4 rounded-xl border border-border bg-card p-6">
+      <div>
+        <h2 className="font-serif text-xl text-fg">Folder tree (Notes sidebar)</h2>
+        <p className="mt-1 text-xs text-fg-dim">
+          Controls the collapsible folder tree on the /notes page. Auto-detect renders the tree when
+          the vault has at least five top-level folders or twenty notes in folders.
+        </p>
+      </div>
+      <fieldset className="space-y-2">
+        <legend className="sr-only">Path tree visibility</legend>
+        {PATH_TREE_MODES.map((m) => (
+          <label key={m} className="flex items-start gap-2 text-sm">
+            <input
+              type="radio"
+              name="path-tree-mode"
+              value={m}
+              checked={mode === m}
+              onChange={() => setMode(m)}
+              className="mt-1 accent-accent"
+            />
+            <span>
+              <span className="text-fg">{PATH_TREE_MODE_LABELS[m].title}</span>
+              <span className="ml-2 text-xs text-fg-dim">{PATH_TREE_MODE_LABELS[m].help}</span>
+            </span>
+          </label>
+        ))}
+      </fieldset>
     </section>
   );
 }

--- a/src/components/PathTree.test.tsx
+++ b/src/components/PathTree.test.tsx
@@ -1,0 +1,85 @@
+import { PathTree } from "@/components/PathTree";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("PathTree", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  function setup(opts: {
+    paths: string[];
+    currentPrefix?: string;
+    onSelect?: (p: string) => void;
+  }) {
+    const onSelect = opts.onSelect ?? vi.fn();
+    const utils = render(
+      <PathTree
+        paths={opts.paths}
+        vaultId="v1"
+        currentPrefix={opts.currentPrefix ?? ""}
+        onSelect={onSelect}
+      />,
+    );
+    return { onSelect, ...utils };
+  }
+
+  it("renders the empty placeholder when no folders are present", () => {
+    setup({ paths: ["loose.md"] });
+    expect(screen.getByText(/no folders yet/i)).toBeInTheDocument();
+  });
+
+  it("clicking a folder calls onSelect with the full prefix", () => {
+    const { onSelect } = setup({
+      paths: ["Canon/Aaron/log.md", "Canon/Uni/origin.md"],
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Canon\b/ }));
+    expect(onSelect).toHaveBeenCalledWith("Canon");
+  });
+
+  it("expands a folder when its chevron is clicked", () => {
+    setup({
+      paths: ["Canon/Aaron/log.md", "Canon/Uni/origin.md"],
+    });
+    // Children are not rendered until the parent is open.
+    expect(screen.queryByRole("button", { name: /^Aaron\b/ })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /expand canon/i }));
+    expect(screen.getByRole("button", { name: /^Aaron\b/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Uni\b/ })).toBeInTheDocument();
+  });
+
+  it("auto-opens ancestors of the selected prefix", () => {
+    setup({
+      paths: ["Canon/Aaron/Log/2026.md"],
+      currentPrefix: "Canon/Aaron/Log",
+    });
+    // Without ancestor force-open, "Aaron" and "Log" wouldn't be visible.
+    expect(screen.getByRole("button", { name: /^Aaron\b/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Log\b/ })).toBeInTheDocument();
+  });
+
+  it("highlights the selected node and shows a Clear button", () => {
+    const { onSelect } = setup({
+      paths: ["Canon/Aaron/log.md"],
+      currentPrefix: "Canon",
+    });
+    const canon = screen.getByRole("button", { name: /^Canon\b/ });
+    expect(canon).toHaveAttribute("aria-current", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: /^clear$/i }));
+    expect(onSelect).toHaveBeenCalledWith("");
+  });
+
+  it("persists expand state across re-mount via localStorage", () => {
+    const first = setup({ paths: ["Canon/Aaron/log.md"] });
+    fireEvent.click(screen.getByRole("button", { name: /expand canon/i }));
+    expect(screen.getByRole("button", { name: /^Aaron\b/ })).toBeInTheDocument();
+    first.unmount();
+
+    setup({ paths: ["Canon/Aaron/log.md"] });
+    expect(screen.getByRole("button", { name: /^Aaron\b/ })).toBeInTheDocument();
+  });
+});

--- a/src/components/PathTree.tsx
+++ b/src/components/PathTree.tsx
@@ -1,0 +1,152 @@
+import { useExpandedPaths } from "@/lib/path-tree/expanded";
+import type { PathTreeNode } from "@/lib/path-tree/tree";
+import { buildPathTree } from "@/lib/path-tree/tree";
+import { useMemo } from "react";
+
+// Collapsible folder nav for the /notes sidebar. Derived from a flat list of
+// note paths; click a folder to drive the `path_prefix` filter. Read-only —
+// folders aren't a write surface here. The selected prefix is highlighted and
+// the ancestors along its chain are force-expanded so the user can always
+// see where they are.
+interface Props {
+  paths: Iterable<string | undefined>;
+  vaultId: string;
+  currentPrefix: string;
+  onSelect(prefix: string): void;
+}
+
+export function PathTree({ paths, vaultId, currentPrefix, onSelect }: Props) {
+  const tree = useMemo(() => buildPathTree(paths), [paths]);
+  const { expanded, toggle } = useExpandedPaths(vaultId);
+
+  const forcedOpen = useMemo(() => ancestorsOf(currentPrefix), [currentPrefix]);
+
+  if (tree.length === 0) {
+    return (
+      <aside aria-label="Path tree">
+        <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">Folders</h2>
+        <p className="text-xs text-fg-dim">No folders yet.</p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside aria-label="Path tree" className="md:sticky md:top-6 md:self-start">
+      <div className="mb-2 flex items-baseline justify-between">
+        <h2 className="text-xs uppercase tracking-wider text-fg-dim">Folders</h2>
+        {currentPrefix ? (
+          <button
+            type="button"
+            onClick={() => onSelect("")}
+            className="text-xs text-fg-dim hover:text-accent"
+          >
+            Clear
+          </button>
+        ) : null}
+      </div>
+      <ul className="space-y-0.5">
+        {tree.map((node) => (
+          <TreeNode
+            key={node.fullPath}
+            node={node}
+            depth={0}
+            expanded={expanded}
+            forcedOpen={forcedOpen}
+            currentPrefix={currentPrefix}
+            onToggle={toggle}
+            onSelect={onSelect}
+          />
+        ))}
+      </ul>
+    </aside>
+  );
+}
+
+function TreeNode({
+  node,
+  depth,
+  expanded,
+  forcedOpen,
+  currentPrefix,
+  onToggle,
+  onSelect,
+}: {
+  node: PathTreeNode;
+  depth: number;
+  expanded: Set<string>;
+  forcedOpen: Set<string>;
+  currentPrefix: string;
+  onToggle(path: string): void;
+  onSelect(prefix: string): void;
+}) {
+  const hasChildren = node.children.length > 0;
+  const isOpen = expanded.has(node.fullPath) || forcedOpen.has(node.fullPath);
+  const isSelected = currentPrefix === node.fullPath;
+
+  return (
+    <li>
+      <div
+        className={`flex items-center gap-1 rounded-md px-1 py-0.5 text-sm ${
+          isSelected ? "bg-accent/10 text-accent" : "text-fg-muted hover:text-accent"
+        }`}
+        style={{ paddingLeft: `${depth * 0.75 + 0.25}rem` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => onToggle(node.fullPath)}
+            aria-label={`${isOpen ? "Collapse" : "Expand"} ${node.fullPath}`}
+            aria-expanded={isOpen}
+            className="flex h-4 w-4 items-center justify-center text-fg-dim hover:text-accent"
+          >
+            <span aria-hidden="true" className="font-mono text-xs">
+              {isOpen ? "▾" : "▸"}
+            </span>
+          </button>
+        ) : (
+          <span aria-hidden="true" className="inline-block h-4 w-4" />
+        )}
+        <button
+          type="button"
+          onClick={() => onSelect(node.fullPath)}
+          aria-current={isSelected ? "true" : undefined}
+          className="flex flex-1 items-baseline gap-1.5 truncate text-left"
+        >
+          <span className="truncate">{node.name}</span>
+          <span className="text-xs text-fg-dim">{node.count}</span>
+        </button>
+      </div>
+      {hasChildren && isOpen ? (
+        <ul className="space-y-0.5">
+          {node.children.map((child) => (
+            <TreeNode
+              key={child.fullPath}
+              node={child}
+              depth={depth + 1}
+              expanded={expanded}
+              forcedOpen={forcedOpen}
+              currentPrefix={currentPrefix}
+              onToggle={onToggle}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+// Given `Canon/Aaron/Log`, return `{Canon, Canon/Aaron, Canon/Aaron/Log}` so
+// the tree stays open along the selected path even when the user hasn't
+// manually expanded each ancestor.
+function ancestorsOf(prefix: string): Set<string> {
+  const out = new Set<string>();
+  if (!prefix) return out;
+  const parts = prefix.split("/").filter((p) => p.length > 0);
+  let acc = "";
+  for (const part of parts) {
+    acc = acc ? `${acc}/${part}` : part;
+    out.add(acc);
+  }
+  return out;
+}

--- a/src/lib/path-tree/expanded.test.ts
+++ b/src/lib/path-tree/expanded.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadExpanded, saveExpanded } from "./expanded";
+
+describe("path-tree expanded storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("round-trips a Set of expanded paths", () => {
+    saveExpanded("v1", new Set(["Canon", "Canon/Aaron", "Corpus"]));
+    const out = loadExpanded("v1");
+    expect(out.has("Canon")).toBe(true);
+    expect(out.has("Canon/Aaron")).toBe(true);
+    expect(out.has("Corpus")).toBe(true);
+    expect(out.size).toBe(3);
+  });
+
+  it("returns an empty Set when nothing is stored", () => {
+    expect(loadExpanded("v1").size).toBe(0);
+  });
+
+  it("returns an empty Set for malformed JSON", () => {
+    localStorage.setItem("lens:path-tree-expanded:v1", "{not");
+    expect(loadExpanded("v1").size).toBe(0);
+  });
+
+  it("ignores non-string entries", () => {
+    localStorage.setItem("lens:path-tree-expanded:v1", JSON.stringify(["ok", 42, null, "also-ok"]));
+    const out = loadExpanded("v1");
+    expect([...out].sort()).toEqual(["also-ok", "ok"]);
+  });
+
+  it("scopes per vault", () => {
+    saveExpanded("a", new Set(["X"]));
+    saveExpanded("b", new Set(["Y"]));
+    expect(loadExpanded("a").has("X")).toBe(true);
+    expect(loadExpanded("a").has("Y")).toBe(false);
+    expect(loadExpanded("b").has("Y")).toBe(true);
+  });
+});

--- a/src/lib/path-tree/expanded.ts
+++ b/src/lib/path-tree/expanded.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+
+// Per-vault expanded/collapsed state for the path-tree sidebar. Persisted so
+// the user's drill-down survives a page reload. We store a sorted array of
+// expanded folder paths in localStorage and re-hydrate to a Set in memory.
+const STORAGE_PREFIX = "lens:path-tree-expanded:";
+
+function keyFor(vaultId: string): string {
+  return STORAGE_PREFIX + vaultId;
+}
+
+export function loadExpanded(vaultId: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(keyFor(vaultId));
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((v): v is string => typeof v === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveExpanded(vaultId: string, expanded: Set<string>): void {
+  try {
+    localStorage.setItem(keyFor(vaultId), JSON.stringify([...expanded].sort()));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+export function useExpandedPaths(vaultId: string | null): {
+  expanded: Set<string>;
+  toggle: (path: string) => void;
+} {
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    vaultId ? loadExpanded(vaultId) : new Set(),
+  );
+
+  useEffect(() => {
+    setExpanded(vaultId ? loadExpanded(vaultId) : new Set());
+  }, [vaultId]);
+
+  const toggle = useCallback(
+    (path: string) => {
+      if (!vaultId) return;
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(path)) next.delete(path);
+        else next.add(path);
+        saveExpanded(vaultId, next);
+        return next;
+      });
+    },
+    [vaultId],
+  );
+
+  return { expanded, toggle };
+}

--- a/src/lib/path-tree/index.ts
+++ b/src/lib/path-tree/index.ts
@@ -1,0 +1,17 @@
+export { useExpandedPaths } from "./expanded";
+export {
+  DEFAULT_PATH_TREE_MODE,
+  PATH_TREE_MODES,
+  type PathTreeMode,
+  deletePathTreeMode,
+  loadPathTreeMode,
+  savePathTreeMode,
+  usePathTreeMode,
+} from "./settings";
+export {
+  AUTO_FOLDERED_NOTES_MIN,
+  AUTO_TOP_LEVEL_MIN,
+  type PathTreeNode,
+  buildPathTree,
+  meetsAutoThreshold,
+} from "./tree";

--- a/src/lib/path-tree/settings.test.ts
+++ b/src/lib/path-tree/settings.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_PATH_TREE_MODE,
+  deletePathTreeMode,
+  loadPathTreeMode,
+  savePathTreeMode,
+} from "./settings";
+
+describe("path-tree mode storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("round-trips a mode value", () => {
+    savePathTreeMode("v1", "always");
+    expect(loadPathTreeMode("v1")).toBe("always");
+  });
+
+  it("returns the default when nothing is stored", () => {
+    expect(loadPathTreeMode("nope")).toBe(DEFAULT_PATH_TREE_MODE);
+  });
+
+  it("falls back to the default for an unknown stored value", () => {
+    localStorage.setItem("lens:path-tree:v1", JSON.stringify({ mode: "weird" }));
+    expect(loadPathTreeMode("v1")).toBe(DEFAULT_PATH_TREE_MODE);
+  });
+
+  it("falls back to the default when stored JSON is malformed", () => {
+    localStorage.setItem("lens:path-tree:v1", "{not json");
+    expect(loadPathTreeMode("v1")).toBe(DEFAULT_PATH_TREE_MODE);
+  });
+
+  it("delete removes the entry", () => {
+    savePathTreeMode("v1", "never");
+    deletePathTreeMode("v1");
+    expect(loadPathTreeMode("v1")).toBe(DEFAULT_PATH_TREE_MODE);
+  });
+
+  it("scopes per vault", () => {
+    savePathTreeMode("a", "always");
+    savePathTreeMode("b", "never");
+    expect(loadPathTreeMode("a")).toBe("always");
+    expect(loadPathTreeMode("b")).toBe("never");
+  });
+});

--- a/src/lib/path-tree/settings.ts
+++ b/src/lib/path-tree/settings.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+
+// Per-vault setting for the path-tree sidebar. `auto` renders the tree only
+// when the vault's paths meet the threshold in `tree.ts`; `always` forces it
+// on; `never` keeps the sidebar tag-flat. Defaults to `auto`.
+export type PathTreeMode = "auto" | "always" | "never";
+
+export const PATH_TREE_MODES: readonly PathTreeMode[] = ["auto", "always", "never"];
+
+export const DEFAULT_PATH_TREE_MODE: PathTreeMode = "auto";
+
+const STORAGE_PREFIX = "lens:path-tree:";
+
+function keyFor(vaultId: string): string {
+  return STORAGE_PREFIX + vaultId;
+}
+
+function normalize(value: unknown): PathTreeMode {
+  return typeof value === "string" && (PATH_TREE_MODES as readonly string[]).includes(value)
+    ? (value as PathTreeMode)
+    : DEFAULT_PATH_TREE_MODE;
+}
+
+export function loadPathTreeMode(vaultId: string): PathTreeMode {
+  try {
+    const raw = localStorage.getItem(keyFor(vaultId));
+    if (!raw) return DEFAULT_PATH_TREE_MODE;
+    const parsed = JSON.parse(raw) as { mode?: unknown };
+    return normalize(parsed.mode);
+  } catch {
+    return DEFAULT_PATH_TREE_MODE;
+  }
+}
+
+export function savePathTreeMode(vaultId: string, mode: PathTreeMode): void {
+  try {
+    localStorage.setItem(keyFor(vaultId), JSON.stringify({ mode }));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+export function deletePathTreeMode(vaultId: string): void {
+  try {
+    localStorage.removeItem(keyFor(vaultId));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+export function usePathTreeMode(vaultId: string | null): {
+  mode: PathTreeMode;
+  setMode: (next: PathTreeMode) => void;
+} {
+  const [mode, setState] = useState<PathTreeMode>(() =>
+    vaultId ? loadPathTreeMode(vaultId) : DEFAULT_PATH_TREE_MODE,
+  );
+
+  useEffect(() => {
+    setState(vaultId ? loadPathTreeMode(vaultId) : DEFAULT_PATH_TREE_MODE);
+  }, [vaultId]);
+
+  const setMode = useCallback(
+    (next: PathTreeMode) => {
+      if (!vaultId) return;
+      savePathTreeMode(vaultId, next);
+      setState(next);
+    },
+    [vaultId],
+  );
+
+  return { mode, setMode };
+}

--- a/src/lib/path-tree/tree.test.ts
+++ b/src/lib/path-tree/tree.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTO_FOLDERED_NOTES_MIN,
+  AUTO_TOP_LEVEL_MIN,
+  buildPathTree,
+  meetsAutoThreshold,
+} from "./tree";
+
+describe("buildPathTree", () => {
+  it("derives a nested tree from folder paths", () => {
+    const tree = buildPathTree([
+      "Canon/Aaron/Log/2026.md",
+      "Canon/Aaron/Draft.md",
+      "Canon/Uni/Origin.md",
+      "Corpus/Ideas/Seeds.md",
+    ]);
+    expect(tree.map((n) => n.name)).toEqual(["Canon", "Corpus"]);
+    const canon = tree[0]!;
+    expect(canon.fullPath).toBe("Canon");
+    expect(canon.count).toBe(3);
+    expect(canon.children.map((c) => c.name)).toEqual(["Aaron", "Uni"]);
+    const aaron = canon.children[0]!;
+    expect(aaron.fullPath).toBe("Canon/Aaron");
+    expect(aaron.count).toBe(2);
+    expect(aaron.children.map((c) => c.name)).toEqual(["Log"]);
+    expect(aaron.children[0]!.fullPath).toBe("Canon/Aaron/Log");
+    expect(aaron.children[0]!.count).toBe(1);
+  });
+
+  it("skips notes with no path or no folder segment", () => {
+    const tree = buildPathTree([undefined, "loose-note.md", "", "Canon/draft.md"]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]!.name).toBe("Canon");
+    expect(tree[0]!.count).toBe(1);
+  });
+
+  it("sorts children alphabetically at every level", () => {
+    const tree = buildPathTree(["Zed/a.md", "Alpha/b.md", "Mid/z.md", "Mid/a/x.md"]);
+    expect(tree.map((n) => n.name)).toEqual(["Alpha", "Mid", "Zed"]);
+    expect(tree[1]!.children.map((c) => c.name)).toEqual(["a"]);
+  });
+
+  it("returns an empty tree for empty input", () => {
+    expect(buildPathTree([])).toEqual([]);
+  });
+});
+
+describe("meetsAutoThreshold", () => {
+  it("returns true once the top-level folder count reaches the minimum", () => {
+    const paths = Array.from({ length: AUTO_TOP_LEVEL_MIN }, (_, i) => `F${i}/n.md`);
+    expect(meetsAutoThreshold(paths)).toBe(true);
+  });
+
+  it("returns true when foldered-note count reaches the minimum even from a single root", () => {
+    const paths = Array.from({ length: AUTO_FOLDERED_NOTES_MIN }, (_, i) => `One/n${i}.md`);
+    expect(meetsAutoThreshold(paths)).toBe(true);
+  });
+
+  it("returns false for sparse tag-flat vaults", () => {
+    expect(meetsAutoThreshold(["a.md", "b.md", "One/x.md", "Two/y.md"])).toBe(false);
+  });
+
+  it("ignores notes without folder segments", () => {
+    // AUTO_TOP_LEVEL_MIN distinct flat files do not meet the threshold.
+    const flat = Array.from({ length: AUTO_TOP_LEVEL_MIN }, (_, i) => `file${i}.md`);
+    expect(meetsAutoThreshold(flat)).toBe(false);
+  });
+});

--- a/src/lib/path-tree/tree.ts
+++ b/src/lib/path-tree/tree.ts
@@ -1,0 +1,88 @@
+// Pure derivation: a flat list of note paths → a folder tree. Notes with no
+// path or whose path is just a filename (no slashes) don't contribute folder
+// nodes — they're "loose" at the root and aren't part of the tree primitive.
+//
+// The auto-detection threshold gates whether the tree is worth showing: tag-
+// flat vaults shouldn't see a near-empty tree taking sidebar space.
+
+export interface PathTreeNode {
+  /** Last segment, used as the display label. */
+  name: string;
+  /** Full prefix from the vault root, e.g. `Canon/Aaron`. Used for the
+   *  `path_prefix` URL filter and as the React key. No trailing slash. */
+  fullPath: string;
+  /** Notes whose path starts with this folder, including descendants. */
+  count: number;
+  children: PathTreeNode[];
+}
+
+interface MutableNode extends PathTreeNode {
+  childMap: Map<string, MutableNode>;
+}
+
+function makeNode(name: string, fullPath: string): MutableNode {
+  return { name, fullPath, count: 0, children: [], childMap: new Map() };
+}
+
+// Split a path into folder segments, dropping the final filename so a note at
+// `Canon/Aaron/draft.md` contributes the `Canon` and `Canon/Aaron` folders but
+// not a leaf node for the file itself.
+function folderSegments(path: string): string[] {
+  const parts = path.split("/").filter((p) => p.length > 0);
+  if (parts.length <= 1) return [];
+  return parts.slice(0, -1);
+}
+
+export function buildPathTree(paths: Iterable<string | undefined>): PathTreeNode[] {
+  const roots = new Map<string, MutableNode>();
+  for (const raw of paths) {
+    if (!raw) continue;
+    const segments = folderSegments(raw);
+    if (segments.length === 0) continue;
+
+    let levelMap = roots;
+    let prefix = "";
+    for (const seg of segments) {
+      prefix = prefix ? `${prefix}/${seg}` : seg;
+      let node = levelMap.get(seg);
+      if (!node) {
+        node = makeNode(seg, prefix);
+        levelMap.set(seg, node);
+      }
+      node.count += 1;
+      levelMap = node.childMap;
+    }
+  }
+
+  const sortNodes = (nodes: MutableNode[]): PathTreeNode[] =>
+    nodes
+      .map((n) => ({
+        name: n.name,
+        fullPath: n.fullPath,
+        count: n.count,
+        children: sortNodes([...n.childMap.values()]),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+  return sortNodes([...roots.values()]);
+}
+
+// Show the tree automatically when the vault has either ≥5 distinct top-level
+// folders or ≥20 notes that live in any folder (multi-segment path). Below
+// that, a tag-flat vault would just see a stub — better to hide it.
+export const AUTO_TOP_LEVEL_MIN = 5;
+export const AUTO_FOLDERED_NOTES_MIN = 20;
+
+export function meetsAutoThreshold(paths: Iterable<string | undefined>): boolean {
+  const topLevel = new Set<string>();
+  let foldered = 0;
+  for (const raw of paths) {
+    if (!raw) continue;
+    const segments = folderSegments(raw);
+    if (segments.length === 0) continue;
+    foldered += 1;
+    topLevel.add(segments[0]!);
+    if (topLevel.size >= AUTO_TOP_LEVEL_MIN || foldered >= AUTO_FOLDERED_NOTES_MIN) return true;
+  }
+  return false;
+}

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -98,6 +98,29 @@ export function useNotesForDateViews() {
   });
 }
 
+// Fetches a capped metadata-only window of the vault for the path-tree
+// sidebar. We want a stable index of every path so the tree and threshold
+// check aren't skewed by whatever filter is currently applied to the main
+// list. Capped at VAULT_GRAPH_NOTE_CAP; vaults beyond that get a tree for
+// the most-recent N paths (the fallback input on the filter bar still works
+// for navigating outside the window).
+export function useNotesForPathTree(enabled: boolean) {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+
+  return useQuery({
+    queryKey: ["notesForPathTree", activeId],
+    enabled: !!client && enabled,
+    queryFn: () => {
+      const params = new URLSearchParams();
+      params.set("sort", "desc");
+      params.set("limit", String(VAULT_GRAPH_NOTE_CAP));
+      return client!.queryNotes(params);
+    },
+    staleTime: 60_000,
+  });
+}
+
 export function useAllNotesWithLinks() {
   const client = useActiveVaultClient();
   const activeId = useVaultStore((s) => s.activeVaultId);


### PR DESCRIPTION
## Summary
- New `PathTree` in the `/notes` sidebar derives a folder tree from a capped, unfiltered notes fetch (`useNotesForPathTree`, limit 5000) so the tree stays stable as the user narrows the list. Clicking a folder drives the existing `path_prefix` URL filter — no new vault endpoint required.
- Auto-detect hides the tree on tag-flat vaults (threshold: ≥5 top-level folders or ≥20 notes in folders). New per-vault setting `lens:path-tree:<vaultId>` (`auto` / `always` / `never`) is exposed in Settings under "Folder tree (Notes sidebar)".
- Expand/collapse state persists per vault (`lens:path-tree-expanded:<vaultId>`); ancestors of the active prefix auto-open so the user always sees where they are. Mobile collapses both the tree and the saved-views block behind a single "Folders & saved views" toggle.

## Test plan
- [x] `bun x tsc -b` — clean
- [x] `bun x biome check src` — clean
- [x] `bun x vitest run` — 64 files / 492 tests pass (25 new across `path-tree/*` + `PathTree` + `Notes` + `Settings`)
- [x] `bun run build` — clean
- [ ] Manual: tag-flat vault hides the tree; switching the setting to `always` shows it; clicking a folder writes `?path_prefix=…` and narrows the list; reload preserves expand state.

Closes #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)