### PR TITLE
Rename product: Notes → Lens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,14 @@
-# parachute-notes (repo dir still named `parachute-lens`)
+# parachute-lens
 
-A browser-based companion for any Parachute Vault. Vite + React + TypeScript, installable PWA, served at `/notes/` under the ecosystem origin. OAuth 2.1 + PKCE + RFC 7591 DCR against the vault (discovery now probes hub-origin per PR #55).
+A browser-based companion for any Parachute Vault. Vite + React + TypeScript, installable PWA, served at `/lens/` under the ecosystem origin. OAuth 2.1 + PKCE + RFC 7591 DCR against the vault (discovery now probes hub-origin per PR #55).
 
 ## Mount-path architecture
 
-Notes lives at `/notes/` externally and uses mount-relative internal routes.
+Lens lives at `/lens/` externally and uses mount-relative internal routes.
 
-- **Vite `base`** = `/notes/` — asset URLs, PWA manifest scope, service worker
-- **BrowserRouter `basename`** = `/notes` (from `import.meta.env.BASE_URL`)
-- **Internal routes** — `/`, `/:id`, `/:id/edit`, `/pinned`, `/tags`, `/new`, `/add` — no `/notes/` prefix. React Router v7 ranked routing picks static routes over `/:id` correctly.
+- **Vite `base`** = `/lens/` — asset URLs, PWA manifest scope, service worker
+- **BrowserRouter `basename`** = `/lens` (from `import.meta.env.BASE_URL`)
+- **Internal routes** — `/`, `/:id`, `/:id/edit`, `/pinned`, `/tags`, `/new`, `/add` — no `/lens/` prefix. React Router v7 ranked routing picks static routes over `/:id` correctly.
 - **OAuth redirect URI** — `BASE_URL + "oauth/callback"` via `basePathPrefix()` in `src/lib/vault/oauth.ts`
 - **Deep-link shim** — `/:id` + `/:id/edit` redirect to the right internal routes (PR #54) for pre-refactor bookmarks
 
@@ -78,4 +78,4 @@ When a PR is merged, locally:
 git checkout main && git pull
 ```
 
-Aaron runs notes via `bun link` + `parachute start notes` in development — the linked install follows whatever branch is checked out. Leaving the repo on a feature branch after merge means Aaron's running stale feature-branch code, not the merged main. Caught 2026-04-21.
+Aaron runs lens via `bun link` + `parachute start lens` in development — the linked install follows whatever branch is checked out. Leaving the repo on a feature branch after merge means Aaron's running stale feature-branch code, not the merged main. Caught 2026-04-21.

--- a/MOBILE_SMOKE.md
+++ b/MOBILE_SMOKE.md
@@ -1,18 +1,18 @@
 # Mobile smoke — PWA install + voice memo + offline
 
-Test Notes as a PWA on a real phone. Android first (you have one), iPhone handed off to Jon.
+Test Lens as a PWA on a real phone. Android first (you have one), iPhone handed off to Jon.
 
-Prereq: tailnet chain is up (`parachute expose tailnet` on your Mac, hub + notes + vault + scribe all running), phone is on your tailnet.
+Prereq: tailnet chain is up (`parachute expose tailnet` on your Mac, hub + lens + vault + scribe all running), phone is on your tailnet.
 
 ## Android (Chrome)
 
 ### 1. Load + install
 
-- [ ] Open Chrome, go to `https://parachute.<tailnet>.ts.net/notes/`
+- [ ] Open Chrome, go to `https://parachute.<tailnet>.ts.net/lens/`
 - [ ] Page loads, renders notes UI (header, sidebar, list)
-- [ ] Chrome's "Install Parachute Notes" prompt appears in the address bar or menu
+- [ ] Chrome's "Install Parachute Lens" prompt appears in the address bar or menu
 - [ ] Tap "Install", confirm
-- [ ] Home-screen icon appears, labeled "Parachute Notes"
+- [ ] Home-screen icon appears, labeled "Parachute Lens"
 - [ ] Tap the home-screen icon → app opens fullscreen (no browser chrome)
 
 ### 2. OAuth (if not already connected)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Parachute Notes
+# Parachute Lens
 
 The default frontend for [Parachute](https://parachute.computer). Browse, edit, and capture in any [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault), from any device.
 
-Parachute Notes is a static single-page app that speaks directly to your vault over its HTTP API. Point it at any vault URL, do OAuth, and browse, edit, create, and visualize your notes. No opinion about how you organize your vault — just a good lens onto what's there.
+Parachute Lens is a static single-page app that speaks directly to your vault over its HTTP API. Point it at any vault URL, do OAuth, and browse, edit, create, and visualize your notes. No opinion about how you organize your vault — just a good lens onto what's there.
 
 ## Status
 
 v1 shipped; v0.2 in progress — offline-capable PWA.
 
-## Install Parachute Notes
+## Install Parachute Lens
 
-Parachute Notes is installable as a Progressive Web App. Once installed, it runs in its own window, launches from your home screen or dock, and (from v0.2 onward) keeps working when you're offline.
+Parachute Lens is installable as a Progressive Web App. Once installed, it runs in its own window, launches from your home screen or dock, and (from v0.2 onward) keeps working when you're offline.
 
-- **Desktop Chrome / Edge** — visit your hosted Parachute Notes, click **Install app** in the header, or use the browser's install icon in the address bar.
+- **Desktop Chrome / Edge** — visit your hosted Parachute Lens, click **Install app** in the header, or use the browser's install icon in the address bar.
 - **Android Chrome** — tap **Install app**, or use the browser menu → **Install app**.
-- **iOS Safari** — tap the Share icon, then **Add to Home Screen**. (Safari doesn't expose a JS install prompt, so Parachute Notes shows a hint with the steps.)
+- **iOS Safari** — tap the Share icon, then **Add to Home Screen**. (Safari doesn't expose a JS install prompt, so Parachute Lens shows a hint with the steps.)
 
 A few iOS quirks worth knowing:
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@openparachute/notes",
+      "name": "@openparachute/lens",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",
@@ -476,39 +476,39 @@
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.2.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.2" } }, "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA=="],
+    "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
 
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.2", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.2", "@tailwindcss/oxide-darwin-arm64": "4.2.2", "@tailwindcss/oxide-darwin-x64": "4.2.2", "@tailwindcss/oxide-freebsd-x64": "4.2.2", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2", "@tailwindcss/oxide-linux-arm64-musl": "4.2.2", "@tailwindcss/oxide-linux-x64-gnu": "4.2.2", "@tailwindcss/oxide-linux-x64-musl": "4.2.2", "@tailwindcss/oxide-wasm32-wasi": "4.2.2", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2", "@tailwindcss/oxide-win32-x64-msvc": "4.2.2" } }, "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg=="],
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.4", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.4", "@tailwindcss/oxide-darwin-arm64": "4.2.4", "@tailwindcss/oxide-darwin-x64": "4.2.4", "@tailwindcss/oxide-freebsd-x64": "4.2.4", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4", "@tailwindcss/oxide-linux-arm64-musl": "4.2.4", "@tailwindcss/oxide-linux-x64-gnu": "4.2.4", "@tailwindcss/oxide-linux-x64-musl": "4.2.4", "@tailwindcss/oxide-wasm32-wasi": "4.2.4", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4", "@tailwindcss/oxide-win32-x64-msvc": "4.2.4" } }, "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q=="],
 
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.2", "", { "os": "android", "cpu": "arm64" }, "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg=="],
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.4", "", { "os": "android", "cpu": "arm64" }, "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g=="],
 
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg=="],
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg=="],
 
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw=="],
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg=="],
 
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ=="],
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw=="],
 
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2", "", { "os": "linux", "cpu": "arm" }, "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ=="],
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA=="],
 
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw=="],
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw=="],
 
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag=="],
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g=="],
 
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg=="],
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA=="],
 
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ=="],
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA=="],
 
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.2", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q=="],
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.4", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw=="],
 
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ=="],
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ=="],
 
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA=="],
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw=="],
 
-    "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.99.1", "", {}, "sha512-5E8xwxyWvr22yt7zvzP3KOZ5TUElOdVA45NP3/Ao1m9mvc9i18NLTDe9m3M00BH2DR5J20cv7xckMPlhKNs+vQ=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.99.2", "", {}, "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.99.1", "", { "dependencies": { "@tanstack/query-core": "5.99.1" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-akg5GdwW70lvJvCqVHZ7tizGyc+TATjUzKX9RuF1xknhEe/1leofXk7YLYbrbRsuhNbHJBAayaQUMvvOFZ5L5g=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.99.2", "", { "dependencies": { "@tanstack/query-core": "5.99.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -770,7 +770,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.340", "", {}, "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.341", "", {}, "sha512-1sZTssferjgDgaqRTc0ieP+ozzpOy7LQTPTtEW3yQFn4+ORdIAZWV5BthXPyHF7YqLvFJCUPhNhdAJQYlYUgiw=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
@@ -992,7 +992,7 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
@@ -1218,7 +1218,7 @@
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
-    "react-router": ["react-router@7.14.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg=="],
+    "react-router": ["react-router@7.14.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
@@ -1254,7 +1254,7 @@
 
     "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
 
-    "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
+    "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -1348,9 +1348,9 @@
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
-    "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
+    "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
-    "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "temp-dir": ["temp-dir@2.0.0", "", {}, "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="],
 
@@ -1559,6 +1559,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
     <meta name="color-scheme" content="light dark" />
     <meta
       name="description"
-      content="Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault."
+      content="Parachute Lens — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault."
     />
-    <title>Parachute Notes</title>
+    <title>Parachute Lens</title>
     <script>
       (function () {
         try {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@openparachute/notes",
+  "name": "@openparachute/lens",
   "version": "0.3.0-rc.1",
   "private": false,
   "type": "module",
-  "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
+  "description": "Parachute Lens — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParachuteComputer/parachute-notes.git"
+    "url": "https://github.com/ParachuteComputer/parachute-lens.git"
   },
   "files": ["dist", "README.md", "LICENSE"],
   "scripts": {

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <title>Parachute Notes</title>
+  <title>Parachute Lens</title>
   <rect width="512" height="512" rx="96" ry="96" fill="#4a7c59" />
   <circle cx="256" cy="256" r="130" fill="none" stroke="#faf8f4" stroke-width="32" />
   <circle cx="256" cy="256" r="44" fill="#faf8f4" />

--- a/scripts/info-endpoint-plugin.test.ts
+++ b/scripts/info-endpoint-plugin.test.ts
@@ -2,26 +2,26 @@ import { describe, expect, it } from "vitest";
 import { type ServiceInfo, buildServiceInfo, infoEndpointPlugin } from "./info-endpoint-plugin";
 
 const exampleInfo: ServiceInfo = {
-  name: "parachute-notes",
-  displayName: "Notes",
+  name: "parachute-lens",
+  displayName: "Lens",
   tagline: "Web client for your Parachute Vault",
   version: "0.0.1",
-  iconUrl: "/notes/icon.svg",
+  iconUrl: "/lens/icon.svg",
   kind: "frontend",
 };
 
 describe("buildServiceInfo", () => {
   it("threads basePath into iconUrl and carries kind through", () => {
     const info = buildServiceInfo({
-      name: "parachute-notes",
-      displayName: "Notes",
+      name: "parachute-lens",
+      displayName: "Lens",
       tagline: "Web client for your Parachute Vault",
       version: "0.0.1",
-      basePath: "/notes",
+      basePath: "/lens",
       iconFile: "icon.svg",
       kind: "frontend",
     });
-    expect(info.iconUrl).toBe("/notes/icon.svg");
+    expect(info.iconUrl).toBe("/lens/icon.svg");
     expect(info.kind).toBe("frontend");
   });
 
@@ -31,11 +31,11 @@ describe("buildServiceInfo", () => {
       displayName: "X",
       tagline: "t",
       version: "1",
-      basePath: "/notes/",
+      basePath: "/lens/",
       iconFile: "/icon.svg",
       kind: "frontend",
     });
-    expect(info.iconUrl).toBe("/notes/icon.svg");
+    expect(info.iconUrl).toBe("/lens/icon.svg");
   });
 
   it("accepts alternate kinds for non-frontend services", () => {
@@ -54,7 +54,7 @@ describe("buildServiceInfo", () => {
 
 describe("infoEndpointPlugin", () => {
   it("emits .parachute/info.json into the bundle on build", () => {
-    const plugin = infoEndpointPlugin({ basePath: "/notes", ...exampleInfo });
+    const plugin = infoEndpointPlugin({ basePath: "/lens", ...exampleInfo });
     const emitted: Array<{ type: string; fileName?: string; source?: string | Uint8Array }> = [];
     const ctx = {
       emitFile(file: { type: string; fileName?: string; source?: string | Uint8Array }) {
@@ -78,7 +78,7 @@ describe("infoEndpointPlugin", () => {
   });
 
   it("serves the same JSON via dev server middleware at basePath/.parachute/info.json", () => {
-    const plugin = infoEndpointPlugin({ basePath: "/notes", ...exampleInfo });
+    const plugin = infoEndpointPlugin({ basePath: "/lens", ...exampleInfo });
     const uses: Array<{ path: string; handler: (req: unknown, res: MockRes) => void }> = [];
     const fakeServer = {
       middlewares: {
@@ -94,7 +94,7 @@ describe("infoEndpointPlugin", () => {
     configure.call(plugin as any, fakeServer as any);
 
     expect(uses).toHaveLength(1);
-    expect(uses[0]?.path).toBe("/notes/.parachute/info.json");
+    expect(uses[0]?.path).toBe("/lens/.parachute/info.json");
 
     const res = new MockRes();
     uses[0]?.handler({}, res);

--- a/scripts/info-endpoint-plugin.ts
+++ b/scripts/info-endpoint-plugin.ts
@@ -41,7 +41,7 @@ export function infoEndpointPlugin(options: PluginOptions): Plugin {
   }
 
   return {
-    name: "parachute-notes-info-endpoint",
+    name: "parachute-lens-info-endpoint",
     configureServer: attach,
     configurePreviewServer: attach,
     generateBundle() {

--- a/scripts/lens-service-plugin.ts
+++ b/scripts/lens-service-plugin.ts
@@ -15,7 +15,7 @@ interface PluginOptions {
   tagline?: string;
 }
 
-// Notes is an SPA — no long-running Node entrypoint that would otherwise own
+// Lens is an SPA — no long-running Node entrypoint that would otherwise own
 // the manifest write. Hook the Vite dev + preview servers instead so the
 // manifest reflects the actual listening port. We deliberately do NOT write
 // during `vite build` (no port to advertise; the CLI's expose tool registers
@@ -23,7 +23,7 @@ interface PluginOptions {
 //
 // Best-effort: a manifest write failure (PARACHUTE_HOME unwritable, schema
 // drift, malformed pre-existing file) only logs a warning. Don't break dev.
-export function notesServicePlugin(options: PluginOptions): Plugin {
+export function lensServicePlugin(options: PluginOptions): Plugin {
   const { name, version, basePath, displayName, tagline } = options;
   const healthPath = basePath.endsWith("/") ? basePath : `${basePath}/`;
 
@@ -54,7 +54,7 @@ export function notesServicePlugin(options: PluginOptions): Plugin {
   }
 
   return {
-    name: "parachute-notes-service-manifest",
+    name: "parachute-lens-service-manifest",
     apply: (_config, env) => env.command === "serve",
     configureServer: attach,
     configurePreviewServer: attach,

--- a/scripts/services-manifest.test.ts
+++ b/scripts/services-manifest.test.ts
@@ -11,18 +11,18 @@ import {
 } from "./services-manifest";
 
 function tempPath(): { path: string; cleanup: () => void } {
-  const dir = mkdtempSync(join(tmpdir(), "pnotes-manifest-"));
+  const dir = mkdtempSync(join(tmpdir(), "plens-manifest-"));
   const path = join(dir, "services.json");
   return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 }
 
-const notes: ServiceEntry = {
-  name: "parachute-notes",
+const lens: ServiceEntry = {
+  name: "parachute-lens",
   port: 1942,
-  paths: ["/notes/"],
-  health: "/notes/",
+  paths: ["/lens/"],
+  health: "/lens/",
   version: "0.0.1",
-  displayName: "Notes",
+  displayName: "Lens",
   tagline: "Web client for your Parachute Vault",
 };
 
@@ -47,9 +47,9 @@ describe("services-manifest", () => {
   it("upsertService creates the file if missing", () => {
     const { path, cleanup } = tempPath();
     try {
-      const m = upsertService(notes, path);
-      expect(m.services).toEqual([notes]);
-      expect(readManifest(path)).toEqual({ services: [notes] });
+      const m = upsertService(lens, path);
+      expect(m.services).toEqual([lens]);
+      expect(readManifest(path)).toEqual({ services: [lens] });
     } finally {
       cleanup();
     }
@@ -58,8 +58,8 @@ describe("services-manifest", () => {
   it("upsertService updates by name and never duplicates", () => {
     const { path, cleanup } = tempPath();
     try {
-      upsertService(notes, path);
-      const updated = { ...notes, port: 4200, version: "0.1.0" };
+      upsertService(lens, path);
+      const updated = { ...lens, port: 4200, version: "0.1.0" };
       upsertService(updated, path);
       const m = readManifest(path);
       expect(m.services).toHaveLength(1);
@@ -73,11 +73,11 @@ describe("services-manifest", () => {
     const { path, cleanup } = tempPath();
     try {
       writeFileSync(path, `${JSON.stringify({ services: [vault] }, null, 2)}\n`);
-      upsertService(notes, path);
+      upsertService(lens, path);
       const m = readManifest(path);
       expect(m.services).toHaveLength(2);
       expect(m.services.find((s) => s.name === "parachute-vault")).toEqual(vault);
-      expect(m.services.find((s) => s.name === "parachute-notes")).toEqual(notes);
+      expect(m.services.find((s) => s.name === "parachute-lens")).toEqual(lens);
     } finally {
       cleanup();
     }
@@ -86,9 +86,9 @@ describe("services-manifest", () => {
   it("upsertService writes pretty-printed JSON with trailing newline", () => {
     const { path, cleanup } = tempPath();
     try {
-      upsertService(notes, path);
+      upsertService(lens, path);
       const raw = readFileSync(path, "utf8");
-      expect(raw).toBe(`${JSON.stringify({ services: [notes] }, null, 2)}\n`);
+      expect(raw).toBe(`${JSON.stringify({ services: [lens] }, null, 2)}\n`);
     } finally {
       cleanup();
     }
@@ -108,7 +108,7 @@ describe("services-manifest", () => {
     const { path, cleanup } = tempPath();
     try {
       writeFileSync(path, `${JSON.stringify({ services: [vault] }, null, 2)}\n`);
-      const bad = { ...notes, port: -1 };
+      const bad = { ...lens, port: -1 };
       expect(() => upsertService(bad as ServiceEntry, path)).toThrow(ServicesManifestError);
       expect(readManifest(path)).toEqual({ services: [vault] });
     } finally {
@@ -131,9 +131,9 @@ describe("services-manifest", () => {
   it("rejects non-string displayName / tagline", () => {
     const { path, cleanup } = tempPath();
     try {
-      const badDisplay = { ...notes, displayName: 42 } as unknown as ServiceEntry;
+      const badDisplay = { ...lens, displayName: 42 } as unknown as ServiceEntry;
       expect(() => upsertService(badDisplay, path)).toThrow(/displayName/);
-      const badTagline = { ...notes, tagline: 42 } as unknown as ServiceEntry;
+      const badTagline = { ...lens, tagline: 42 } as unknown as ServiceEntry;
       expect(() => upsertService(badTagline, path)).toThrow(/tagline/);
     } finally {
       cleanup();
@@ -141,13 +141,13 @@ describe("services-manifest", () => {
   });
 
   it("default path honors PARACHUTE_HOME set at runtime", () => {
-    const dir = mkdtempSync(join(tmpdir(), "pnotes-home-"));
+    const dir = mkdtempSync(join(tmpdir(), "plens-home-"));
     const prior = process.env.PARACHUTE_HOME;
     process.env.PARACHUTE_HOME = dir;
     try {
       expect(servicesManifestPath()).toBe(join(dir, "services.json"));
-      upsertService(notes);
-      expect(readManifest()).toEqual({ services: [notes] });
+      upsertService(lens);
+      expect(readManifest()).toEqual({ services: [lens] });
     } finally {
       // biome-ignore lint/performance/noDelete: process.env coerces assignments to strings; only delete actually unsets the key
       if (prior === undefined) delete process.env.PARACHUTE_HOME;

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -15,9 +15,9 @@ describe("App", () => {
     localStorage.clear();
     sessionStorage.clear();
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
-    // BrowserRouter is mounted with basename="/notes" (BASE_URL from Vite).
-    // Tests simulate the external mount by placing the browser under /notes/.
-    window.history.replaceState({}, "", "/notes/");
+    // BrowserRouter is mounted with basename="/lens" (BASE_URL from Vite).
+    // Tests simulate the external mount by placing the browser under /lens/.
+    window.history.replaceState({}, "", "/lens/");
     stubFetch();
   });
 
@@ -26,9 +26,9 @@ describe("App", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders the Parachute Notes wordmark and the connect CTA when no vaults exist", async () => {
+  it("renders the Parachute Lens wordmark and the connect CTA when no vaults exist", async () => {
     render(<App />);
-    expect(screen.getByRole("link", { name: /parachute notes/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /parachute lens/i })).toBeInTheDocument();
     // Home holds back the CTA until the origin probe settles to avoid
     // flashing "Connect a vault" before swapping to "Looks like there's a
     // vault at …". Wait for the probe to resolve before asserting the CTA.
@@ -38,34 +38,34 @@ describe("App", () => {
     expect(screen.getByText(/no vault connected/i)).toBeInTheDocument();
   });
 
-  it("resolves the root list view at external /notes/ without double-prefixing", () => {
+  it("resolves the root list view at external /lens/ without double-prefixing", () => {
     render(<App />);
-    // Regression guard against the /notes/notes bug: with basename="/notes"
+    // Regression guard against the /lens/lens bug: with basename="/lens"
     // stripping the external prefix, the internal path is "/" and the index
-    // dispatcher (Home for no vault) renders. The URL must stay /notes/, not
-    // become /notes/notes.
-    expect(screen.getByRole("link", { name: /parachute notes/i })).toBeInTheDocument();
-    expect(window.location.pathname).toBe("/notes/");
+    // dispatcher (Home for no vault) renders. The URL must stay /lens/, not
+    // become /lens/lens.
+    expect(screen.getByRole("link", { name: /parachute lens/i })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/lens/");
   });
 
-  it("resolves NoteView at external /notes/n/<id>", () => {
-    window.history.replaceState({}, "", "/notes/n/some-id");
+  it("resolves NoteView at external /lens/n/<id>", () => {
+    window.history.replaceState({}, "", "/lens/n/some-id");
     render(<App />);
     // With no vault the NoteView route redirects internally to "/" (basename
-    // strips /notes). The critical regression guard: the external URL must
-    // sit under /notes, never /notes/notes.
-    expect(window.location.pathname.startsWith("/notes")).toBe(true);
-    expect(window.location.pathname.startsWith("/notes/notes")).toBe(false);
+    // strips /lens). The critical regression guard: the external URL must
+    // sit under /lens, never /lens/lens.
+    expect(window.location.pathname.startsWith("/lens")).toBe(true);
+    expect(window.location.pathname.startsWith("/lens/lens")).toBe(false);
   });
 
-  it("catch-all redirects to the root list, not /notes/notes", () => {
-    window.history.replaceState({}, "", "/notes/some-unknown-internal-path");
+  it("catch-all redirects to the root list, not /lens/lens", () => {
+    window.history.replaceState({}, "", "/lens/some-unknown-internal-path");
     render(<App />);
-    // The `*` route navigates to internal `/`. With basename=/notes this is
-    // external /notes (with or without trailing slash — both resolve the root
-    // list). The bug Aaron hit (/notes/notes) would surface here if basename
+    // The `*` route navigates to internal `/`. With basename=/lens this is
+    // external /lens (with or without trailing slash — both resolve the root
+    // list). The bug Aaron hit (/lens/lens) would surface here if basename
     // and route paths disagreed.
-    expect(window.location.pathname).toMatch(/^\/notes\/?$/);
+    expect(window.location.pathname).toMatch(/^\/lens\/?$/);
   });
 
   it("static route /settings wins over the dynamic /:id deep-link shim", () => {
@@ -84,13 +84,13 @@ describe("App", () => {
       },
       activeVaultId: "v1",
     });
-    window.history.replaceState({}, "", "/notes/settings");
+    window.history.replaceState({}, "", "/lens/settings");
     render(<App />);
     // Regression guard against future route-table accidents: RR7's ranked
     // routing must hold `/settings` (and every other named static route)
     // above the `/:id` pre-#49 bookmark shim. If this ever fails, the shim
     // would start swallowing real internal pages.
     expect(screen.getByRole("heading", { level: 1, name: /settings/i })).toBeInTheDocument();
-    expect(window.location.pathname).toBe("/notes/settings");
+    expect(window.location.pathname).toBe("/lens/settings");
   });
 });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -23,7 +23,7 @@ import { VaultGraph } from "./routes/VaultGraph";
 import { Vaults } from "./routes/Vaults";
 
 // Index dispatcher: render the notes list when a vault is connected, else the
-// landing page. Both live at internal `/`, which maps to external `/notes/`
+// landing page. Both live at internal `/`, which maps to external `/lens/`
 // via BrowserRouter's basename. Keeps Notes free of "no vault?" presentation
 // concerns and Home free of any redirect logic.
 function NotesIndex() {
@@ -31,11 +31,11 @@ function NotesIndex() {
   return activeVault ? <Notes /> : <Home />;
 }
 
-// Shim for pre-#49 external bookmarks. When Notes lived at the origin root,
-// links were `/notes/<id>` and `/notes/<id>/edit`. After #49 moved Notes
-// under `/notes/`, Tailscale strips that prefix, leaving internal `/<id>`
-// and `/<id>/edit` — which the catch-all would otherwise bounce to `/`.
-// Redirect them to the canonical `/n/<id>` routes so old bookmarks survive.
+// Shim for pre-mount external bookmarks. When the app lived at the origin root,
+// links were `/<id>` and `/<id>/edit`. After Lens moved under `/lens/`,
+// Tailscale strips that prefix, leaving internal `/<id>` and `/<id>/edit` —
+// which the catch-all would otherwise bounce to `/`. Redirect them to the
+// canonical `/n/<id>` routes so old bookmarks survive.
 function NoteIdRedirect({ suffix = "" }: { suffix?: string }) {
   const { id } = useParams<{ id: string }>();
   if (!id) return <Navigate to="/" replace />;

--- a/src/app/routes/AddVault.tsx
+++ b/src/app/routes/AddVault.tsx
@@ -55,7 +55,7 @@ export function AddVault() {
       <h1 className="mb-2 font-serif text-4xl tracking-tight">Connect a vault</h1>
       <p className="mb-8 text-fg-muted">
         Paste the URL of a Parachute Vault. You'll be taken to its consent page to authorize
-        Parachute Notes.
+        Parachute Lens.
       </p>
 
       <form onSubmit={onSubmit} className="space-y-4">

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -14,7 +14,7 @@ export function Home() {
       <p className="mb-8 font-serif text-xl italic text-fg-muted">
         The default frontend for Parachute.
       </p>
-      <h1 className="mb-4 font-serif text-5xl tracking-tight">Notes</h1>
+      <h1 className="mb-4 font-serif text-5xl tracking-tight">Lens</h1>
 
       {/* Hold back the CTA while probing so we don't flash "Connect a vault"
           and then swap it for "Looks like there's a vault at ..." once the

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -57,7 +57,7 @@ function InstallStateSection() {
         <span className="mr-2 inline-block rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-300">
           Installed
         </span>
-        Parachute Notes is running as an installed app on this device.
+        Parachute Lens is running as an installed app on this device.
       </p>
     </section>
   );

--- a/src/base-url.test.ts
+++ b/src/base-url.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, it } from "vitest";
 // strips the external prefix on read and prepends it on write. Moving the
 // mount is a one-line change here — not a route-by-route search-and-replace.
 describe("import.meta.env.BASE_URL", () => {
-  it("defaults to /notes/ — Notes is mounted under /notes by the hub", () => {
-    expect(import.meta.env.BASE_URL).toBe("/notes/");
+  it("defaults to /lens/ — Lens is mounted under /lens by the hub", () => {
+    expect(import.meta.env.BASE_URL).toBe("/lens/");
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,7 +40,7 @@ export function Header() {
     >
       <nav className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-6 py-4 md:py-5">
         <Link to="/" className="font-serif text-xl tracking-tight text-fg hover:text-accent">
-          Parachute Notes
+          Parachute Lens
         </Link>
 
         {/* Desktop nav */}

--- a/src/components/InstallPrompt.test.tsx
+++ b/src/components/InstallPrompt.test.tsx
@@ -74,7 +74,7 @@ describe("InstallPrompt", () => {
     await act(async () => {
       fireEvent.click(btn);
     });
-    expect(screen.getByText(/add parachute notes to your home screen/i)).toBeInTheDocument();
+    expect(screen.getByText(/add parachute lens to your home screen/i)).toBeInTheDocument();
     expect(screen.getByText(/share icon/i)).toBeInTheDocument();
   });
 });

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -57,14 +57,14 @@ export function InstallPrompt() {
           className="fixed inset-0 z-50 m-auto max-w-sm rounded-md border border-border bg-card p-6 text-fg shadow-lg backdrop:bg-black/40"
         >
           <h2 id="ios-install-title" className="mb-3 font-serif text-xl">
-            Add Parachute Notes to your home screen
+            Add Parachute Lens to your home screen
           </h2>
           <ol className="mb-5 list-decimal space-y-2 pl-5 text-sm text-fg-muted">
             <li>Tap the Share icon in Safari's toolbar.</li>
             <li>
               Choose <strong className="text-fg">Add to Home Screen</strong>.
             </li>
-            <li>Tap Add. Parachute Notes will open standalone from your home screen.</li>
+            <li>Tap Add. Parachute Lens will open standalone from your home screen.</li>
           </ol>
           <div className="flex justify-end">
             <button

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -19,7 +19,7 @@ export function UpdateBanner() {
 
   return (
     <output className="fixed inset-x-0 bottom-4 z-40 mx-auto flex max-w-sm items-center justify-between gap-3 rounded-md border border-border bg-card px-4 py-3 shadow-lg">
-      <p className="text-sm text-fg">A new version of Parachute Notes is available.</p>
+      <p className="text-sm text-fg">A new version of Parachute Lens is available.</p>
       <div className="flex gap-2">
         <button
           type="button"

--- a/src/lib/vault/discovery.test.ts
+++ b/src/lib/vault/discovery.test.ts
@@ -68,7 +68,7 @@ describe("registerClient", () => {
       {
         json: {
           client_id: "abc-123",
-          client_name: "Parachute Notes",
+          client_name: "Parachute Lens",
           redirect_uris: ["http://localhost/oauth/callback"],
         },
       },
@@ -86,7 +86,7 @@ describe("registerClient", () => {
     expect(init.method).toBe("POST");
     const body = JSON.parse(init.body as string);
     expect(body.redirect_uris).toEqual(["http://localhost/oauth/callback"]);
-    expect(body.client_name).toBe("Parachute Notes");
+    expect(body.client_name).toBe("Parachute Lens");
   });
 
   it("throws on non-OK response", async () => {

--- a/src/lib/vault/discovery.ts
+++ b/src/lib/vault/discovery.ts
@@ -55,7 +55,7 @@ export async function registerClient(
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
     body: JSON.stringify({
-      client_name: "Parachute Notes",
+      client_name: "Parachute Lens",
       redirect_uris: [redirectUri],
       grant_types: ["authorization_code"],
       response_types: ["code"],

--- a/src/lib/vault/oauth.test.ts
+++ b/src/lib/vault/oauth.test.ts
@@ -18,7 +18,7 @@ const validMetadata = {
 
 const clientReg = {
   client_id: "client-123",
-  client_name: "Parachute Notes",
+  client_name: "Parachute Lens",
   redirect_uris: ["http://localhost:3000/oauth/callback"],
 };
 
@@ -53,7 +53,7 @@ describe("beginOAuth", () => {
     expect(url.searchParams.get("response_type")).toBe("code");
     expect(url.searchParams.get("client_id")).toBe("client-123");
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
-    expect(url.searchParams.get("redirect_uri")).toBe("http://localhost:3000/notes/oauth/callback");
+    expect(url.searchParams.get("redirect_uri")).toBe("http://localhost:3000/lens/oauth/callback");
     expect(url.searchParams.get("scope")).toBe("full");
 
     const challenge = url.searchParams.get("code_challenge");
@@ -86,17 +86,17 @@ describe("redirectUriForOrigin under VITE_BASE_PATH", () => {
     );
   });
 
-  it("includes the base path when Notes is mounted under a sub-path", () => {
-    vi.stubEnv("BASE_URL", "/notes/");
+  it("includes the base path when Lens is mounted under a sub-path", () => {
+    vi.stubEnv("BASE_URL", "/lens/");
     expect(redirectUriForOrigin("http://host.example")).toBe(
-      "http://host.example/notes/oauth/callback",
+      "http://host.example/lens/oauth/callback",
     );
   });
 
   it("strips a single trailing slash on the origin and the base", () => {
-    vi.stubEnv("BASE_URL", "/notes/");
+    vi.stubEnv("BASE_URL", "/lens/");
     expect(redirectUriForOrigin("http://host.example/")).toBe(
-      "http://host.example/notes/oauth/callback",
+      "http://host.example/lens/oauth/callback",
     );
   });
 });

--- a/src/lib/vault/oauth.ts
+++ b/src/lib/vault/oauth.ts
@@ -6,8 +6,8 @@ import { normalizeVaultUrl } from "./url";
 
 const REDIRECT_PATH = "/oauth/callback";
 
-// Notes is mounted under `import.meta.env.BASE_URL` (defaults to `/`, can be
-// `/notes/` when the CLI's expose tooling path-routes us). The OAuth callback
+// Lens is mounted under `import.meta.env.BASE_URL` (defaults to `/`, can be
+// `/lens/` when the CLI's expose tooling path-routes us). The OAuth callback
 // must include that prefix so the authorization server bounces the browser
 // back to a URL the SPA actually serves.
 function basePathPrefix(): string {

--- a/src/pwa-manifest.test.ts
+++ b/src/pwa-manifest.test.ts
@@ -34,14 +34,14 @@ describe("PWA_MANIFEST", () => {
 
 describe("buildPwaManifest under a sub-path", () => {
   it("threads the base into id, start_url, and scope so installed PWAs land on the right route", () => {
-    const m = buildPwaManifest("/notes/");
-    expect(m.id).toBe("/notes/");
-    expect(m.start_url).toBe("/notes/");
-    expect(m.scope).toBe("/notes/");
+    const m = buildPwaManifest("/lens/");
+    expect(m.id).toBe("/lens/");
+    expect(m.start_url).toBe("/lens/");
+    expect(m.scope).toBe("/lens/");
   });
 
   it("normalizes a base passed without a trailing slash", () => {
-    const m = buildPwaManifest("/notes");
-    expect(m.start_url).toBe("/notes/");
+    const m = buildPwaManifest("/lens");
+    expect(m.start_url).toBe("/lens/");
   });
 });

--- a/src/pwa-manifest.ts
+++ b/src/pwa-manifest.ts
@@ -2,13 +2,13 @@ import type { ManifestOptions } from "vite-plugin-pwa";
 
 // Build the PWA manifest at config-load time. `id`/`start_url`/`scope` must
 // reflect the deployed base path; otherwise an installed PWA would launch at
-// `/` and 404 when Notes is mounted under e.g. `/notes/`.
+// `/` and 404 when Lens is mounted under e.g. `/lens/`.
 export function buildPwaManifest(base = "/"): Partial<ManifestOptions> {
   const normalized = base.endsWith("/") ? base : `${base}/`;
   return {
     id: normalized,
-    name: "Parachute Notes",
-    short_name: "Notes",
+    name: "Parachute Lens",
+    short_name: "Lens",
     description:
       "The default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
     theme_color: "#4a7c59",
@@ -19,7 +19,7 @@ export function buildPwaManifest(base = "/"): Partial<ManifestOptions> {
     scope: normalized,
     // Icon `src` values are intentionally bare (no leading `/`). They resolve
     // relative to the manifest URL, which itself sits under the deployed base
-    // path (e.g. `/notes/manifest.webmanifest`). That keeps the icons portable
+    // path (e.g. `/lens/manifest.webmanifest`). That keeps the icons portable
     // across mounts without rewriting each path — don't add a leading slash.
     icons: [
       { src: "pwa-64x64.png", sizes: "64x64", type: "image/png" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,20 +5,20 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { buildServiceInfo, infoEndpointPlugin } from "./scripts/info-endpoint-plugin";
-import { notesServicePlugin } from "./scripts/notes-service-plugin";
+import { lensServicePlugin } from "./scripts/lens-service-plugin";
 import { buildPwaManifest } from "./src/pwa-manifest";
 
 // Set VITE_EXPOSE=true to bind the dev server to all interfaces and accept any
 // Host header — useful when reaching the dev server over a tailnet. Off by default.
 const devExposure = process.env.VITE_EXPOSE === "true";
 
-// Notes is one of N frontends mounted under a shared root: the CLI hub page
-// owns `/`, and each frontend lives under its own slug. Default to `/notes`
-// here so dev, build, and `parachute start notes` all agree.
+// Lens is one of N frontends mounted under a shared root: the CLI hub page
+// owns `/`, and each frontend lives under its own slug. Default to `/lens`
+// here so dev, build, and `parachute start lens` all agree.
 // Override with VITE_BASE_PATH=/ if you want the legacy stand-alone shape.
-const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/notes");
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/lens");
 
-const DISPLAY_NAME = "Notes";
+const DISPLAY_NAME = "Lens";
 const TAGLINE = "Web client for your Parachute Vault";
 
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, "./package.json"), "utf8")) as {
@@ -26,14 +26,14 @@ const pkg = JSON.parse(readFileSync(path.resolve(__dirname, "./package.json"), "
 };
 
 const serviceInfo = buildServiceInfo({
-  name: "parachute-notes",
+  name: "parachute-lens",
   displayName: DISPLAY_NAME,
   tagline: TAGLINE,
   version: pkg.version,
   basePath,
   iconFile: "icon.svg",
-  // Notes has a real UI — the hub should render it as a clickable card that
-  // navigates into `/notes/`, not a detail panel.
+  // Lens has a real UI — the hub should render it as a clickable card that
+  // navigates into `/lens/`, not a detail panel.
   kind: "frontend",
 });
 
@@ -48,8 +48,8 @@ export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
-    notesServicePlugin({
-      name: "parachute-notes",
+    lensServicePlugin({
+      name: "parachute-lens",
       version: pkg.version,
       basePath,
       displayName: DISPLAY_NAME,
@@ -85,9 +85,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  // Notes' canonical Parachute slot is 1942 (vault is 1940; the 1939–1949
+  // Lens' canonical Parachute slot is 1942 (vault is 1940; the 1939–1949
   // range is reserved for first-party services). Pin it so the manifest
-  // write in `notes-service-plugin.ts` advertises a stable port — Vite's
+  // write in `lens-service-plugin.ts` advertises a stable port — Vite's
   // 5173 default would otherwise drift if anything else grabs that port.
   server: {
     port: 1942,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   // Mirror the production default so `import.meta.env.BASE_URL` in tests
   // reflects what the SPA actually sees at runtime.
-  base: "/notes/",
+  base: "/lens/",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Product-name rename across package metadata, mount path, service manifest, PWA manifest, OAuth client name, and UI copy. Aaron decided pre-launch the name is Lens, not Notes.

The `Note` domain concept is deliberately unchanged — Lens is the frontend for browsing/editing notes in a vault:

- API endpoint stays `/api/notes/:id`
- Editor/viewer components stay `NoteEditor`, `NoteView`, `useNote`, etc.
- React Query key stays `["notes", vaultId, …]`
- Internal route stays `/n/:id`
- Apple Notes external references stay as-is

Rule of thumb: the product name "Notes" becomes "Lens"; the data type "note" stays.

### What changed

- `package.json`: `@openparachute/notes` → `@openparachute/lens`, description + repo URL
- Vite `base` + BrowserRouter basename: `/notes/` → `/lens/`
- PWA manifest: name `Parachute Lens`, short_name `Lens`, scope/start_url/id `/lens/`
- `services.json` write: `name: parachute-lens`, `displayName: Lens`, `paths: [/lens/]`
- `/.parachute/info.json`: `name: parachute-lens`, `displayName: Lens`, `iconUrl: /lens/icon.svg`
- OAuth RFC 7591 `client_name`: `Parachute Notes` → `Parachute Lens`
- `scripts/notes-service-plugin.ts` → `scripts/lens-service-plugin.ts` (export + plugin.name follow)
- Header wordmark, Home H1, InstallPrompt copy, UpdateBanner, AddVault help text, Settings copy: all `Parachute Notes` → `Parachute Lens`
- README, CLAUDE.md, MOBILE_SMOKE.md: updated
- Test fixtures + URL assertions updated to match new base path

### Coordination

CLI-side steward handles the `parachute start` + migration safelist + alias side in parallel. GitHub repo rename `parachute-notes` → `parachute-lens` preserves redirects.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (545 tests pass)
- [x] `bun run build` — `dist/.parachute/info.json` and `dist/manifest.webmanifest` verified with new name + base
- [ ] Post-merge: visit `https://parachute.<tailnet>.ts.net/lens/`, confirm install prompt shows "Install Parachute Lens"
- [ ] Post-merge: re-OAuth flow, confirm consent screen shows `Parachute Lens` as the client name

🤖 Generated with [Claude Code](https://claude.com/claude-code)