### PR TITLE
Move Notes to /notes default base + /.parachute/info endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,7 @@
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-notes.git"
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/scripts/info-endpoint-plugin.test.ts
+++ b/scripts/info-endpoint-plugin.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { type ServiceInfo, buildServiceInfo, infoEndpointPlugin } from "./info-endpoint-plugin";
+
+const exampleInfo: ServiceInfo = {
+  name: "parachute-notes",
+  displayName: "Notes",
+  tagline: "Web client for your Parachute Vault",
+  version: "0.0.1",
+  iconUrl: "/notes/icon.svg",
+};
+
+describe("buildServiceInfo", () => {
+  it("threads basePath into iconUrl", () => {
+    const info = buildServiceInfo({
+      name: "parachute-notes",
+      displayName: "Notes",
+      tagline: "Web client for your Parachute Vault",
+      version: "0.0.1",
+      basePath: "/notes",
+      iconFile: "icon.svg",
+    });
+    expect(info.iconUrl).toBe("/notes/icon.svg");
+  });
+
+  it("normalizes a trailing slash and strips a leading icon slash", () => {
+    const info = buildServiceInfo({
+      name: "x",
+      displayName: "X",
+      tagline: "t",
+      version: "1",
+      basePath: "/notes/",
+      iconFile: "/icon.svg",
+    });
+    expect(info.iconUrl).toBe("/notes/icon.svg");
+  });
+});
+
+describe("infoEndpointPlugin", () => {
+  it("emits .parachute/info.json into the bundle on build", () => {
+    const plugin = infoEndpointPlugin({ basePath: "/notes", ...exampleInfo });
+    const emitted: Array<{ type: string; fileName?: string; source?: string | Uint8Array }> = [];
+    const ctx = {
+      emitFile(file: { type: string; fileName?: string; source?: string | Uint8Array }) {
+        emitted.push(file);
+      },
+    };
+    const handler = plugin.generateBundle;
+    if (typeof handler !== "function") throw new Error("generateBundle missing");
+    handler.call(
+      ctx as unknown as ThisParameterType<typeof handler>,
+      // biome-ignore lint/suspicious/noExplicitAny: rollup options object isn't worth typing for a smoke test
+      {} as any,
+      // biome-ignore lint/suspicious/noExplicitAny: same
+      {} as any,
+      true,
+    );
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]?.fileName).toBe(".parachute/info.json");
+    const parsed = JSON.parse(String(emitted[0]?.source));
+    expect(parsed).toEqual(exampleInfo);
+  });
+
+  it("serves the same JSON via dev server middleware at basePath/.parachute/info.json", () => {
+    const plugin = infoEndpointPlugin({ basePath: "/notes", ...exampleInfo });
+    const uses: Array<{ path: string; handler: (req: unknown, res: MockRes) => void }> = [];
+    const fakeServer = {
+      middlewares: {
+        use(path: string, handler: (req: unknown, res: MockRes) => void) {
+          uses.push({ path, handler });
+        },
+      },
+      httpServer: null,
+    };
+    const configure = plugin.configureServer;
+    if (typeof configure !== "function") throw new Error("configureServer missing");
+    // biome-ignore lint/suspicious/noExplicitAny: ViteDevServer surface isn't worth typing for a smoke test
+    configure.call(plugin as any, fakeServer as any);
+
+    expect(uses).toHaveLength(1);
+    expect(uses[0]?.path).toBe("/notes/.parachute/info.json");
+
+    const res = new MockRes();
+    uses[0]?.handler({}, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["Content-Type"]).toMatch(/application\/json/);
+    expect(JSON.parse(res.body)).toEqual(exampleInfo);
+  });
+});
+
+class MockRes {
+  statusCode = 0;
+  headers: Record<string, string> = {};
+  body = "";
+  setHeader(k: string, v: string) {
+    this.headers[k] = v;
+  }
+  end(chunk: string) {
+    this.body = chunk;
+  }
+}

--- a/scripts/info-endpoint-plugin.ts
+++ b/scripts/info-endpoint-plugin.ts
@@ -1,0 +1,67 @@
+import type { Plugin, PreviewServer, ViteDevServer } from "vite";
+
+export interface ServiceInfo {
+  name: string;
+  displayName: string;
+  tagline: string;
+  version: string;
+  iconUrl: string;
+}
+
+interface PluginOptions extends ServiceInfo {
+  basePath: string;
+}
+
+const ENDPOINT = ".parachute/info.json";
+
+// Synthesize the `/.parachute/info.json` endpoint that the hub page reads to
+// render service cards. We don't commit a placeholder file in `public/`
+// because `version` has to come from `package.json` at build time — keeping
+// it dynamic avoids drift between the package version and the served value.
+export function infoEndpointPlugin(options: PluginOptions): Plugin {
+  const { basePath, ...info } = options;
+  const body = `${JSON.stringify(info satisfies ServiceInfo, null, 2)}\n`;
+  const baseWithSlash = basePath.endsWith("/") ? basePath : `${basePath}/`;
+  const servePath = `${baseWithSlash}${ENDPOINT}`;
+
+  function attach(server: ViteDevServer | PreviewServer): void {
+    server.middlewares.use(servePath, (_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.setHeader("Cache-Control", "no-cache");
+      res.end(body);
+    });
+  }
+
+  return {
+    name: "parachute-notes-info-endpoint",
+    configureServer: attach,
+    configurePreviewServer: attach,
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: ENDPOINT,
+        source: body,
+      });
+    },
+  };
+}
+
+export function buildServiceInfo(args: {
+  name: string;
+  displayName: string;
+  tagline: string;
+  version: string;
+  basePath: string;
+  iconFile: string;
+}): ServiceInfo {
+  const baseWithSlash = args.basePath.endsWith("/") ? args.basePath : `${args.basePath}/`;
+  const icon = args.iconFile.startsWith("/") ? args.iconFile.slice(1) : args.iconFile;
+  return {
+    name: args.name,
+    displayName: args.displayName,
+    tagline: args.tagline,
+    version: args.version,
+    iconUrl: `${baseWithSlash}${icon}`,
+  };
+}

--- a/scripts/notes-service-plugin.ts
+++ b/scripts/notes-service-plugin.ts
@@ -11,6 +11,8 @@ interface PluginOptions {
   name: string;
   version: string;
   basePath: string;
+  displayName?: string;
+  tagline?: string;
 }
 
 // Notes is an SPA — no long-running Node entrypoint that would otherwise own
@@ -22,7 +24,7 @@ interface PluginOptions {
 // Best-effort: a manifest write failure (PARACHUTE_HOME unwritable, schema
 // drift, malformed pre-existing file) only logs a warning. Don't break dev.
 export function notesServicePlugin(options: PluginOptions): Plugin {
-  const { name, version, basePath } = options;
+  const { name, version, basePath, displayName, tagline } = options;
   const healthPath = basePath.endsWith("/") ? basePath : `${basePath}/`;
 
   function writeEntry(port: number): void {
@@ -32,6 +34,8 @@ export function notesServicePlugin(options: PluginOptions): Plugin {
       paths: [healthPath],
       health: healthPath,
       version,
+      ...(displayName ? { displayName } : {}),
+      ...(tagline ? { tagline } : {}),
     };
     try {
       upsertService(entry);

--- a/scripts/services-manifest.test.ts
+++ b/scripts/services-manifest.test.ts
@@ -19,9 +19,11 @@ function tempPath(): { path: string; cleanup: () => void } {
 const notes: ServiceEntry = {
   name: "parachute-notes",
   port: 5173,
-  paths: ["/"],
-  health: "/",
+  paths: ["/notes/"],
+  health: "/notes/",
   version: "0.0.1",
+  displayName: "Notes",
+  tagline: "Web client for your Parachute Vault",
 };
 
 const vault: ServiceEntry = {
@@ -109,6 +111,30 @@ describe("services-manifest", () => {
       const bad = { ...notes, port: -1 };
       expect(() => upsertService(bad as ServiceEntry, path)).toThrow(ServicesManifestError);
       expect(readManifest(path)).toEqual({ services: [vault] });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("accepts entries without optional displayName and tagline (vault-style)", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      const m = upsertService(vault, path);
+      expect(m.services[0]).toEqual(vault);
+      expect(m.services[0]?.displayName).toBeUndefined();
+      expect(m.services[0]?.tagline).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("rejects non-string displayName / tagline", () => {
+    const { path, cleanup } = tempPath();
+    try {
+      const badDisplay = { ...notes, displayName: 42 } as unknown as ServiceEntry;
+      expect(() => upsertService(badDisplay, path)).toThrow(/displayName/);
+      const badTagline = { ...notes, tagline: 42 } as unknown as ServiceEntry;
+      expect(() => upsertService(badTagline, path)).toThrow(/tagline/);
     } finally {
       cleanup();
     }

--- a/scripts/services-manifest.ts
+++ b/scripts/services-manifest.ts
@@ -22,6 +22,11 @@ export interface ServiceEntry {
   paths: string[];
   health: string;
   version: string;
+  // Optional display metadata consumed by the hub page and service cards.
+  // Kept optional so older writers (vault, scribe) don't break validation
+  // until they catch up.
+  displayName?: string;
+  tagline?: string;
 }
 
 export interface ServicesManifest {
@@ -37,7 +42,7 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
     throw new ServicesManifestError(`${where}: expected object, got ${typeof raw}`);
   }
   const e = raw as Record<string, unknown>;
-  const { name, port, paths, health, version } = e;
+  const { name, port, paths, health, version, displayName, tagline } = e;
   if (typeof name !== "string" || name.length === 0) {
     throw new ServicesManifestError(`${where}: "name" must be a non-empty string`);
   }
@@ -53,7 +58,16 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
   if (typeof version !== "string") {
     throw new ServicesManifestError(`${where}: "version" must be a string`);
   }
-  return { name, port, paths: paths as string[], health, version };
+  if (displayName !== undefined && typeof displayName !== "string") {
+    throw new ServicesManifestError(`${where}: "displayName" must be a string when present`);
+  }
+  if (tagline !== undefined && typeof tagline !== "string") {
+    throw new ServicesManifestError(`${where}: "tagline" must be a string when present`);
+  }
+  const out: ServiceEntry = { name, port, paths: paths as string[], health, version };
+  if (typeof displayName === "string") out.displayName = displayName;
+  if (typeof tagline === "string") out.tagline = tagline;
+  return out;
 }
 
 function validateManifest(raw: unknown, where: string): ServicesManifest {

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -6,6 +6,9 @@ describe("App", () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
+    // BrowserRouter is mounted with basename="/notes" (from BASE_URL).
+    // Navigate the test browser into that scope so routes resolve.
+    window.history.replaceState({}, "", "/notes/");
   });
 
   it("renders the Parachute Notes wordmark and the connect CTA when no vaults exist", () => {

--- a/src/base-url.test.ts
+++ b/src/base-url.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+// Guards the production default. If you change vite.config's `VITE_BASE_PATH`
+// default or vitest.config's `base`, this should fail until both move
+// together — the SPA's BrowserRouter basename, OAuth redirect URI, and PWA
+// manifest start_url all derive from import.meta.env.BASE_URL.
+describe("import.meta.env.BASE_URL", () => {
+  it("defaults to /notes/ — Notes is mounted under /notes by the hub", () => {
+    expect(import.meta.env.BASE_URL).toBe("/notes/");
+  });
+});

--- a/src/lib/vault/oauth.test.ts
+++ b/src/lib/vault/oauth.test.ts
@@ -53,7 +53,7 @@ describe("beginOAuth", () => {
     expect(url.searchParams.get("response_type")).toBe("code");
     expect(url.searchParams.get("client_id")).toBe("client-123");
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
-    expect(url.searchParams.get("redirect_uri")).toBe("http://localhost:3000/oauth/callback");
+    expect(url.searchParams.get("redirect_uri")).toBe("http://localhost:3000/notes/oauth/callback");
     expect(url.searchParams.get("scope")).toBe("full");
 
     const challenge = url.searchParams.get("code_challenge");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
+import { buildServiceInfo, infoEndpointPlugin } from "./scripts/info-endpoint-plugin";
 import { notesServicePlugin } from "./scripts/notes-service-plugin";
 import { buildPwaManifest } from "./src/pwa-manifest";
 
@@ -11,13 +12,27 @@ import { buildPwaManifest } from "./src/pwa-manifest";
 // Host header — useful when reaching the dev server over a tailnet. Off by default.
 const devExposure = process.env.VITE_EXPOSE === "true";
 
-// VITE_BASE_PATH lets the CLI's expose tooling serve Notes at a sub-path
-// (e.g. `/notes/`) without code changes. Defaults to `/` for stand-alone use.
-const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/");
+// Notes is one of N frontends mounted under a shared root: the CLI hub page
+// owns `/`, and each frontend lives under its own slug. Default to `/notes`
+// here so dev, build, and `parachute start notes` all agree.
+// Override with VITE_BASE_PATH=/ if you want the legacy stand-alone shape.
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/notes");
+
+const DISPLAY_NAME = "Notes";
+const TAGLINE = "Web client for your Parachute Vault";
 
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, "./package.json"), "utf8")) as {
   version: string;
 };
+
+const serviceInfo = buildServiceInfo({
+  name: "parachute-notes",
+  displayName: DISPLAY_NAME,
+  tagline: TAGLINE,
+  version: pkg.version,
+  basePath,
+  iconFile: "icon.svg",
+});
 
 function normalizeBase(input: string): string {
   let b = input.startsWith("/") ? input : `/${input}`;
@@ -30,7 +45,14 @@ export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
-    notesServicePlugin({ name: "parachute-notes", version: pkg.version, basePath }),
+    notesServicePlugin({
+      name: "parachute-notes",
+      version: pkg.version,
+      basePath,
+      displayName: DISPLAY_NAME,
+      tagline: TAGLINE,
+    }),
+    infoEndpointPlugin({ basePath, ...serviceInfo }),
     VitePWA({
       registerType: "prompt",
       includeAssets: ["icon.svg", "apple-touch-icon-180x180.png", "favicon.ico"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,9 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Mirror the production default so `import.meta.env.BASE_URL` in tests
+  // reflects what the SPA actually sees at runtime.
+  base: "/notes/",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Default Vite base path moves from `/` to `/notes` everywhere — `vite.config`, `vitest.config`, the React Router basename, the OAuth redirect URI, and the PWA manifest all derive from `import.meta.env.BASE_URL`.
- New `/.parachute/info.json` endpoint synthesized by a Vite plugin (`scripts/info-endpoint-plugin.ts`) — served via dev/preview middleware and emitted into the build output. Carries `name`, `displayName`, `tagline`, `version` (from `package.json` at build time), and `iconUrl`. No static placeholder file.
- `services.json` schema gains optional `displayName` + `tagline` so the hub page can render a card label and one-line pitch. Validation accepts older entries that omit them so vault/scribe keep working until they catch up.

## Why

Pairs with the CLI hub-page PR. The CLI now generates a landing page at `/` that reads `services.json` and per-service `/.parachute/info` to show a card grid. Each frontend mounts under its own sub-path so the root is reserved for the hub.

## Test plan

- [x] `bun x vitest run` — 538/538 passing (added 4 new tests in `info-endpoint-plugin.test.ts`, 2 new tests in `services-manifest.test.ts`, smoke test in `src/base-url.test.ts`)
- [x] `bun run build` — green; emits `dist/.parachute/info.json` with `/notes/icon.svg`; HTML asset paths use `/notes/` base
- [x] `bun x tsc --noEmit` — clean
- [x] `bun x biome check .` — clean
- [ ] Aaron tests the full chain locally (CLI hub + Notes under `/notes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)