### PR TITLE
Ship dist/ in npm tarball + prepublishOnly build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-notes.git"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -18,7 +23,8 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "typecheck": "tsc -b --noEmit"
+    "typecheck": "tsc -b --noEmit",
+    "prepublishOnly": "bun run build"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",


### PR DESCRIPTION
## Summary
- Add `"files": ["dist", "README.md", "LICENSE"]` so the built bundle actually ships.
- Add `"prepublishOnly": "bun run build"` so every publish carries fresh assets.

## Why
Without an explicit `files` array, npm falls back to `.gitignore` — which excludes `dist/` — so the bundle never made it into the tarball. `parachute start notes` (CLI PR 6, just merged) can't serve the app from a vanilla `npm install @openparachute/notes` until this lands.

## Verification
Ran `bun pm pack` before and after:

| | Before | After |
|---|---|---|
| Total files in tarball | 187 | 18 |
| `dist/` entries | 0 | 15 |
| Packed size | 204.74 KB | 530 KB |
| Unpacked size | 0.82 MB | 1.63 MB |

The file-count drop is the good kind: we stop shipping `src/`, `scripts/`, configs, tests, etc. The size jump is just the built bundle finally landing in the package.

Sample of tarball contents after the change:

```
package/package.json
package/LICENSE
package/README.md
package/dist/assets/index-Ia1TLYFf.js
package/dist/assets/react-force-graph-2d-DG6eyEaj.js
package/dist/assets/index-D9Ok_cRd.css
package/dist/sw.js
package/dist/workbox-d24cdb67.js
package/dist/index.html
package/dist/manifest.webmanifest
package/dist/icon.svg
package/dist/favicon.ico
package/dist/apple-touch-icon-180x180.png
package/dist/maskable-icon-512x512.png
package/dist/pwa-192x192.png
package/dist/pwa-512x512.png
package/dist/pwa-64x64.png
```

## Note on `"private": true`
Leaving it in place — flipping to publishable is a separate decision tied to first actual npm publish. This PR only ensures the tarball is shaped correctly once that decision is made.

## Test plan
- [x] `bun pm pack` before: 0 dist entries — confirms the gap
- [x] `bun pm pack` after: 15 dist entries — confirms the fix
- [x] `bun run build` still green (unchanged)
- [ ] Future: first actual `npm publish` will exercise `prepublishOnly` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)