### PR TITLE
Bump to 0.3.0 + flip private:false for launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.0.1",
-  "private": true,
+  "version": "0.3.0",
+  "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Ready for `bun publish`. Flips private:false since we're shipping to npm as @openparachute/notes.