### PR TITLE
OAuth hub discovery + services catalog + service kind

### DIFF
--- a/scripts/info-endpoint-plugin.test.ts
+++ b/scripts/info-endpoint-plugin.test.ts
@@ -7,10 +7,11 @@ const exampleInfo: ServiceInfo = {
   tagline: "Web client for your Parachute Vault",
   version: "0.0.1",
   iconUrl: "/notes/icon.svg",
+  kind: "frontend",
 };
 
 describe("buildServiceInfo", () => {
-  it("threads basePath into iconUrl", () => {
+  it("threads basePath into iconUrl and carries kind through", () => {
     const info = buildServiceInfo({
       name: "parachute-notes",
       displayName: "Notes",
@@ -18,8 +19,10 @@ describe("buildServiceInfo", () => {
       version: "0.0.1",
       basePath: "/notes",
       iconFile: "icon.svg",
+      kind: "frontend",
     });
     expect(info.iconUrl).toBe("/notes/icon.svg");
+    expect(info.kind).toBe("frontend");
   });
 
   it("normalizes a trailing slash and strips a leading icon slash", () => {
@@ -30,8 +33,22 @@ describe("buildServiceInfo", () => {
       version: "1",
       basePath: "/notes/",
       iconFile: "/icon.svg",
+      kind: "frontend",
     });
     expect(info.iconUrl).toBe("/notes/icon.svg");
+  });
+
+  it("accepts alternate kinds for non-frontend services", () => {
+    const api = buildServiceInfo({
+      name: "parachute-vault",
+      displayName: "Vault",
+      tagline: "Memory",
+      version: "1",
+      basePath: "/vault/default",
+      iconFile: "icon.svg",
+      kind: "api",
+    });
+    expect(api.kind).toBe("api");
   });
 });
 

--- a/scripts/info-endpoint-plugin.ts
+++ b/scripts/info-endpoint-plugin.ts
@@ -1,11 +1,18 @@
 import type { Plugin, PreviewServer, ViteDevServer } from "vite";
 
+// `kind` tells the hub how to present the card: `frontend` is clickable
+// (opens the UI), `api` shows an inline detail panel (click-through is a raw
+// JSON response, not useful for humans), `tool` is a CLI-only or headless
+// service. See DESIGN-2026-04-20-hub-as-portal-oauth-and-service-catalog.md.
+export type ServiceKind = "frontend" | "api" | "tool";
+
 export interface ServiceInfo {
   name: string;
   displayName: string;
   tagline: string;
   version: string;
   iconUrl: string;
+  kind: ServiceKind;
 }
 
 interface PluginOptions extends ServiceInfo {
@@ -54,6 +61,7 @@ export function buildServiceInfo(args: {
   version: string;
   basePath: string;
   iconFile: string;
+  kind: ServiceKind;
 }): ServiceInfo {
   const baseWithSlash = args.basePath.endsWith("/") ? args.basePath : `${args.basePath}/`;
   const icon = args.iconFile.startsWith("/") ? args.iconFile.slice(1) : args.iconFile;
@@ -63,5 +71,6 @@ export function buildServiceInfo(args: {
     tagline: args.tagline,
     version: args.version,
     iconUrl: `${baseWithSlash}${icon}`,
+    kind: args.kind,
   };
 }

--- a/src/app/routes/AddVault.tsx
+++ b/src/app/routes/AddVault.tsx
@@ -75,8 +75,9 @@ export function AddVault() {
             className="w-full rounded-md border border-border bg-card px-3 py-2 font-mono text-sm text-fg focus:border-accent focus:outline-none"
           />
           <p className="mt-1.5 text-xs text-fg-dim">
-            Include the vault path (e.g. <code>/vault/default</code>). If the host serves a{" "}
-            <code>parachute.json</code> registry, just paste the origin and we'll discover it.
+            The Parachute hub URL works too — we'll read the vault URL from the token response.
+            Otherwise paste a vault directly (e.g. <code>https://host/vault/default</code>) or a
+            host that serves a <code>parachute.json</code> registry.
           </p>
         </div>
 

--- a/src/app/routes/OAuthCallback.tsx
+++ b/src/app/routes/OAuthCallback.tsx
@@ -1,4 +1,4 @@
-import { completeOAuth, useVaultStore, vaultIdFromUrl } from "@/lib/vault";
+import { completeOAuth, saveServicesCatalog, useVaultStore, vaultIdFromUrl } from "@/lib/vault";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
@@ -31,9 +31,14 @@ export function OAuthCallback() {
     (async () => {
       try {
         const { pending, token } = await completeOAuth(code, state);
-        addVault(
+        // Hub-issued tokens carry a `services` catalog (Phase 1): trust the
+        // hub's vault URL over whatever the user pasted, so a hub login works
+        // even if the user typed the hub origin. Vault-issued tokens (no
+        // catalog) keep the pre-hub behavior of using the pending vault URL.
+        const vaultUrl = token.services?.vault?.url ?? pending.vaultUrl;
+        const id = addVault(
           {
-            url: pending.vaultUrl,
+            url: vaultUrl,
             name: token.vault,
             issuer: pending.issuer,
             clientId: pending.clientId,
@@ -41,6 +46,7 @@ export function OAuthCallback() {
           },
           { accessToken: token.access_token, scope: token.scope, vault: token.vault },
         );
+        if (token.services) saveServicesCatalog(id, token.services);
         navigate("/", { replace: true });
       } catch (err) {
         setStatus({ kind: "error", message: (err as Error).message });

--- a/src/lib/vault/oauth.test.ts
+++ b/src/lib/vault/oauth.test.ts
@@ -168,4 +168,28 @@ describe("completeOAuth", () => {
     );
     expect(loadPendingOAuth()).toBeNull();
   });
+
+  it("returns the non-standard services catalog when the hub embeds it (Phase 1)", async () => {
+    // Hub-issued token responses carry a `services` object so clients can
+    // skip asking for the vault URL. Vault-issued tokens omit it — that
+    // back-compat is exercised by the "exchanges the code…" test above.
+    savePendingOAuth(pending);
+    const fetchImpl = mockFetch([
+      {
+        json: {
+          access_token: "pvt_abc",
+          token_type: "bearer",
+          scope: "full",
+          vault: "default",
+          services: {
+            vault: { url: "https://parachute.x.ts.net/vault/default", version: "0.3.0" },
+            scribe: { url: "https://parachute.x.ts.net/scribe", version: "0.2.0" },
+          },
+        },
+      },
+    ]);
+    const { token } = await completeOAuth("auth-code", "state-xyz", fetchImpl);
+    expect(token.services?.vault?.url).toBe("https://parachute.x.ts.net/vault/default");
+    expect(token.services?.scribe?.url).toBe("https://parachute.x.ts.net/scribe");
+  });
 });

--- a/src/lib/vault/probe.test.ts
+++ b/src/lib/vault/probe.test.ts
@@ -42,8 +42,34 @@ function routedFetch(routes: Record<string, MockResponse | "network-error">) {
 }
 
 describe("probeVaultAtOrigin", () => {
-  it("discovers via parachute.json and returns the chosen vault URL", async () => {
+  it("resolves at the hub origin directly via OAuth metadata (Phase 0)", async () => {
+    // Hub origin advertises itself as issuer; the parachute.json registry
+    // isn't needed at all. Direct OAuth discovery wins without any registry
+    // fetch being required.
+    const hubMetadata = { ...validMetadata, issuer: "https://hub.example" };
     const fetchImpl = routedFetch({
+      "/.well-known/oauth-authorization-server": { json: hubMetadata },
+    });
+    const result = await probeVaultAtOrigin("https://hub.example", 500, fetchImpl);
+    expect(result).toBe("https://hub.example");
+  });
+
+  it("resolves a directly-pasted vault URL via OAuth metadata", async () => {
+    // Standalone vault case: user pastes the full vault URL. Direct probe
+    // (first) succeeds; no registry consulted.
+    const fetchImpl = routedFetch({
+      "/vault/default/.well-known/oauth-authorization-server": { json: validMetadata },
+    });
+    const result = await probeVaultAtOrigin("https://h.example/vault/default", 500, fetchImpl);
+    expect(result).toBe("https://h.example/vault/default");
+  });
+
+  it("falls back to parachute.json when direct OAuth discovery fails", async () => {
+    // User pasted a bare origin that doesn't serve OAuth metadata itself but
+    // does publish a registry pointing at a real vault URL.
+    const fetchImpl = routedFetch({
+      // Direct probe on the origin fails.
+      "https://h.example/.well-known/oauth-authorization-server": { ok: false, status: 404 },
       "/.well-known/parachute.json": {
         json: { vault: { url: "https://h.example/vault/default" } },
       },
@@ -53,8 +79,9 @@ describe("probeVaultAtOrigin", () => {
     expect(result).toBe("https://h.example/vault/default");
   });
 
-  it("prefers the entry named `default` from a multi-vault parachute.json", async () => {
+  it("prefers the entry named `default` from a multi-vault parachute.json fallback", async () => {
     const fetchImpl = routedFetch({
+      "https://h.example/.well-known/oauth-authorization-server": { ok: false, status: 404 },
       "/.well-known/parachute.json": {
         json: {
           vaults: [
@@ -69,40 +96,31 @@ describe("probeVaultAtOrigin", () => {
     expect(result).toBe("https://h.example/vault/default");
   });
 
-  it("falls back to direct OAuth metadata probing when parachute.json is missing", async () => {
-    // User pasted a full vault URL directly; no parachute.json on origin.
+  it("returns null when neither direct OAuth nor parachute.json resolve", async () => {
     const fetchImpl = routedFetch({
-      "/.well-known/parachute.json": { ok: false, status: 404 },
-      "/vault/default/.well-known/oauth-authorization-server": { json: validMetadata },
-    });
-    const result = await probeVaultAtOrigin("https://h.example/vault/default", 500, fetchImpl);
-    expect(result).toBe("https://h.example/vault/default");
-  });
-
-  it("returns null when neither parachute.json nor direct OAuth metadata resolve", async () => {
-    const fetchImpl = routedFetch({
-      "/.well-known/parachute.json": { ok: false, status: 404 },
       "/.well-known/oauth-authorization-server": { ok: false, status: 404 },
+      "/.well-known/parachute.json": { ok: false, status: 404 },
     });
     expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
   });
 
-  it("returns null on network error during direct probe", async () => {
+  it("returns null on network error during direct probe with no registry", async () => {
     const fetchImpl = routedFetch({
-      "/.well-known/parachute.json": { ok: false, status: 404 },
       "/.well-known/oauth-authorization-server": "network-error",
+      "/.well-known/parachute.json": { ok: false, status: 404 },
     });
     expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
   });
 
   it("returns null when parachute.json is found but its vault fails OAuth metadata", async () => {
     const fetchImpl = routedFetch({
+      // Direct probe on the origin fails, and the registry-pointed vault
+      // also fails OAuth metadata.
+      "https://h.example/.well-known/oauth-authorization-server": { ok: false, status: 404 },
       "/.well-known/parachute.json": {
         json: { vault: { url: "https://h.example/vault/broken" } },
       },
-      // Both the parachute.json-pointed and direct probes fail.
       "/vault/broken/.well-known/oauth-authorization-server": { ok: false, status: 500 },
-      "/.well-known/oauth-authorization-server": { ok: false, status: 404 },
     });
     expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
   });

--- a/src/lib/vault/probe.ts
+++ b/src/lib/vault/probe.ts
@@ -14,22 +14,28 @@ export interface ProbeResult {
 
 const DEFAULT_TIMEOUT_MS = 2500;
 
-// Probe an origin for a Parachute Vault. Two paths:
+// Probe an input URL for a Parachute OAuth issuer. Two paths, in this order:
 //
-//   1. Ecosystem discovery: fetch `${origin}/.well-known/parachute.json` and
-//      pick a vault entry (name=default, else first). Validate by hitting its
-//      OAuth metadata.
-//   2. Direct: probe `${input}/.well-known/oauth-authorization-server` — for
-//      when the user pasted a vault URL directly (e.g. `https://h/vault/work`)
-//      without a parachute.json registry on the origin.
+//   1. Direct OAuth discovery: `${input}/.well-known/oauth-authorization-server`.
+//      Matches the hub-as-portal Phase 0 seam (hub advertises its own origin
+//      as issuer; vault's OAuth is proxied behind it) *and* the standalone
+//      vault case where the user pastes a full vault URL. We try this first
+//      because the hub origin usually doesn't serve a parachute.json.
+//   2. Ecosystem registry fallback: `${origin}/.well-known/parachute.json` →
+//      pick a vault entry (name=default, else first) → validate by hitting
+//      its OAuth metadata. Useful when the user pastes a bare host that only
+//      publishes the registry.
 //
-// Returns the discovered vault URL (full path including `/vault/<name>`) or
-// null if neither path resolves.
+// Returns the URL that successfully resolves OAuth metadata (either the input
+// itself or the registry-pointed vault URL), or null if neither path resolves.
 export async function probeVaultAtOrigin(
   origin: string,
   timeoutMs: number = DEFAULT_TIMEOUT_MS,
   fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<string | null> {
+  const direct = await tryDiscoverAuthServer(origin, timeoutMs, fetchImpl);
+  if (direct) return direct;
+
   const manifest = await fetchParachuteJson(origin, timeoutMs, fetchImpl);
   if (manifest) {
     const chosen = pickVault(manifest);
@@ -39,7 +45,7 @@ export async function probeVaultAtOrigin(
     }
   }
 
-  return tryDiscoverAuthServer(origin, timeoutMs, fetchImpl);
+  return null;
 }
 
 async function tryDiscoverAuthServer(

--- a/src/lib/vault/storage.ts
+++ b/src/lib/vault/storage.ts
@@ -1,8 +1,9 @@
-import type { PendingOAuthState, StoredToken, VaultRecord } from "./types";
+import type { PendingOAuthState, ServicesCatalog, StoredToken, VaultRecord } from "./types";
 
 const VAULTS_KEY = "lens:vaults";
 const ACTIVE_KEY = "lens:active_vault";
 const TOKEN_PREFIX = "lens:token:";
+const SERVICES_PREFIX = "lens:services:";
 const PENDING_OAUTH_KEY = "lens:oauth:pending";
 
 function read<T>(storage: Storage, key: string): T | null {
@@ -59,6 +60,22 @@ export function saveToken(vaultId: string, token: StoredToken): void {
 export function deleteToken(vaultId: string): void {
   try {
     localStorage.removeItem(TOKEN_PREFIX + vaultId);
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+export function loadServicesCatalog(vaultId: string): ServicesCatalog | null {
+  return read<ServicesCatalog>(localStorage, SERVICES_PREFIX + vaultId);
+}
+
+export function saveServicesCatalog(vaultId: string, catalog: ServicesCatalog): void {
+  write(localStorage, SERVICES_PREFIX + vaultId, catalog);
+}
+
+export function deleteServicesCatalog(vaultId: string): void {
+  try {
+    localStorage.removeItem(SERVICES_PREFIX + vaultId);
   } catch {
     // storage unavailable — best-effort only
   }

--- a/src/lib/vault/store.ts
+++ b/src/lib/vault/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import {
+  deleteServicesCatalog,
   deleteToken,
   loadActiveVaultId,
   loadToken,
@@ -47,6 +48,7 @@ export const useVaultStore = create<VaultStoreState>((set, get) => ({
     const { [id]: _removed, ...rest } = get().vaults;
     saveVaults(rest);
     deleteToken(id);
+    deleteServicesCatalog(id);
     const nextActive =
       get().activeVaultId === id ? (Object.keys(rest)[0] ?? null) : get().activeVaultId;
     saveActiveVaultId(nextActive);

--- a/src/lib/vault/types.ts
+++ b/src/lib/vault/types.ts
@@ -35,11 +35,27 @@ export interface ClientRegistration {
   redirect_uris: string[];
 }
 
+// Non-standard `services` extension per hub-as-portal Phase 1: the hub, when
+// it issues a token, tells the client where every ecosystem service lives so
+// the client never has to ask the user for URLs. Vault-issued tokens omit it
+// (standalone deployments); clients must tolerate its absence.
+export interface ServiceCatalogEntry {
+  url: string;
+  version?: string;
+}
+
+export interface ServicesCatalog {
+  vault?: ServiceCatalogEntry;
+  scribe?: ServiceCatalogEntry;
+  [key: string]: ServiceCatalogEntry | undefined;
+}
+
 export interface TokenResponse {
   access_token: string;
   token_type: "bearer";
   scope: TokenScope;
   vault: string;
+  services?: ServicesCatalog;
 }
 
 export interface VaultInfo {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,9 @@ const serviceInfo = buildServiceInfo({
   version: pkg.version,
   basePath,
   iconFile: "icon.svg",
+  // Notes has a real UI — the hub should render it as a clickable card that
+  // navigates into `/notes/`, not a detail panel.
+  kind: "frontend",
 });
 
 function normalizeBase(input: string): string {


### PR DESCRIPTION
## Summary

Three composable seams for the hub-as-portal architecture
([design note](../DESIGN-2026-04-20-hub-as-portal-oauth-and-service-catalog.md))
that land Notes' public contract before launch, while keeping vault's
current OAuth as the implementation underneath.

- **Phase 0 — hub-origin OAuth discovery.** `probeVaultAtOrigin` now
  tries direct `/.well-known/oauth-authorization-server` on the input URL
  first, and only falls back to `parachute.json` registry discovery if
  that fails. When the hub is live it serves OAuth metadata at its own
  origin (proxying vault underneath); standalone-vault URLs keep working
  via the same path.
- **Phase 1 — services catalog in the token response.** `TokenResponse`
  gains an optional `services` object. If present, `OAuthCallback`
  prefers `services.vault.url` as the vault URL (so a hub login works
  even if the user pastes the hub origin) and persists the catalog
  under `lens:services:<vaultId>` for future features (scribe, etc.).
  Vault-issued tokens omit the catalog → back-compat.
- **Service kind on `/.parachute/info.json`.** `kind: "frontend" | "api"
  | "tool"`. Notes declares `frontend`; the hub can use it to choose
  click-through UX (navigate for frontends, detail panel for APIs).

Out of scope: scope UI, step-up consent (Phase 2), OAuth flow changes
beyond discovery ordering, and anything PWA/sync/memo-related.

## Changes

- `src/lib/vault/types.ts` — `ServicesCatalog`/`ServiceCatalogEntry`
  types; `TokenResponse.services?`.
- `src/lib/vault/storage.ts` — `loadServicesCatalog` /
  `saveServicesCatalog` / `deleteServicesCatalog` keyed
  `lens:services:<vaultId>`.
- `src/lib/vault/store.ts` — `removeVault` also cleans services.
- `src/lib/vault/probe.ts` — reorder: direct OAuth first,
  `parachute.json` fallback second.
- `src/app/routes/OAuthCallback.tsx` — consume `token.services.vault.url`
  when present; persist full catalog.
- `scripts/info-endpoint-plugin.ts` + `vite.config.ts` — `ServiceKind`
  type, `kind` field in `ServiceInfo`; Notes emits `kind: "frontend"`.
- `src/app/routes/AddVault.tsx` — help text mentions hub URL works.

## Tests

- `src/lib/vault/probe.test.ts` — replaced fixtures with the new
  ordering; new hub-origin test (direct OAuth with no registry wins),
  explicit registry-fallback test, explicit standalone-vault test.
- `src/lib/vault/oauth.test.ts` — new case asserting `completeOAuth`
  surfaces `token.services` when the token response carries it
  (existing test covers the no-catalog back-compat path).
- `scripts/info-endpoint-plugin.test.ts` — fixtures carry `kind`;
  explicit case for non-frontend kinds (`api`).

## Coordination

Parallel-safe with the vault/cli/scribe PRs enumerated in the design
note. All four compose when merged and \`PARACHUTE_HUB_ORIGIN\` is set:
vault emits `services` in token responses, cli adds tailnet rules for
hub-origin OAuth URLs, scribe declares `kind: "api"`.

## Test plan

- [ ] \`bun run test\` — 544/544 passing locally.
- [ ] \`bun run typecheck\` — clean.
- [ ] \`bun run lint\` — clean.
- [ ] \`bun run build\` — emits \`dist/.parachute/info.json\` with
      \`"kind": "frontend"\`.
- [ ] Manual: pasting the hub origin (once vault PR is merged + env set)
      resolves OAuth discovery without a \`parachute.json\` on the hub.
- [ ] Manual: pasting a standalone vault URL still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)