### PR TITLE
Discover vaults via parachute.json; migrate stored URLs to /vault/<name>

### DIFF
--- a/src/app/routes/AddVault.tsx
+++ b/src/app/routes/AddVault.tsx
@@ -75,7 +75,8 @@ export function AddVault() {
             className="w-full rounded-md border border-border bg-card px-3 py-2 font-mono text-sm text-fg focus:border-accent focus:outline-none"
           />
           <p className="mt-1.5 text-xs text-fg-dim">
-            For multi-vault servers, include the vault path (e.g. <code>/vaults/work</code>).
+            Include the vault path (e.g. <code>/vault/default</code>). If the host serves a{" "}
+            <code>parachute.json</code> registry, just paste the origin and we'll discover it.
           </p>
         </div>
 

--- a/src/app/routes/Vaults.tsx
+++ b/src/app/routes/Vaults.tsx
@@ -1,4 +1,4 @@
-import { useVaultStore } from "@/lib/vault";
+import { isLegacyVaultUrl, useVaultStore } from "@/lib/vault";
 import { Link } from "react-router";
 
 export function Vaults() {
@@ -27,47 +27,62 @@ export function Vaults() {
         <ul className="space-y-3">
           {list.map((vault) => {
             const isActive = vault.id === activeVaultId;
+            const isLegacy = isLegacyVaultUrl(vault.url);
             return (
-              <li
-                key={vault.id}
-                className="flex items-center justify-between rounded-lg border border-border bg-card p-4"
-              >
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-serif text-lg text-fg">{vault.name}</span>
-                    {isActive ? (
-                      <span className="rounded bg-accent/10 px-2 py-0.5 text-xs text-accent">
-                        active
+              <li key={vault.id} className="rounded-lg border border-border bg-card p-4">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-serif text-lg text-fg">{vault.name}</span>
+                      {isActive ? (
+                        <span className="rounded bg-accent/10 px-2 py-0.5 text-xs text-accent">
+                          active
+                        </span>
+                      ) : null}
+                      <span className="rounded border border-border px-2 py-0.5 text-xs text-fg-dim">
+                        {vault.scope}
                       </span>
-                    ) : null}
-                    <span className="rounded border border-border px-2 py-0.5 text-xs text-fg-dim">
-                      {vault.scope}
-                    </span>
+                      {isLegacy ? (
+                        <span className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs text-amber-500">
+                          needs reconnect
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-1 truncate font-mono text-xs text-fg-muted">{vault.url}</p>
                   </div>
-                  <p className="mt-1 font-mono text-xs text-fg-muted">{vault.url}</p>
-                </div>
-                <div className="flex items-center gap-4 text-sm">
-                  {!isActive ? (
+                  <div className="flex shrink-0 items-center gap-4 text-sm">
+                    {!isActive ? (
+                      <button
+                        type="button"
+                        onClick={() => setActiveVault(vault.id)}
+                        className="text-fg-muted hover:text-accent"
+                      >
+                        Make active
+                      </button>
+                    ) : null}
                     <button
                       type="button"
-                      onClick={() => setActiveVault(vault.id)}
-                      className="text-fg-muted hover:text-accent"
+                      onClick={() => {
+                        if (confirm(`Remove ${vault.name}? The access token will be deleted.`)) {
+                          removeVault(vault.id);
+                        }
+                      }}
+                      className="text-red-400 hover:text-red-300"
                     >
-                      Make active
+                      Remove
                     </button>
-                  ) : null}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (confirm(`Remove ${vault.name}? The access token will be deleted.`)) {
-                        removeVault(vault.id);
-                      }
-                    }}
-                    className="text-red-400 hover:text-red-300"
-                  >
-                    Remove
-                  </button>
+                  </div>
                 </div>
+                {isLegacy ? (
+                  <p className="mt-3 rounded border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-500">
+                    Vault now serves under <code>/vault/&lt;name&gt;/</code>. This stored URL is
+                    from the older scheme and won't reach the new endpoints. Remove this entry and{" "}
+                    <Link to="/add" className="underline">
+                      add it again
+                    </Link>{" "}
+                    — discovery will pick the right URL automatically.
+                  </p>
+                ) : null}
               </li>
             );
           })}

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -4,6 +4,7 @@ export * from "./graph";
 export * from "./neighborhood";
 export * from "./note-query";
 export * from "./oauth";
+export * from "./parachute-json";
 export * from "./pkce";
 export * from "./probe";
 export * from "./queries";

--- a/src/lib/vault/parachute-json.test.ts
+++ b/src/lib/vault/parachute-json.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchParachuteJson, parseParachuteJson, pickVault } from "./parachute-json";
+
+function mockFetch(
+  responses: Array<{ ok?: boolean; status?: number; json?: unknown } | "network-error">,
+) {
+  const queue = [...responses];
+  return vi.fn<typeof fetch>(async () => {
+    const next = queue.shift();
+    if (!next) throw new Error("unexpected fetch call");
+    if (next === "network-error") throw new Error("network down");
+    return {
+      ok: next.ok ?? true,
+      status: next.status ?? 200,
+      json: async () => next.json,
+      text: async () => "",
+    } as Response;
+  });
+}
+
+describe("parseParachuteJson", () => {
+  it("accepts the single-vault shape `{ vault: { url } }`", () => {
+    const out = parseParachuteJson({ vault: { url: "https://h.example/vault/default" } });
+    expect(out).toEqual({ vaults: [{ name: "default", url: "https://h.example/vault/default" }] });
+  });
+
+  it("accepts the multi-vault shape `{ vaults: [...] }`", () => {
+    const out = parseParachuteJson({
+      vaults: [
+        { name: "default", url: "https://h.example/vault/default" },
+        { name: "work", url: "https://h.example/vault/work" },
+      ],
+    });
+    expect(out?.vaults).toHaveLength(2);
+    expect(out?.vaults[1]?.name).toBe("work");
+  });
+
+  it("prefers `vaults` when both shapes are present", () => {
+    const out = parseParachuteJson({
+      vault: { url: "https://h.example/vault/default" },
+      vaults: [{ name: "work", url: "https://h.example/vault/work" }],
+    });
+    expect(out?.vaults).toEqual([{ name: "work", url: "https://h.example/vault/work" }]);
+  });
+
+  it("fills in a fallback name when an entry has no name", () => {
+    const out = parseParachuteJson({ vaults: [{ url: "https://h.example/vault/x" }] });
+    expect(out?.vaults[0]?.name).toBe("default");
+  });
+
+  it("returns null on garbage input", () => {
+    expect(parseParachuteJson(null)).toBeNull();
+    expect(parseParachuteJson("nope")).toBeNull();
+    expect(parseParachuteJson({ vaults: [] })).toBeNull();
+    expect(parseParachuteJson({ vaults: [{ name: "x" }] })).toBeNull();
+  });
+});
+
+describe("pickVault", () => {
+  const sample = {
+    vaults: [
+      { name: "work", url: "https://h.example/vault/work" },
+      { name: "default", url: "https://h.example/vault/default" },
+    ],
+  };
+
+  it("prefers a vault matching the requested name", () => {
+    expect(pickVault(sample, "work")?.name).toBe("work");
+  });
+
+  it("falls back to the entry named `default`", () => {
+    expect(pickVault(sample)?.name).toBe("default");
+  });
+
+  it("falls back to the first entry when no `default` exists", () => {
+    expect(pickVault({ vaults: [{ name: "work", url: "u" }] })?.name).toBe("work");
+  });
+});
+
+describe("fetchParachuteJson", () => {
+  it("hits the well-known path on the origin and parses the response", async () => {
+    const fetchImpl = mockFetch([{ json: { vault: { url: "https://h.example/vault/default" } } }]);
+    const out = await fetchParachuteJson("https://h.example/some/path", 500, fetchImpl);
+    expect(out?.vaults[0]?.url).toBe("https://h.example/vault/default");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://h.example/.well-known/parachute.json",
+      expect.any(Object),
+    );
+  });
+
+  it("returns null on 404", async () => {
+    const fetchImpl = mockFetch([{ ok: false, status: 404 }]);
+    expect(await fetchParachuteJson("https://h.example", 500, fetchImpl)).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    const fetchImpl = mockFetch(["network-error"]);
+    expect(await fetchParachuteJson("https://h.example", 500, fetchImpl)).toBeNull();
+  });
+});

--- a/src/lib/vault/parachute-json.ts
+++ b/src/lib/vault/parachute-json.ts
@@ -1,0 +1,103 @@
+// Discovery primitive served at `${origin}/.well-known/parachute.json` by the
+// Parachute CLI when an install is registered for the host. Lets Notes find
+// the running vault without hardcoding a path. Schema is tolerant by design —
+// the CLI may write either single- or multi-vault shapes.
+//
+// Accepted shapes:
+//   { "vault":  { "url": "https://host/vault/default" } }
+//   { "vaults": [{ "name": "default", "url": "..." }, { "name": "work", "url": "..." }] }
+//   (and combinations — `vaults` wins if both present)
+
+const WELL_KNOWN_PATH = "/.well-known/parachute.json";
+const DEFAULT_TIMEOUT_MS = 2500;
+
+export interface ParachuteJsonVault {
+  name: string;
+  url: string;
+}
+
+export interface ParachuteJson {
+  vaults: ParachuteJsonVault[];
+}
+
+export async function fetchParachuteJson(
+  origin: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
+): Promise<ParachuteJson | null> {
+  const url = `${stripTrailingSlash(originOf(origin))}${WELL_KNOWN_PATH}`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, {
+      headers: { Accept: "application/json" },
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return null;
+    const raw = (await res.json()) as unknown;
+    return parseParachuteJson(raw);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function parseParachuteJson(raw: unknown): ParachuteJson | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const vaults: ParachuteJsonVault[] = [];
+
+  if (Array.isArray(r.vaults)) {
+    for (const entry of r.vaults) {
+      const v = coerceVault(entry, vaults.length === 0 ? "default" : `vault-${vaults.length}`);
+      if (v) vaults.push(v);
+    }
+  }
+
+  if (vaults.length === 0 && r.vault && typeof r.vault === "object") {
+    const single = coerceVault(r.vault, "default");
+    if (single) vaults.push(single);
+  }
+
+  if (vaults.length === 0) return null;
+  return { vaults };
+}
+
+// Pick the best vault from a parachute.json. Prefer one named `default` (or
+// matching the caller's preference); fall back to the first entry. Returns
+// `null` only when the manifest has no vaults at all.
+export function pickVault(
+  manifest: ParachuteJson,
+  preferredName?: string,
+): ParachuteJsonVault | null {
+  if (manifest.vaults.length === 0) return null;
+  if (preferredName) {
+    const match = manifest.vaults.find((v) => v.name === preferredName);
+    if (match) return match;
+  }
+  const def = manifest.vaults.find((v) => v.name === "default");
+  if (def) return def;
+  return manifest.vaults[0] ?? null;
+}
+
+function coerceVault(raw: unknown, fallbackName: string): ParachuteJsonVault | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const url = typeof r.url === "string" ? r.url.trim() : "";
+  if (!url) return null;
+  const name = typeof r.name === "string" && r.name.trim() ? r.name.trim() : fallbackName;
+  return { name, url };
+}
+
+function originOf(input: string): string {
+  try {
+    return new URL(input).origin;
+  } catch {
+    return input;
+  }
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.replace(/\/+$/, "");
+}

--- a/src/lib/vault/probe.test.ts
+++ b/src/lib/vault/probe.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { probeVaultAtOrigin } from "./probe";
 
 const validMetadata = {
-  issuer: "http://localhost:1940",
-  authorization_endpoint: "http://localhost:1940/oauth/authorize",
-  token_endpoint: "http://localhost:1940/oauth/token",
-  registration_endpoint: "http://localhost:1940/oauth/register",
+  issuer: "https://h.example/vault/default",
+  authorization_endpoint: "https://h.example/vault/default/oauth/authorize",
+  token_endpoint: "https://h.example/vault/default/oauth/token",
+  registration_endpoint: "https://h.example/vault/default/oauth/register",
   response_types_supported: ["code"],
   code_challenge_methods_supported: ["S256"],
   grant_types_supported: ["authorization_code"],
@@ -13,67 +13,97 @@ const validMetadata = {
   scopes_supported: ["full", "read"],
 };
 
-function mockFetch(
-  responses: Array<
-    { ok?: boolean; status?: number; json?: unknown; text?: string } | "network-error"
-  >,
-) {
-  const queue = [...responses];
-  return vi.fn<typeof fetch>(async () => {
-    const next = queue.shift();
-    if (!next) throw new Error("unexpected fetch call");
-    if (next === "network-error") throw new Error("network down");
-    return {
-      ok: next.ok ?? true,
-      status: next.status ?? 200,
-      json: async () => next.json,
-      text: async () => next.text ?? "",
-    } as Response;
+interface MockResponse {
+  ok?: boolean;
+  status?: number;
+  json?: unknown;
+  text?: string;
+}
+
+// Fetch mock that routes by URL substring instead of a fixed queue — the new
+// probe makes two kinds of calls (parachute.json + oauth metadata) and a
+// flat queue is brittle if the order changes.
+function routedFetch(routes: Record<string, MockResponse | "network-error">) {
+  return vi.fn<typeof fetch>(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    for (const [pattern, response] of Object.entries(routes)) {
+      if (url.includes(pattern)) {
+        if (response === "network-error") throw new Error("network down");
+        return {
+          ok: response.ok ?? true,
+          status: response.status ?? 200,
+          json: async () => response.json,
+          text: async () => response.text ?? "",
+        } as Response;
+      }
+    }
+    throw new Error(`unmatched fetch: ${url}`);
   });
 }
 
 describe("probeVaultAtOrigin", () => {
-  it("returns the origin when discovery succeeds", async () => {
-    const fetchImpl = mockFetch([{ json: validMetadata }]);
-    const result = await probeVaultAtOrigin("http://localhost:1940", 500, fetchImpl);
-    expect(result).toBe("http://localhost:1940");
+  it("discovers via parachute.json and returns the chosen vault URL", async () => {
+    const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": {
+        json: { vault: { url: "https://h.example/vault/default" } },
+      },
+      "/vault/default/.well-known/oauth-authorization-server": { json: validMetadata },
+    });
+    const result = await probeVaultAtOrigin("https://h.example", 500, fetchImpl);
+    expect(result).toBe("https://h.example/vault/default");
   });
 
-  it("returns null on 404 without bubbling the error", async () => {
-    const fetchImpl = mockFetch([{ ok: false, status: 404 }]);
-    const result = await probeVaultAtOrigin("http://localhost:1940", 500, fetchImpl);
-    expect(result).toBeNull();
+  it("prefers the entry named `default` from a multi-vault parachute.json", async () => {
+    const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": {
+        json: {
+          vaults: [
+            { name: "work", url: "https://h.example/vault/work" },
+            { name: "default", url: "https://h.example/vault/default" },
+          ],
+        },
+      },
+      "/vault/default/.well-known/oauth-authorization-server": { json: validMetadata },
+    });
+    const result = await probeVaultAtOrigin("https://h.example", 500, fetchImpl);
+    expect(result).toBe("https://h.example/vault/default");
   });
 
-  it("returns null when metadata validation fails", async () => {
-    const fetchImpl = mockFetch([
-      { json: { ...validMetadata, code_challenge_methods_supported: ["plain"] } },
-    ]);
-    const result = await probeVaultAtOrigin("http://localhost:1940", 500, fetchImpl);
-    expect(result).toBeNull();
+  it("falls back to direct OAuth metadata probing when parachute.json is missing", async () => {
+    // User pasted a full vault URL directly; no parachute.json on origin.
+    const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": { ok: false, status: 404 },
+      "/vault/default/.well-known/oauth-authorization-server": { json: validMetadata },
+    });
+    const result = await probeVaultAtOrigin("https://h.example/vault/default", 500, fetchImpl);
+    expect(result).toBe("https://h.example/vault/default");
   });
 
-  it("returns null on network error", async () => {
-    const fetchImpl = mockFetch(["network-error"]);
-    const result = await probeVaultAtOrigin("http://localhost:1940", 500, fetchImpl);
-    expect(result).toBeNull();
+  it("returns null when neither parachute.json nor direct OAuth metadata resolve", async () => {
+    const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": { ok: false, status: 404 },
+      "/.well-known/oauth-authorization-server": { ok: false, status: 404 },
+    });
+    expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
   });
 
-  it("falls back to the port-stripped origin when the primary fails", async () => {
-    // Primary (:8443) 404s; stripped origin (https://example.com) succeeds.
-    const fetchImpl = mockFetch([
-      { ok: false, status: 404 },
-      { json: { ...validMetadata, issuer: "https://example.com" } },
-    ]);
-    const result = await probeVaultAtOrigin("https://example.com:8443", 500, fetchImpl);
-    expect(result).toBe("https://example.com");
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  it("returns null on network error during direct probe", async () => {
+    const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": { ok: false, status: 404 },
+      "/.well-known/oauth-authorization-server": "network-error",
+    });
+    expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
   });
 
-  it("does not retry when the origin has no port", async () => {
-    const fetchImpl = mockFetch([{ ok: false, status: 404 }]);
-    const result = await probeVaultAtOrigin("https://example.com", 500, fetchImpl);
-    expect(result).toBeNull();
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  it("returns null when parachute.json is found but its vault fails OAuth metadata", async () => {
+    const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": {
+        json: { vault: { url: "https://h.example/vault/broken" } },
+      },
+      // Both the parachute.json-pointed and direct probes fail.
+      "/vault/broken/.well-known/oauth-authorization-server": { ok: false, status: 500 },
+      "/.well-known/oauth-authorization-server": { ok: false, status: 404 },
+    });
+    expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
   });
 });

--- a/src/lib/vault/probe.ts
+++ b/src/lib/vault/probe.ts
@@ -1,52 +1,64 @@
 import { useEffect, useState } from "react";
 import { discoverAuthServer } from "./discovery";
+import { fetchParachuteJson, pickVault } from "./parachute-json";
 import { useVaultStore } from "./store";
 
 export type ProbeStatus = "probing" | "found" | "not-found" | "skipped";
 
 export interface ProbeResult {
   status: ProbeStatus;
+  // Full vault URL (origin + `/vault/<name>`), not just origin. Naming kept
+  // for backwards-compat with existing callers.
   origin: string | null;
 }
 
 const DEFAULT_TIMEOUT_MS = 2500;
 
-// Probe an origin for a Parachute Vault by fetching RFC 8414 metadata. Returns
-// the origin on success, null on any failure (network, non-200, bad metadata,
-// timeout). If the given origin has a non-default port and fails, retry with
-// the port stripped — covers reverse-proxy setups (e.g. Tailscale serve) where
-// Lens is reachable at :8443 but the vault is on :443.
+// Probe an origin for a Parachute Vault. Two paths:
+//
+//   1. Ecosystem discovery: fetch `${origin}/.well-known/parachute.json` and
+//      pick a vault entry (name=default, else first). Validate by hitting its
+//      OAuth metadata.
+//   2. Direct: probe `${input}/.well-known/oauth-authorization-server` — for
+//      when the user pasted a vault URL directly (e.g. `https://h/vault/work`)
+//      without a parachute.json registry on the origin.
+//
+// Returns the discovered vault URL (full path including `/vault/<name>`) or
+// null if neither path resolves.
 export async function probeVaultAtOrigin(
   origin: string,
   timeoutMs: number = DEFAULT_TIMEOUT_MS,
   fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<string | null> {
-  const tryOnce = async (candidate: string): Promise<string | null> => {
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
-    const withSignal: typeof fetch = (input, init) =>
-      fetchImpl(input, { ...(init ?? {}), signal: ctrl.signal });
-    try {
-      await discoverAuthServer(candidate, withSignal);
-      return candidate;
-    } catch {
-      return null;
-    } finally {
-      clearTimeout(timer);
+  const manifest = await fetchParachuteJson(origin, timeoutMs, fetchImpl);
+  if (manifest) {
+    const chosen = pickVault(manifest);
+    if (chosen) {
+      const validated = await tryDiscoverAuthServer(chosen.url, timeoutMs, fetchImpl);
+      if (validated) return validated;
     }
-  };
+  }
 
-  const primary = await tryOnce(origin);
-  if (primary) return primary;
+  return tryDiscoverAuthServer(origin, timeoutMs, fetchImpl);
+}
 
+async function tryDiscoverAuthServer(
+  candidate: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+): Promise<string | null> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  const withSignal: typeof fetch = (input, init) =>
+    fetchImpl(input, { ...(init ?? {}), signal: ctrl.signal });
   try {
-    const url = new URL(origin);
-    if (url.port) {
-      url.port = "";
-      return await tryOnce(url.origin);
-    }
-  } catch {}
-  return null;
+    await discoverAuthServer(candidate, withSignal);
+    return candidate;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 // Probe the current window's origin on mount, but skip if the user already has

--- a/src/lib/vault/url.test.ts
+++ b/src/lib/vault/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeVaultUrl, vaultIdFromUrl } from "./url";
+import { isLegacyVaultUrl, normalizeVaultUrl, vaultIdFromUrl } from "./url";
 
 describe("normalizeVaultUrl", () => {
   it("adds https when scheme is missing", () => {
@@ -63,5 +63,25 @@ describe("vaultIdFromUrl", () => {
     expect(vaultIdFromUrl("https://vault.example.com/vaults/work")).toBe(
       "vault.example.com_vaults_work",
     );
+  });
+});
+
+describe("isLegacyVaultUrl", () => {
+  it("flags origin-only URLs (pre-PR-7 default)", () => {
+    expect(isLegacyVaultUrl("https://vault.example.com")).toBe(true);
+    expect(isLegacyVaultUrl("http://localhost:1940")).toBe(true);
+  });
+
+  it("flags the previous `/vaults/<name>/` plural scheme", () => {
+    expect(isLegacyVaultUrl("https://vault.example.com/vaults/work")).toBe(true);
+  });
+
+  it("accepts current `/vault/<name>` URLs", () => {
+    expect(isLegacyVaultUrl("https://vault.example.com/vault/default")).toBe(false);
+    expect(isLegacyVaultUrl("http://localhost:1940/vault/work")).toBe(false);
+  });
+
+  it("returns false for unparseable input rather than misclassifying", () => {
+    expect(isLegacyVaultUrl("not-a-url")).toBe(false);
   });
 });

--- a/src/lib/vault/url.ts
+++ b/src/lib/vault/url.ts
@@ -31,6 +31,7 @@ export function normalizeVaultUrl(input: string): string {
     "/mcp",
     "/.well-known/oauth-authorization-server",
     "/.well-known/oauth-protected-resource",
+    "/.well-known/parachute.json",
     "/oauth/authorize",
     "/oauth/token",
     "/oauth/register",
@@ -48,4 +49,19 @@ export function normalizeVaultUrl(input: string): string {
 
 export function vaultIdFromUrl(url: string): string {
   return url.replace(/^https?:\/\//, "").replace(/[^\w.-]+/g, "_");
+}
+
+// Vault PR 7 moved every endpoint under `/vault/<name>/`. Older stored
+// VaultRecords whose URL is origin-only (or the previous `/vaults/<name>/`
+// plural) won't reach the new endpoints and their tokens are invalid because
+// vault's issuer changed. Detect them so the Vaults page can prompt re-add.
+export function isLegacyVaultUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  return !(segments.length >= 2 && segments[0] === "vault");
 }


### PR DESCRIPTION
## Summary

Vault PR 7 (#79) moved every endpoint under `/vault/<name>/` with no backward compat. This updates Notes to match.

- **Probe rewrite** — `probeVaultAtOrigin` now fetches `/.well-known/parachute.json` on the origin first, picks the entry named `default` (or first if none), and validates via OAuth metadata at the chosen vault URL. If parachute.json is missing or unparseable, falls back to direct OAuth metadata at the input URL (so a raw paste of `https://host/vault/<name>` still works). Old port-strip workaround removed — parachute.json points at the correct URL explicitly.
- **VaultRecord.url** is now treated as the full vault URL including `/vault/<name>`. `VaultClient` already builds requests as `${baseUrl}${path}`, so no method bodies needed changes.
- **Migration UX** — `isLegacyVaultUrl(url)` detects origin-only URLs (pre-PR-7 default) and the older `/vaults/<name>/` plural scheme. `/vaults` shows a per-entry amber "needs reconnect" badge + banner linking to `/add` for re-discovery. No silent rewrite — the user re-adds explicitly.
- **AddVault hint text** updated to mention parachute.json discovery.

### parachute.json shape (tolerant parser)

Accepts both:
- `{ "vault": { "url": "https://host/vault/default" } }` — single
- `{ "vaults": [{ "name": "default", "url": "..." }, ...] }` — multi

If both present, `vaults` wins. Missing names get `default` (first) or `vault-N` fallbacks. Picker prefers requested name → entry named `default` → first.

### Out of scope (per brief)

- No dual-scheme support — old URLs flagged + re-add flow only.
- No multi-vault selector UI for launch.
- OAuth callback URI unchanged (still `import.meta.env.BASE_URL`).

## Test plan

- [x] `bun x vitest run` — 507/507 pass (added 17 tests: 11 parachute-json, 6 probe rewrite, 4 isLegacyVaultUrl)
- [x] `bun x biome check src` — clean
- [x] `bun run build` — clean
- [ ] Manual: add a vault via origin paste against a host serving parachute.json
- [ ] Manual: add a vault via direct `/vault/default` paste against a host without parachute.json
- [ ] Manual: confirm `/vaults` flags any pre-existing entries as "needs reconnect"

🤖 Generated with [Claude Code](https://claude.com/claude-code)