### PR TITLE
Mobile polish: collapsing header, stacked editor tabs, graph touch fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
     <meta
       name="description"

--- a/src/app/routes/NoteEditor.tsx
+++ b/src/app/routes/NoteEditor.tsx
@@ -62,6 +62,8 @@ function toEditorState(note: Note): EditorState {
   };
 }
 
+type EditorPane = "edit" | "preview";
+
 function EditorSurface({ note }: { note: Note }) {
   const navigate = useNavigate();
   const pushToast = useToastStore((s) => s.push);
@@ -71,6 +73,8 @@ function EditorSurface({ note }: { note: Note }) {
   const [tagInput, setTagInput] = useState("");
   const [conflict, setConflict] = useState<VaultConflictError | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
+  // Mobile-only pane toggle. Desktop renders both side-by-side and ignores it.
+  const [mobilePane, setMobilePane] = useState<EditorPane>("edit");
   const mutation = useUpdateNote(note.id);
   const lastServerNote = useRef<Note>(note);
   const editorRef = useRef<CodeMirrorEditorHandle>(null);
@@ -266,10 +270,33 @@ function EditorSurface({ note }: { note: Note }) {
         </div>
       ) : null}
 
+      <div
+        role="tablist"
+        aria-label="Editor view"
+        className="mb-3 inline-flex rounded-md border border-border bg-card p-0.5 text-sm lg:hidden"
+      >
+        {(["edit", "preview"] as const).map((p) => (
+          <button
+            key={p}
+            type="button"
+            role="tab"
+            aria-selected={mobilePane === p}
+            onClick={() => setMobilePane(p)}
+            className={`rounded px-3 py-1.5 capitalize ${
+              mobilePane === p ? "bg-accent text-white" : "text-fg-muted hover:text-accent"
+            }`}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+
       <div className="grid min-h-[60vh] gap-4 lg:grid-cols-2">
         <AttachmentDropZone
           onDropFiles={uploader.start}
-          className="min-w-0 rounded-md border border-border bg-card"
+          className={`min-w-0 rounded-md border border-border bg-card ${
+            mobilePane === "edit" ? "" : "hidden lg:block"
+          }`}
           hint={ALLOWLIST_HINT}
         >
           <CodeMirrorEditor
@@ -284,7 +311,11 @@ function EditorSurface({ note }: { note: Note }) {
             }}
           />
         </AttachmentDropZone>
-        <div className="min-w-0 overflow-auto rounded-md border border-border bg-card p-4">
+        <div
+          className={`min-w-0 overflow-auto rounded-md border border-border bg-card p-4 ${
+            mobilePane === "preview" ? "" : "hidden lg:block"
+          }`}
+        >
           <MarkdownView content={previewContent} resolve={resolver} />
         </div>
       </div>

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -192,12 +192,12 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-10">
-      <header className="mb-6 flex items-baseline justify-between gap-4">
+      <header className="mb-6 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-3">
         <div>
           <p className="text-xs uppercase tracking-wider text-fg-dim">{activeVault.name}</p>
           <h1 className="font-serif text-3xl tracking-tight">{title}</h1>
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
           {!preset ? (
             <label className="flex items-center gap-1.5 text-sm text-fg-muted hover:text-accent">
               <input

--- a/src/app/routes/Tags.tsx
+++ b/src/app/routes/Tags.tsx
@@ -45,7 +45,7 @@ export function Tags() {
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-10">
-      <header className="mb-6 flex items-baseline justify-between gap-4">
+      <header className="mb-6 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-3">
         <div>
           <p className="text-xs uppercase tracking-wider text-fg-dim">{activeVault.name}</p>
           <h1 className="font-serif text-3xl tracking-tight">Tags</h1>

--- a/src/app/routes/VaultGraph.tsx
+++ b/src/app/routes/VaultGraph.tsx
@@ -168,6 +168,10 @@ function GraphCanvas({
 }) {
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // The ref is typed loosely because react-force-graph-2d's exposed methods
+  // (zoomToFit) live on the kapsule instance, not in its public TS type when
+  // wrapped in React.lazy.
+  const graphRef = useRef<{ zoomToFit?: (ms?: number, padding?: number) => void } | null>(null);
   const [size, setSize] = useState<{ w: number; h: number }>({ w: 800, h: 600 });
 
   useEffect(() => {
@@ -186,6 +190,10 @@ function GraphCanvas({
     return () => obs.disconnect();
   }, []);
 
+  const fitToScreen = () => {
+    graphRef.current?.zoomToFit?.(400, 40);
+  };
+
   const graphData = useMemo(
     () => ({
       nodes: graph.nodes.map((n) => ({ ...n })),
@@ -202,14 +210,22 @@ function GraphCanvas({
   const nodeOpacity = (id: string) => (!hasFilter || matched.has(id) ? 1 : 0.15);
 
   return (
-    <div ref={containerRef} data-testid="vault-graph-canvas" className="h-full w-full">
+    <div
+      ref={containerRef}
+      data-testid="vault-graph-canvas"
+      // touch-action: none stops the browser from scrolling/zooming the page
+      // while the user is panning or pinching the graph itself.
+      className="relative h-full w-full touch-none"
+    >
       <Suspense fallback={<GraphSkeleton message="Rendering graph…" />}>
         <ForceGraph2D
+          ref={graphRef as never}
           graphData={graphData}
           width={size.w}
           height={size.h}
           backgroundColor="rgba(0,0,0,0)"
           nodeLabel={(n) => nodeTooltip(n as unknown as VaultGraphNode)}
+          nodeRelSize={5}
           nodeVal={(n) => {
             const node = n as unknown as VaultGraphNode;
             return 2 + Math.min(node.degree, 12);
@@ -218,6 +234,19 @@ function GraphCanvas({
             const node = n as unknown as VaultGraphNode;
             const base = tagColor(node.topTag);
             return hasFilter && !matched.has(node.id) ? fade(base) : base;
+          }}
+          // Fatter invisible hit area so taps on small nodes are reliable on
+          // touch devices. Painted to an offscreen canvas the lib uses for
+          // pixel-perfect picking — visible appearance is unchanged.
+          nodePointerAreaPaint={(n, color, ctx) => {
+            const node = n as unknown as VaultGraphNode & { x?: number; y?: number };
+            if (node.x == null || node.y == null) return;
+            const val = 2 + Math.min(node.degree, 12);
+            const r = Math.max(Math.sqrt(val) * 5, 10);
+            ctx.fillStyle = color;
+            ctx.beginPath();
+            ctx.arc(node.x, node.y, r, 0, 2 * Math.PI);
+            ctx.fill();
           }}
           linkColor={(l) => {
             const link = l as unknown as { source: unknown; target: unknown };
@@ -232,6 +261,9 @@ function GraphCanvas({
           linkDirectionalArrowLength={2.5}
           linkDirectionalArrowRelPos={1}
           cooldownTicks={100}
+          // Auto-fit once the simulation settles so the user doesn't land on a
+          // graph that's panned off-screen.
+          onEngineStop={() => fitToScreen()}
           nodeCanvasObjectMode={() => "after"}
           nodeCanvasObject={(n, ctx, globalScale) => {
             const node = n as unknown as VaultGraphNode & { x?: number; y?: number };
@@ -251,6 +283,13 @@ function GraphCanvas({
           }}
         />
       </Suspense>
+      <button
+        type="button"
+        onClick={fitToScreen}
+        className="absolute right-3 bottom-3 rounded-md border border-border bg-card/90 px-3 py-1.5 text-xs text-fg-muted shadow-sm backdrop-blur hover:text-accent"
+      >
+        Fit to screen
+      </button>
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,13 +2,23 @@ import { InstallPrompt } from "@/components/InstallPrompt";
 import { SyncStatusIndicator } from "@/components/SyncStatusIndicator";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { type VaultRecord, useVaultStore } from "@/lib/vault";
-import { Link, useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router";
 
 export function Header() {
   const navigate = useNavigate();
+  const location = useLocation();
   const vaults = useVaultStore((s) => s.vaults);
   const activeVaultId = useVaultStore((s) => s.activeVaultId);
   const setActiveVault = useVaultStore((s) => s.setActiveVault);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Close the mobile menu whenever the route changes — otherwise a tap on a
+  // nav link would leave the panel open over the destination page.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the trigger, not a value used in the body
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
 
   const vaultLabel = (v: VaultRecord): string => {
     if (v.name) return v.name;
@@ -24,13 +34,17 @@ export function Header() {
   const hasVaults = vaultList.length > 0;
 
   return (
-    <header className="sticky top-0 z-10 border-b border-border bg-bg/90 backdrop-blur">
-      <nav className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-5">
+    <header
+      className="sticky top-0 z-10 border-b border-border bg-bg/90 backdrop-blur"
+      style={{ paddingTop: "env(safe-area-inset-top)" }}
+    >
+      <nav className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-6 py-4 md:py-5">
         <Link to="/" className="font-serif text-xl tracking-tight text-fg hover:text-accent">
           Parachute Notes
         </Link>
 
-        <div className="flex items-center gap-3">
+        {/* Desktop nav */}
+        <div className="hidden items-center gap-3 md:flex">
           {hasVaults ? (
             <>
               <Link to="/notes" className="text-sm text-fg-muted hover:text-accent">
@@ -82,7 +96,81 @@ export function Header() {
             </>
           )}
         </div>
+
+        {/* Mobile cluster: sync status (always visible) + hamburger */}
+        <div className="flex items-center gap-2 md:hidden">
+          {hasVaults ? <SyncStatusIndicator /> : null}
+          <button
+            type="button"
+            onClick={() => setMenuOpen((o) => !o)}
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={menuOpen}
+            aria-controls="mobile-menu"
+            className="flex h-10 w-10 items-center justify-center rounded-md border border-border bg-card text-fg-muted hover:text-accent"
+          >
+            <span aria-hidden="true" className="font-mono text-base leading-none">
+              {menuOpen ? "✕" : "☰"}
+            </span>
+          </button>
+        </div>
       </nav>
+
+      {menuOpen ? (
+        <div id="mobile-menu" className="border-t border-border bg-bg/95 px-6 py-4 md:hidden">
+          {hasVaults ? (
+            <div className="flex flex-col gap-3">
+              <Link to="/notes" className="py-1 text-sm text-fg hover:text-accent">
+                Notes
+              </Link>
+              <Link to="/tags" className="py-1 text-sm text-fg hover:text-accent">
+                Tags
+              </Link>
+              <Link to="/graph" className="py-1 text-sm text-fg hover:text-accent">
+                Graph
+              </Link>
+              <Link to="/capture" className="py-1 text-sm text-fg hover:text-accent">
+                + Capture
+              </Link>
+              <Link to="/settings" className="py-1 text-sm text-fg hover:text-accent">
+                Settings
+              </Link>
+              <button
+                type="button"
+                onClick={() => navigate("/vaults")}
+                className="py-1 text-left text-sm text-fg hover:text-accent"
+              >
+                Manage vaults
+              </button>
+              <label className="mt-1 block text-xs text-fg-dim">
+                <span className="mb-1 block uppercase tracking-wider">Active vault</span>
+                <select
+                  value={activeVaultId ?? ""}
+                  onChange={(e) => setActiveVault(e.target.value || null)}
+                  className="w-full rounded-md border border-border bg-card px-2.5 py-2 text-sm text-fg"
+                >
+                  {vaultList.map((v) => (
+                    <option key={v.id} value={v.id}>
+                      {vaultLabel(v)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="mt-1 flex items-center gap-3">
+                <InstallPrompt />
+                <ThemeToggle />
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-fg-dim">No vault connected</p>
+              <div className="flex items-center gap-3">
+                <InstallPrompt />
+                <ThemeToggle />
+              </div>
+            </div>
+          )}
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -66,6 +66,15 @@ body {
   line-height: 1.65;
 }
 
+/* Respect iOS safe-area insets for installed PWAs so content doesn't sit
+   under the notch or home indicator. The header is sticky and gets its own
+   top inset; main content gets bottom + horizontal insets. */
+body {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
 .prose-note {
   color: var(--color-fg);
   font-size: 1rem;


### PR DESCRIPTION
## Summary
Final v0.3 mobile polish pass (#32).

- **Header** collapses to a hamburger drawer under `md`; sync-status dot remains persistently visible so the user can still see connection state without opening the menu. Drawer auto-closes on route change.
- **Editor** gains an edit/preview tab switcher on narrow viewports (`lg:hidden`); `lg+` keeps the side-by-side grid unchanged. `role="tablist"` + `aria-selected` for screen readers.
- **Graph** gets a "Fit to screen" button, `touch-action: none` on the canvas so pinch/pan doesn't scroll the document, fatter `nodePointerAreaPaint` hit targets (min 10 graph units), slightly larger `nodeRelSize`, and an auto-fit on `onEngineStop` so the sim never settles off-screen.
- **Notes/Tags** page headers switch to `flex-wrap` so the action cluster (sort / new note / show-archived) drops below the title on narrow widths instead of crowding it.
- **Safe-area insets**: `viewport-fit=cover` meta + `env(safe-area-inset-*)` padding on `body` (left/right/bottom) and `header` (top) so installed iOS PWAs don't sit under the notch or home indicator.

Out of scope (per the brief): native-feel gestures, pull-to-refresh, any full redesign.

## Test plan
- [x] `bun x tsc -b` clean
- [x] `bun x biome check src` clean
- [x] `bun x vitest run` — 492/492
- [x] `bun run build` — clean
- [ ] Chrome DevTools mobile emulation (375×667 iPhone SE) — header drawer, editor tabs, graph touch
- [ ] iPhone Safari via Tailscale HTTPS — installed PWA with safe-area insets honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)