### PR TITLE
Add /activity feed grouped by Today / Yesterday / This week / Older

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,7 @@ import { UpdateBanner } from "@/components/UpdateBanner";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { SyncProvider } from "@/providers/SyncProvider";
 import { BrowserRouter, Route, Routes } from "react-router";
+import { Activity } from "./routes/Activity";
 import { AddVault } from "./routes/AddVault";
 import { Calendar } from "./routes/Calendar";
 import { Capture } from "./routes/Capture";
@@ -42,6 +43,7 @@ export function App() {
                 <Route path="/graph" element={<VaultGraph />} />
                 <Route path="/today" element={<Today />} />
                 <Route path="/calendar" element={<Calendar />} />
+                <Route path="/activity" element={<Activity />} />
                 <Route path="/notes/:id" element={<NoteView />} />
                 <Route path="/notes/:id/edit" element={<NoteEditor />} />
                 <Route path="/add" element={<AddVault />} />

--- a/src/app/routes/Activity.test.tsx
+++ b/src/app/routes/Activity.test.tsx
@@ -1,0 +1,180 @@
+import { Activity } from "@/app/routes/Activity";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface Row {
+  id: string;
+  path: string;
+  createdAt: string;
+  updatedAt?: string;
+  tags?: string[];
+  preview?: string;
+}
+
+function installFetch(notes: Row[]) {
+  const impl = vi.fn<typeof fetch>(async () => {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => notes,
+      text: async () => "",
+    } as Response;
+  });
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      v1: {
+        id: "v1",
+        url: "http://localhost:1940/vault/default",
+        name: "default",
+        issuer: "http://localhost:1940/vault/default",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v1",
+  });
+  localStorage.setItem(
+    "lens:token:v1",
+    JSON.stringify({ accessToken: "t", scope: "full", vault: "default" }),
+  );
+}
+
+function LocationSpy() {
+  const loc = useLocation();
+  return <div data-testid="location">{`${loc.pathname}${loc.search}`}</div>;
+}
+
+function Wrap({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return (
+    <MemoryRouter initialEntries={["/activity"]}>
+      <QueryClientProvider client={qc}>
+        <Routes>
+          <Route path="/activity" element={children} />
+          <Route path="/" element={<LocationSpy />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function localIso(year: number, month: number, day: number, hour = 12): string {
+  return new Date(year, month - 1, day, hour).toISOString();
+}
+
+describe("Activity route", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 3, 18, 12, 0, 0));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+  });
+
+  it("groups events into Today / Yesterday / This week / Older", async () => {
+    installFetch([
+      { id: "n1", path: "Today.md", createdAt: localIso(2026, 4, 18, 9) },
+      { id: "n2", path: "Yesterday.md", createdAt: localIso(2026, 4, 17, 9) },
+      { id: "n3", path: "Wk.md", createdAt: localIso(2026, 4, 14, 9) },
+      { id: "n4", path: "Old.md", createdAt: localIso(2026, 4, 1, 9) },
+    ]);
+    render(
+      <Wrap>
+        <Activity />
+      </Wrap>,
+    );
+
+    await screen.findByText("Today.md");
+    expect(screen.getByText(/^today \(1\)$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^yesterday \(1\)$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^this week \(1\)$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^older \(1\)$/i)).toBeInTheDocument();
+  });
+
+  it("renders both Created and Edited rows for an updated note", async () => {
+    installFetch([
+      {
+        id: "n1",
+        path: "Edited.md",
+        createdAt: localIso(2026, 4, 15, 10),
+        updatedAt: localIso(2026, 4, 18, 14),
+      },
+    ]);
+    render(
+      <Wrap>
+        <Activity />
+      </Wrap>,
+    );
+
+    await screen.findAllByText("Edited.md");
+    expect(screen.getByText("Created")).toBeInTheDocument();
+    expect(screen.getByText("Edited")).toBeInTheDocument();
+  });
+
+  it("shows the empty state with capture link when there's nothing", async () => {
+    installFetch([]);
+    render(
+      <Wrap>
+        <Activity />
+      </Wrap>,
+    );
+    expect(await screen.findByText(/no activity in the last 30 days/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open capture/i })).toBeInTheDocument();
+  });
+
+  it("paginates with Load more and reveals the next 50", async () => {
+    // 60 distinct notes inside the 30-day window — first 50 shown, 10 hidden
+    // until the user clicks Load more.
+    const notes: Row[] = [];
+    for (let i = 0; i < 60; i++) {
+      notes.push({
+        id: `n${i}`,
+        path: `N${i}.md`,
+        createdAt: localIso(2026, 4, 18, 11 - Math.floor(i / 10)),
+      });
+    }
+    installFetch(notes);
+    render(
+      <Wrap>
+        <Activity />
+      </Wrap>,
+    );
+
+    await screen.findByText("N0.md");
+    expect(screen.queryByText("N50.md")).not.toBeInTheDocument();
+    const btn = screen.getByRole("button", { name: /load more \(10 remaining\)/i });
+    fireEvent.click(btn);
+    await screen.findByText("N50.md");
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it("redirects home when no active vault", async () => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    installFetch([]);
+    render(
+      <Wrap>
+        <Activity />
+      </Wrap>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toBe("/");
+    });
+  });
+});

--- a/src/app/routes/Activity.tsx
+++ b/src/app/routes/Activity.tsx
@@ -1,0 +1,174 @@
+import {
+  type ActivityEvent,
+  BUCKET_LABELS,
+  BUCKET_ORDER,
+  buildActivityEvents,
+  groupEventsByBucket,
+} from "@/lib/activity/events";
+import { relativeTime } from "@/lib/time";
+import { useNotesForDateViews, useVaultStore } from "@/lib/vault";
+import { VaultAuthError } from "@/lib/vault/client";
+import { useMemo, useState } from "react";
+import { Link, Navigate } from "react-router";
+
+const PAGE_SIZE = 50;
+
+export function Activity() {
+  const activeVault = useVaultStore((s) => s.getActiveVault());
+  const notes = useNotesForDateViews();
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  const events = useMemo(() => {
+    if (!notes.data) return [];
+    return buildActivityEvents(notes.data);
+  }, [notes.data]);
+
+  const visibleEvents = useMemo(() => events.slice(0, visibleCount), [events, visibleCount]);
+  const grouped = useMemo(() => groupEventsByBucket(visibleEvents), [visibleEvents]);
+  const remaining = events.length - visibleEvents.length;
+
+  if (!activeVault) return <Navigate to="/" replace />;
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-6">
+        <p className="text-xs uppercase tracking-wider text-fg-dim">Activity</p>
+        <h1 className="font-serif text-3xl tracking-tight">Recent changes</h1>
+        <p className="mt-1 text-sm text-fg-muted">
+          Last 30 days, newest first. Deletions aren't tracked yet.
+        </p>
+      </header>
+
+      {notes.isPending ? (
+        <Skeleton />
+      ) : notes.isError ? (
+        <ErrorBlock error={notes.error} />
+      ) : events.length === 0 ? (
+        <EmptyBlock />
+      ) : (
+        <>
+          <div className="space-y-8">
+            {BUCKET_ORDER.map((bucket) =>
+              grouped[bucket].length > 0 ? (
+                <Section key={bucket} title={BUCKET_LABELS[bucket]} events={grouped[bucket]} />
+              ) : null,
+            )}
+          </div>
+          {remaining > 0 ? (
+            <div className="mt-8 flex justify-center">
+              <button
+                type="button"
+                onClick={() => setVisibleCount((n) => n + PAGE_SIZE)}
+                className="rounded-md border border-border bg-card px-4 py-2 text-sm text-fg-muted hover:text-accent"
+              >
+                Load more ({remaining} remaining)
+              </button>
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+function Section({ title, events }: { title: string; events: ActivityEvent[] }) {
+  return (
+    <section>
+      <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">
+        {title} ({events.length})
+      </h2>
+      <ol className="divide-y divide-border rounded-md border border-border bg-card">
+        {events.map((ev) => (
+          <li key={ev.id}>
+            <Link
+              to={`/notes/${encodeURIComponent(ev.noteId)}`}
+              className="block px-4 py-3 hover:bg-bg/60 focus:bg-bg/60 focus:outline-none"
+            >
+              <div className="flex items-baseline justify-between gap-4">
+                <div className="flex min-w-0 items-baseline gap-2">
+                  <KindBadge kind={ev.kind} />
+                  <span className="truncate font-mono text-sm text-fg">{ev.noteName}</span>
+                </div>
+                <span className="shrink-0 text-xs text-fg-dim">{relativeTime(ev.at)}</span>
+              </div>
+              {ev.preview ? (
+                <p className="mt-1 truncate text-sm text-fg-muted">{ev.preview}</p>
+              ) : null}
+              {ev.tags && ev.tags.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {ev.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-md bg-border/40 px-1.5 py-0.5 text-xs text-fg-dim"
+                    >
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function KindBadge({ kind }: { kind: "created" | "updated" }) {
+  if (kind === "created") {
+    return (
+      <span className="shrink-0 rounded-md bg-accent/10 px-1.5 py-0.5 text-xs text-accent">
+        Created
+      </span>
+    );
+  }
+  return (
+    <span className="shrink-0 rounded-md bg-border/40 px-1.5 py-0.5 text-xs text-fg-muted">
+      Edited
+    </span>
+  );
+}
+
+function EmptyBlock() {
+  return (
+    <div className="rounded-md border border-border bg-card p-10 text-center">
+      <p className="mb-4 text-fg-muted">No activity in the last 30 days.</p>
+      <Link
+        to="/capture"
+        className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+      >
+        Open capture
+      </Link>
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div className="space-y-3" aria-busy="true">
+      {[0, 1, 2, 3, 4].map((i) => (
+        <div key={i} className="h-16 animate-pulse rounded-md bg-border/30" />
+      ))}
+    </div>
+  );
+}
+
+function ErrorBlock({ error }: { error: Error }) {
+  const isAuth = error instanceof VaultAuthError;
+  return (
+    <div className="rounded-md border border-red-500/30 bg-red-500/5 p-6">
+      <p className="mb-2 font-medium text-red-400">
+        {isAuth ? "Session expired" : "Could not load activity"}
+      </p>
+      <p className="mb-4 text-sm text-fg-muted">{error.message}</p>
+      {isAuth ? (
+        <Link
+          to="/add"
+          className="inline-block rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Reconnect vault
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -56,6 +56,9 @@ export function Header() {
               <Link to="/graph" className="text-sm text-fg-muted hover:text-accent">
                 Graph
               </Link>
+              <Link to="/activity" className="text-sm text-fg-muted hover:text-accent">
+                Activity
+              </Link>
               <Link to="/capture" className="text-sm text-fg-muted hover:text-accent">
                 + Capture
               </Link>
@@ -127,6 +130,9 @@ export function Header() {
               </Link>
               <Link to="/graph" className="py-1 text-sm text-fg hover:text-accent">
                 Graph
+              </Link>
+              <Link to="/activity" className="py-1 text-sm text-fg hover:text-accent">
+                Activity
               </Link>
               <Link to="/capture" className="py-1 text-sm text-fg hover:text-accent">
                 + Capture

--- a/src/lib/activity/events.test.ts
+++ b/src/lib/activity/events.test.ts
@@ -1,0 +1,139 @@
+import type { Note } from "@/lib/vault/types";
+import { describe, expect, it } from "vitest";
+import { bucketOf, buildActivityEvents, groupEventsByBucket } from "./events";
+
+// All ISO timestamps in this file are local-time built from `new Date(...)`
+// then `.toISOString()` so bucketing matches the test clock regardless of
+// the host timezone.
+function localIso(year: number, month: number, day: number, hour = 12): string {
+  return new Date(year, month - 1, day, hour).toISOString();
+}
+
+const NOW = new Date(2026, 3, 18, 12, 0, 0);
+
+describe("buildActivityEvents", () => {
+  it("returns an empty list for no notes", () => {
+    expect(buildActivityEvents([], 30, NOW)).toEqual([]);
+  });
+
+  it("emits a `created` event for a note inside the window", () => {
+    const notes: Note[] = [{ id: "n1", path: "Morning.md", createdAt: localIso(2026, 4, 18, 9) }];
+    const events = buildActivityEvents(notes, 30, NOW);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      id: "n1:created",
+      noteId: "n1",
+      noteName: "Morning.md",
+      kind: "created",
+    });
+  });
+
+  it("emits both `created` and `updated` when updated is later than created", () => {
+    const notes: Note[] = [
+      {
+        id: "n1",
+        path: "Edited.md",
+        createdAt: localIso(2026, 4, 15, 10),
+        updatedAt: localIso(2026, 4, 18, 14),
+      },
+    ];
+    const events = buildActivityEvents(notes, 30, NOW);
+    expect(events.map((e) => e.kind)).toEqual(["updated", "created"]);
+    expect(events[0]?.id).toBe("n1:updated");
+    expect(events[1]?.id).toBe("n1:created");
+  });
+
+  it("collapses near-simultaneous create+update into a single `created` event", () => {
+    // Vault PR 6 sets updated_at = created_at on insert; a follow-up edit
+    // within 5 seconds is treated as part of the same capture.
+    const created = localIso(2026, 4, 18, 9);
+    const updated = new Date(Date.parse(created) + 1_000).toISOString();
+    const notes: Note[] = [{ id: "n1", path: "Quick.md", createdAt: created, updatedAt: updated }];
+    const events = buildActivityEvents(notes, 30, NOW);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("created");
+  });
+
+  it("drops events outside the window", () => {
+    const notes: Note[] = [
+      { id: "old", path: "Old.md", createdAt: localIso(2026, 1, 1, 10) },
+      { id: "new", path: "New.md", createdAt: localIso(2026, 4, 17, 10) },
+    ];
+    const events = buildActivityEvents(notes, 30, NOW);
+    expect(events.map((e) => e.noteId)).toEqual(["new"]);
+  });
+
+  it("sorts events newest-first by timestamp", () => {
+    const notes: Note[] = [
+      { id: "a", path: "A.md", createdAt: localIso(2026, 4, 10, 10) },
+      { id: "b", path: "B.md", createdAt: localIso(2026, 4, 17, 10) },
+      { id: "c", path: "C.md", createdAt: localIso(2026, 4, 15, 10) },
+    ];
+    const events = buildActivityEvents(notes, 30, NOW);
+    expect(events.map((e) => e.noteId)).toEqual(["b", "c", "a"]);
+  });
+
+  it("falls back to id when path is missing", () => {
+    const notes: Note[] = [{ id: "n1", createdAt: localIso(2026, 4, 18, 9) }];
+    const events = buildActivityEvents(notes, 30, NOW);
+    expect(events[0]?.noteName).toBe("n1");
+  });
+
+  it("carries preview and tags onto each event", () => {
+    const notes: Note[] = [
+      {
+        id: "n1",
+        path: "Tagged.md",
+        createdAt: localIso(2026, 4, 18, 9),
+        preview: "first line",
+        tags: ["work", "urgent"],
+      },
+    ];
+    const events = buildActivityEvents(notes, 30, NOW);
+    expect(events[0]?.preview).toBe("first line");
+    expect(events[0]?.tags).toEqual(["work", "urgent"]);
+  });
+});
+
+describe("bucketOf", () => {
+  it("classifies same-day timestamps as today", () => {
+    expect(bucketOf(localIso(2026, 4, 18, 8), NOW)).toBe("today");
+    expect(bucketOf(localIso(2026, 4, 18, 23), NOW)).toBe("today");
+  });
+
+  it("classifies prior-day as yesterday", () => {
+    expect(bucketOf(localIso(2026, 4, 17, 9), NOW)).toBe("yesterday");
+  });
+
+  it("classifies days 2–6 ago as thisWeek", () => {
+    expect(bucketOf(localIso(2026, 4, 16, 9), NOW)).toBe("thisWeek");
+    expect(bucketOf(localIso(2026, 4, 12, 9), NOW)).toBe("thisWeek");
+  });
+
+  it("classifies anything 7+ days ago as older", () => {
+    expect(bucketOf(localIso(2026, 4, 11, 9), NOW)).toBe("older");
+    expect(bucketOf(localIso(2026, 1, 1, 9), NOW)).toBe("older");
+  });
+
+  it("returns null for unparseable timestamps", () => {
+    expect(bucketOf("not-a-date", NOW)).toBeNull();
+  });
+});
+
+describe("groupEventsByBucket", () => {
+  it("places events in the right bucket and preserves order within each", () => {
+    const notes: Note[] = [
+      { id: "today1", path: "T1.md", createdAt: localIso(2026, 4, 18, 11) },
+      { id: "today2", path: "T2.md", createdAt: localIso(2026, 4, 18, 8) },
+      { id: "yest", path: "Y.md", createdAt: localIso(2026, 4, 17, 10) },
+      { id: "wk", path: "W.md", createdAt: localIso(2026, 4, 14, 10) },
+      { id: "old", path: "O.md", createdAt: localIso(2026, 4, 1, 10) },
+    ];
+    const events = buildActivityEvents(notes, 30, NOW);
+    const groups = groupEventsByBucket(events, NOW);
+    expect(groups.today.map((e) => e.noteId)).toEqual(["today1", "today2"]);
+    expect(groups.yesterday.map((e) => e.noteId)).toEqual(["yest"]);
+    expect(groups.thisWeek.map((e) => e.noteId)).toEqual(["wk"]);
+    expect(groups.older.map((e) => e.noteId)).toEqual(["old"]);
+  });
+});

--- a/src/lib/activity/events.ts
+++ b/src/lib/activity/events.ts
@@ -1,0 +1,114 @@
+import type { Note } from "@/lib/vault/types";
+
+export type ActivityKind = "created" | "updated";
+
+export interface ActivityEvent {
+  id: string;
+  noteId: string;
+  noteName: string;
+  kind: ActivityKind;
+  at: string;
+  preview?: string;
+  tags?: string[];
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Vault PR 6 sets updated_at = created_at on insert, and a fast follow-up
+// edit usually lands within a second of the insert. Treat anything within
+// this gap as "same event" so a single capture doesn't show up as adjacent
+// Created/Edited rows.
+const UPDATE_THRESHOLD_MS = 5_000;
+
+export function buildActivityEvents(
+  notes: readonly Note[],
+  windowDays = 30,
+  now: Date = new Date(),
+): ActivityEvent[] {
+  const cutoff = now.getTime() - windowDays * DAY_MS;
+  const events: ActivityEvent[] = [];
+  for (const note of notes) {
+    const noteName = note.path ?? note.id;
+    const created = Date.parse(note.createdAt);
+    if (Number.isFinite(created) && created >= cutoff) {
+      events.push({
+        id: `${note.id}:created`,
+        noteId: note.id,
+        noteName,
+        kind: "created",
+        at: note.createdAt,
+        preview: note.preview,
+        tags: note.tags,
+      });
+    }
+    if (note.updatedAt) {
+      const updated = Date.parse(note.updatedAt);
+      if (
+        Number.isFinite(updated) &&
+        updated >= cutoff &&
+        Number.isFinite(created) &&
+        updated - created > UPDATE_THRESHOLD_MS
+      ) {
+        events.push({
+          id: `${note.id}:updated`,
+          noteId: note.id,
+          noteName,
+          kind: "updated",
+          at: note.updatedAt,
+          preview: note.preview,
+          tags: note.tags,
+        });
+      }
+    }
+  }
+  events.sort((a, b) => Date.parse(b.at) - Date.parse(a.at));
+  return events;
+}
+
+export type Bucket = "today" | "yesterday" | "thisWeek" | "older";
+
+export const BUCKET_ORDER: readonly Bucket[] = ["today", "yesterday", "thisWeek", "older"];
+
+export const BUCKET_LABELS: Record<Bucket, string> = {
+  today: "Today",
+  yesterday: "Yesterday",
+  thisWeek: "This week",
+  older: "Older",
+};
+
+// Local-time bucketing — same reasoning as src/lib/dates.ts. The "this week"
+// window is days 2–6 ago; today/yesterday are handled separately so the
+// labels never overlap.
+export function bucketOf(at: string, now: Date = new Date()): Bucket | null {
+  const t = Date.parse(at);
+  if (!Number.isFinite(t)) return null;
+  const today = startOfDay(now);
+  const eventDay = startOfDay(new Date(t));
+  const dayDelta = Math.round((today.getTime() - eventDay.getTime()) / DAY_MS);
+  if (dayDelta < 0) return "today";
+  if (dayDelta === 0) return "today";
+  if (dayDelta === 1) return "yesterday";
+  if (dayDelta < 7) return "thisWeek";
+  return "older";
+}
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+export function groupEventsByBucket(
+  events: readonly ActivityEvent[],
+  now: Date = new Date(),
+): Record<Bucket, ActivityEvent[]> {
+  const groups: Record<Bucket, ActivityEvent[]> = {
+    today: [],
+    yesterday: [],
+    thisWeek: [],
+    older: [],
+  };
+  for (const ev of events) {
+    const b = bucketOf(ev.at, now);
+    if (b) groups[b].push(ev);
+  }
+  return groups;
+}


### PR DESCRIPTION
## Summary

Last v0.3 surface — chronological feed of recent vault changes.

- **`/activity` route** with header, sectioned list, and a "Load more" pager (50 per page).
- **Two events per note** — each note can produce both a `Created` and an `Edited` row, sorted newest first across the whole 30-day window. Events within 5 seconds of each other collapse to a single `Created` entry so a fresh capture doesn't render as Created+Edited adjacent rows (vault PR 6 sets `updated_at = created_at` on insert).
- **Bucketing** — Today / Yesterday / This week (days 2–6) / Older (7+ days, within window). All local-time, same reasoning as `/today` and `/calendar`.
- **Each row** shows kind badge (Created / Edited), note path, relative timestamp, preview snippet, and tag pills. Click → `/notes/:id`.
- **Empty / loading / auth-error states** match the patterns in `/today`.
- **Nav** — added `Activity` link to desktop and mobile menus, between Graph and + Capture.

### Architecture

Pure helpers live in `src/lib/activity/events.ts` (`buildActivityEvents`, `bucketOf`, `groupEventsByBucket`) and are tested independently of React. The route component calls `useNotesForDateViews()` (already capped at 5000, sorted desc — same hook backing `/today` and `/calendar`) and runs the helpers in `useMemo`.

### Out of scope (per brief)

- **Deletion events** — vault doesn't track a deletion log today. Filed as a future vault enhancement; documented in the page subtitle ("Deletions aren't tracked yet").
- **Real diff summaries** ("added 2 tags", "+150 words") — would require vault-side history tracking. Skipped rather than fabricating from current state.
- **Real-time / websocket updates** — polling via React Query is fine.
- **Multi-vault activity** — scoped to active vault.

### Known limit

`useNotesForDateViews` hard-caps at 5000 most-recent notes (same trade as the calendar / graph). For vaults that exceed that within 30 days, the older end of the window will be empty. Pagination/sampling is a follow-up shared with the other date surfaces.

## Test plan

- [x] `bun x vitest run` — 526/526 (added 19: 14 helper unit, 5 route)
- [x] `bun x biome check src` — clean
- [x] `bun x tsc --noEmit` — clean
- [x] `bun run build` — clean
- [ ] Manual: `/activity` against an active vault — confirm grouping, pagination, click-through, kind badges, empty state, auth-error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)