### PR TITLE
Launch polish: deep-link shim, Home probe flash, static-route guard

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -1,5 +1,5 @@
 import { useVaultStore } from "@/lib/vault/store";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 
@@ -26,10 +26,15 @@ describe("App", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders the Parachute Notes wordmark and the connect CTA when no vaults exist", () => {
+  it("renders the Parachute Notes wordmark and the connect CTA when no vaults exist", async () => {
     render(<App />);
     expect(screen.getByRole("link", { name: /parachute notes/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /connect a vault/i })).toBeInTheDocument();
+    // Home holds back the CTA until the origin probe settles to avoid
+    // flashing "Connect a vault" before swapping to "Looks like there's a
+    // vault at …". Wait for the probe to resolve before asserting the CTA.
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /connect a vault/i })).toBeInTheDocument();
+    });
     expect(screen.getByText(/no vault connected/i)).toBeInTheDocument();
   });
 
@@ -61,5 +66,31 @@ describe("App", () => {
     // list). The bug Aaron hit (/notes/notes) would surface here if basename
     // and route paths disagreed.
     expect(window.location.pathname).toMatch(/^\/notes\/?$/);
+  });
+
+  it("static route /settings wins over the dynamic /:id deep-link shim", () => {
+    useVaultStore.setState({
+      vaults: {
+        v1: {
+          id: "v1",
+          url: "http://localhost:1940",
+          name: "default",
+          issuer: "http://localhost:1940",
+          clientId: "c",
+          scope: "full",
+          addedAt: "2026-04-20T00:00:00.000Z",
+          lastUsedAt: "2026-04-20T00:00:00.000Z",
+        },
+      },
+      activeVaultId: "v1",
+    });
+    window.history.replaceState({}, "", "/notes/settings");
+    render(<App />);
+    // Regression guard against future route-table accidents: RR7's ranked
+    // routing must hold `/settings` (and every other named static route)
+    // above the `/:id` pre-#49 bookmark shim. If this ever fails, the shim
+    // would start swallowing real internal pages.
+    expect(screen.getByRole("heading", { level: 1, name: /settings/i })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/notes/settings");
   });
 });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,7 +5,7 @@ import { UpdateBanner } from "@/components/UpdateBanner";
 import { useVaultStore } from "@/lib/vault";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { SyncProvider } from "@/providers/SyncProvider";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router";
+import { BrowserRouter, Navigate, Route, Routes, useParams } from "react-router";
 import { Activity } from "./routes/Activity";
 import { AddVault } from "./routes/AddVault";
 import { Calendar } from "./routes/Calendar";
@@ -29,6 +29,17 @@ import { Vaults } from "./routes/Vaults";
 function NotesIndex() {
   const activeVault = useVaultStore((s) => s.getActiveVault());
   return activeVault ? <Notes /> : <Home />;
+}
+
+// Shim for pre-#49 external bookmarks. When Notes lived at the origin root,
+// links were `/notes/<id>` and `/notes/<id>/edit`. After #49 moved Notes
+// under `/notes/`, Tailscale strips that prefix, leaving internal `/<id>`
+// and `/<id>/edit` — which the catch-all would otherwise bounce to `/`.
+// Redirect them to the canonical `/n/<id>` routes so old bookmarks survive.
+function NoteIdRedirect({ suffix = "" }: { suffix?: string }) {
+  const { id } = useParams<{ id: string }>();
+  if (!id) return <Navigate to="/" replace />;
+  return <Navigate to={`/n/${encodeURIComponent(id)}${suffix}`} replace />;
 }
 
 export function App() {
@@ -57,6 +68,8 @@ export function App() {
                 <Route path="/activity" element={<Activity />} />
                 <Route path="/n/:id" element={<NoteView />} />
                 <Route path="/n/:id/edit" element={<NoteEditor />} />
+                <Route path="/:id" element={<NoteIdRedirect />} />
+                <Route path="/:id/edit" element={<NoteIdRedirect suffix="/edit" />} />
                 <Route path="/add" element={<AddVault />} />
                 <Route path="/oauth/callback" element={<OAuthCallback />} />
                 <Route path="/vaults" element={<Vaults />} />

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -7,6 +7,7 @@ import { Link } from "react-router";
 export function Home() {
   const probe = useOriginVaultProbe();
   const foundOrigin = probe.status === "found" ? probe.origin : null;
+  const probing = probe.status === "probing";
 
   return (
     <div className="mx-auto max-w-2xl px-6 py-20 text-center">
@@ -15,7 +16,12 @@ export function Home() {
       </p>
       <h1 className="mb-4 font-serif text-5xl tracking-tight">Notes</h1>
 
-      {foundOrigin ? (
+      {/* Hold back the CTA while probing so we don't flash "Connect a vault"
+          and then swap it for "Looks like there's a vault at ..." once the
+          probe resolves. Reserve vertical space so the wordmark doesn't jump. */}
+      {probing ? (
+        <div className="h-28" aria-hidden="true" />
+      ) : foundOrigin ? (
         <>
           <p className="mb-8 text-fg tracking-wide">
             Looks like there's a vault at{" "}

--- a/src/pwa-manifest.ts
+++ b/src/pwa-manifest.ts
@@ -17,6 +17,10 @@ export function buildPwaManifest(base = "/"): Partial<ManifestOptions> {
     orientation: "any",
     start_url: normalized,
     scope: normalized,
+    // Icon `src` values are intentionally bare (no leading `/`). They resolve
+    // relative to the manifest URL, which itself sits under the deployed base
+    // path (e.g. `/notes/manifest.webmanifest`). That keeps the icons portable
+    // across mounts without rewriting each path — don't add a leading slash.
     icons: [
       { src: "pwa-64x64.png", sizes: "64x64", type: "image/png" },
       { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },


### PR DESCRIPTION
## Verification first

Team-lead asked me to verify which route shape actually shipped. I grepped main:

```
src/app/App.tsx:58:  <Route path=\"/n/:id\" element={<NoteView />} />
src/app/App.tsx:59:  <Route path=\"/n/:id/edit\" element={<NoteEditor />} />
```

**Shipped: `/n/:id` — not `/:id`.** PR #50's `headRefOid` was `36955d33` (the pre-revision commit), so my `/n/:id → /:id` sweep from task #91 never made it into the merge. My earlier report that the bare-`/:id` shape shipped was wrong; flagging openly.

Upshot: pre-#49 bookmarks of the form `https://<host>/notes/<id>` DO break today. Tailscale strips `/notes/` → internal `/<id>` → no static match → catch-all → redirect to `/`. Shim needed.

## Summary

- **Deep-link redirect shim**: add `<Route path=\"/:id\" element={<NoteIdRedirect />} />` and its `/:id/edit` sibling. Both navigate to the canonical `/n/<id>` routes. RR7 ranks all named static siblings (`/pinned`, `/archived`, `/settings`, `/tags`, `/add`, …) above `/:id`, so nothing real is shadowed — only bare single-segment IDs fall through.
- **Home probe flash**: hold back the CTA while `probe.status === \"probing\"`. Previously the page rendered \"Connect a vault\" then swapped to \"Looks like there's a vault at …\" once the probe resolved. Now the wordmark renders immediately with reserved vertical space; the CTA appears once probe settles. One-line skeleton — no refactor of probe logic.
- **Static-route specificity test**: explicit assertion in `App.test.tsx` that `/notes/settings` renders Settings (seeded with an active vault so the redirect doesn't fire). Guards against future route-table accidents that could invert the specificity and let the shim swallow real pages.
- **PWA manifest comment**: note the intentional relative-to-manifest icon path resolution in `pwa-manifest.ts:20-28` so a future editor doesn't prepend slashes.

## Migration note for existing users

No user-visible change: pre-#49 bookmarks now resolve through the shim instead of 404-bouncing to the home page. Post-#49 bookmarks (`/n/<id>`) were already correct and stay that way.

## Test plan
- [x] `bun run test` — 542/542 pass (added 1, no removals)
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)