### PR TITLE
Bump to 0.3.0-rc.1 for pre-launch RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.0",
+  "version": "0.3.0-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",


### PR DESCRIPTION
Publish with `bun publish --tag rc`. First-time publish.