### PR TITLE
fix: probe parachute.json before direct OAuth

### DIFF
--- a/src/lib/vault/probe.test.ts
+++ b/src/lib/vault/probe.test.ts
@@ -20,9 +20,9 @@ interface MockResponse {
   text?: string;
 }
 
-// Fetch mock that routes by URL substring instead of a fixed queue — the new
-// probe makes two kinds of calls (parachute.json + oauth metadata) and a
-// flat queue is brittle if the order changes.
+// Fetch mock that routes by URL substring. The probe makes two kinds of calls
+// (parachute.json + oauth metadata) and a flat queue would be brittle if the
+// order changes.
 function routedFetch(routes: Record<string, MockResponse | "network-error">) {
   return vi.fn<typeof fetch>(async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
@@ -42,46 +42,28 @@ function routedFetch(routes: Record<string, MockResponse | "network-error">) {
 }
 
 describe("probeVaultAtOrigin", () => {
-  it("resolves at the hub origin directly via OAuth metadata (Phase 0)", async () => {
-    // Hub origin advertises itself as issuer; the parachute.json registry
-    // isn't needed at all. Direct OAuth discovery wins without any registry
-    // fetch being required.
-    const hubMetadata = { ...validMetadata, issuer: "https://hub.example" };
+  it("prefers parachute.json so a hub URL resolves to its vault, not the portal origin", async () => {
+    // Regression guard: hub origin serves BOTH a parachute.json registry AND
+    // direct OAuth metadata (it proxies vault's metadata at the portal root).
+    // If we probed direct OAuth first, we'd return the hub origin — but the
+    // hub isn't a vault, it's a portal. `/api/notes` on the hub doesn't exist
+    // and every API call would 404. Registry-first ensures we end up at
+    // `${hub}/vault/<name>`.
     const fetchImpl = routedFetch({
-      "/.well-known/oauth-authorization-server": { json: hubMetadata },
-    });
-    const result = await probeVaultAtOrigin("https://hub.example", 500, fetchImpl);
-    expect(result).toBe("https://hub.example");
-  });
-
-  it("resolves a directly-pasted vault URL via OAuth metadata", async () => {
-    // Standalone vault case: user pastes the full vault URL. Direct probe
-    // (first) succeeds; no registry consulted.
-    const fetchImpl = routedFetch({
-      "/vault/default/.well-known/oauth-authorization-server": { json: validMetadata },
-    });
-    const result = await probeVaultAtOrigin("https://h.example/vault/default", 500, fetchImpl);
-    expect(result).toBe("https://h.example/vault/default");
-  });
-
-  it("falls back to parachute.json when direct OAuth discovery fails", async () => {
-    // User pasted a bare origin that doesn't serve OAuth metadata itself but
-    // does publish a registry pointing at a real vault URL.
-    const fetchImpl = routedFetch({
-      // Direct probe on the origin fails.
-      "https://h.example/.well-known/oauth-authorization-server": { ok: false, status: 404 },
       "/.well-known/parachute.json": {
-        json: { vault: { url: "https://h.example/vault/default" } },
+        json: { vault: { url: "https://hub.example/vault/default" } },
       },
       "/vault/default/.well-known/oauth-authorization-server": { json: validMetadata },
+      // Direct OAuth would also succeed at the hub, but we should never reach
+      // it — the registry win short-circuits the fallback.
+      "https://hub.example/.well-known/oauth-authorization-server": { json: validMetadata },
     });
-    const result = await probeVaultAtOrigin("https://h.example", 500, fetchImpl);
-    expect(result).toBe("https://h.example/vault/default");
+    const result = await probeVaultAtOrigin("https://hub.example", 500, fetchImpl);
+    expect(result).toBe("https://hub.example/vault/default");
   });
 
-  it("prefers the entry named `default` from a multi-vault parachute.json fallback", async () => {
+  it("prefers the entry named `default` from a multi-vault parachute.json", async () => {
     const fetchImpl = routedFetch({
-      "https://h.example/.well-known/oauth-authorization-server": { ok: false, status: 404 },
       "/.well-known/parachute.json": {
         json: {
           vaults: [
@@ -96,31 +78,59 @@ describe("probeVaultAtOrigin", () => {
     expect(result).toBe("https://h.example/vault/default");
   });
 
-  it("returns null when neither direct OAuth nor parachute.json resolve", async () => {
+  it("falls back to direct OAuth for a bare standalone vault with no registry", async () => {
+    // Standalone vault case: user pastes `http://localhost:1940`. No
+    // parachute.json served; direct OAuth metadata on the origin works.
     const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": { ok: false, status: 404 },
+      "http://localhost:1940/.well-known/oauth-authorization-server": { json: validMetadata },
+    });
+    const result = await probeVaultAtOrigin("http://localhost:1940", 500, fetchImpl);
+    expect(result).toBe("http://localhost:1940");
+  });
+
+  it("falls back to direct OAuth for a vault-path URL behind a non-hub proxy", async () => {
+    // User pastes `https://my-vault.example.com/vault/default` directly.
+    // parachute.json at origin root doesn't exist (this host isn't running
+    // the Parachute CLI portal); direct OAuth at the pasted URL works.
+    const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": { ok: false, status: 404 },
+      "/vault/default/.well-known/oauth-authorization-server": { json: validMetadata },
+    });
+    const result = await probeVaultAtOrigin(
+      "https://my-vault.example.com/vault/default",
+      500,
+      fetchImpl,
+    );
+    expect(result).toBe("https://my-vault.example.com/vault/default");
+  });
+
+  it("returns null when neither parachute.json nor direct OAuth resolve", async () => {
+    const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": { ok: false, status: 404 },
       "/.well-known/oauth-authorization-server": { ok: false, status: 404 },
-      "/.well-known/parachute.json": { ok: false, status: 404 },
     });
     expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
   });
 
-  it("returns null on network error during direct probe with no registry", async () => {
+  it("falls through to direct OAuth when parachute.json points at a broken vault", async () => {
+    // Registry was found but its vault entry fails OAuth metadata. Fall
+    // through to direct discovery at the input origin — maybe the origin
+    // itself is a valid vault and the registry is stale.
     const fetchImpl = routedFetch({
-      "/.well-known/oauth-authorization-server": "network-error",
-      "/.well-known/parachute.json": { ok: false, status: 404 },
-    });
-    expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
-  });
-
-  it("returns null when parachute.json is found but its vault fails OAuth metadata", async () => {
-    const fetchImpl = routedFetch({
-      // Direct probe on the origin fails, and the registry-pointed vault
-      // also fails OAuth metadata.
-      "https://h.example/.well-known/oauth-authorization-server": { ok: false, status: 404 },
       "/.well-known/parachute.json": {
         json: { vault: { url: "https://h.example/vault/broken" } },
       },
       "/vault/broken/.well-known/oauth-authorization-server": { ok: false, status: 500 },
+      "https://h.example/.well-known/oauth-authorization-server": { json: validMetadata },
+    });
+    expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBe("https://h.example");
+  });
+
+  it("returns null when parachute.json network-errors and no direct OAuth", async () => {
+    const fetchImpl = routedFetch({
+      "/.well-known/parachute.json": "network-error",
+      "/.well-known/oauth-authorization-server": { ok: false, status: 404 },
     });
     expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
   });

--- a/src/lib/vault/probe.ts
+++ b/src/lib/vault/probe.ts
@@ -16,26 +16,29 @@ const DEFAULT_TIMEOUT_MS = 2500;
 
 // Probe an input URL for a Parachute OAuth issuer. Two paths, in this order:
 //
-//   1. Direct OAuth discovery: `${input}/.well-known/oauth-authorization-server`.
-//      Matches the hub-as-portal Phase 0 seam (hub advertises its own origin
-//      as issuer; vault's OAuth is proxied behind it) *and* the standalone
-//      vault case where the user pastes a full vault URL. We try this first
-//      because the hub origin usually doesn't serve a parachute.json.
-//   2. Ecosystem registry fallback: `${origin}/.well-known/parachute.json` →
-//      pick a vault entry (name=default, else first) → validate by hitting
-//      its OAuth metadata. Useful when the user pastes a bare host that only
-//      publishes the registry.
+//   1. Ecosystem registry: `${origin}/.well-known/parachute.json` → pick a
+//      vault entry (name=default, else first) → validate by hitting its
+//      OAuth metadata. This is the path that matters for the hub-as-portal
+//      case: the hub origin *itself* proxies OAuth metadata (so direct
+//      discovery would succeed at the hub origin, which isn't a vault),
+//      but only the registry reveals the actual vault resource URL
+//      (`${origin}/vault/<name>`). Preferring the registry ensures Lens
+//      ends up pointing at the vault and not at the portal.
+//   2. Direct OAuth discovery fallback:
+//      `${input}/.well-known/oauth-authorization-server`. Covers the
+//      standalone vault case (user pastes `http://localhost:1940`) and
+//      the vault-behind-a-non-hub-proxy case (user pastes
+//      `https://my-vault.example.com/vault/default`) — neither serves
+//      parachute.json, but both answer OAuth metadata directly.
 //
-// Returns the URL that successfully resolves OAuth metadata (either the input
-// itself or the registry-pointed vault URL), or null if neither path resolves.
+// Returns the URL that successfully resolves OAuth metadata (either the
+// registry-pointed vault URL or the input itself), or null if neither
+// path resolves.
 export async function probeVaultAtOrigin(
   origin: string,
   timeoutMs: number = DEFAULT_TIMEOUT_MS,
   fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<string | null> {
-  const direct = await tryDiscoverAuthServer(origin, timeoutMs, fetchImpl);
-  if (direct) return direct;
-
   const manifest = await fetchParachuteJson(origin, timeoutMs, fetchImpl);
   if (manifest) {
     const chosen = pickVault(manifest);
@@ -44,6 +47,9 @@ export async function probeVaultAtOrigin(
       if (validated) return validated;
     }
   }
+
+  const direct = await tryDiscoverAuthServer(origin, timeoutMs, fetchImpl);
+  if (direct) return direct;
 
   return null;
 }


### PR DESCRIPTION
## Summary

Hotfix: when a user pastes the **hub origin** as their vault URL, the probe was resolving to the hub origin itself (no `/vault/<name>` suffix), OAuth completed, and then every API call hit `${hub}/api/notes` instead of `${hub}/vault/default/api/notes` — user saw "could not load notes" on a brand-new install.

## Root cause

`probeVaultAtOrigin` tried OAuth discovery directly at the input first, then parachute.json as a fallback. The hub-as-portal Phase 0 seam has the hub proxying vault's OAuth metadata at its own root — so direct discovery **succeeds** at the hub origin and short-circuits the fallback. The registry (which gives the real vault URL) never runs.

## Fix

Flip the order: parachute.json first, direct OAuth as fallback.

```ts
const manifest = await fetchParachuteJson(origin, ...);
if (manifest) {
  const chosen = pickVault(manifest);
  if (chosen) {
    const validated = await tryDiscoverAuthServer(chosen.url, ...);
    if (validated) return validated;
  }
}

const direct = await tryDiscoverAuthServer(origin, ...);
if (direct) return direct;
return null;
```

## Why this works for all three shapes

1. **Hub URL** (`https://parachute.xxx.ts.net`) — parachute.json exists → registry points at `${hub}/vault/default` → validate OAuth there → return the vault URL. ✓ (the bug this fixes)
2. **Standalone vault** (`http://localhost:1940`) — no parachute.json → fall through to direct OAuth at origin → return origin. ✓ (same behavior as before)
3. **Vault behind non-hub proxy** (`https://my-vault.example.com/vault/default`) — no parachute.json at origin root → fall through to direct OAuth at the pasted URL → return URL. ✓ (same behavior as before)

## Tests

Rewrote `probe.test.ts` around the new ordering. 7 tests, including:

- **Regression guard**: hub origin serves *both* parachute.json AND direct OAuth metadata; the probe must return the registry-pointed vault URL. This is the test that would have caught the bug.
- Standalone vault (no registry, direct OAuth works) → returns origin
- Non-hub-proxy vault URL with `/vault/<name>` path → returns pasted URL
- `default`-name preference from a multi-vault manifest
- Broken-vault fall-through: registry found but vault entry fails OAuth → fall through to direct; if direct works, return origin
- Both fail → null
- parachute.json network-errors + no direct OAuth → null

Updated the header comment in `probe.ts` to describe the new order and the reasoning.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — **514 pass / 0 fail** across 67 files
- [ ] Manual: paste hub URL into Lens add-vault flow, confirm probe resolves to `${hub}/vault/default` and `/api/notes` requests include the `/vault/default` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)