### PR TITLE
fix(lens): offline create/update/delete no longer hang on bad onLine

### DIFF
--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -178,24 +178,30 @@ export class VaultClient {
     return rows ?? null;
   }
 
-  async updateNote(id: string, payload: UpdateNotePayload): Promise<Note> {
+  async updateNote(
+    id: string,
+    payload: UpdateNotePayload,
+    opts: { signal?: AbortSignal } = {},
+  ): Promise<Note> {
     return this.request<Note>(`/api/notes/${encodeURIComponent(id)}`, {
       method: "PATCH",
       body: JSON.stringify(payload),
+      signal: opts.signal,
     });
   }
 
-  async createNote(payload: CreateNotePayload): Promise<Note> {
+  async createNote(payload: CreateNotePayload, opts: { signal?: AbortSignal } = {}): Promise<Note> {
     return this.request<Note>("/api/notes", {
       method: "POST",
       body: JSON.stringify(payload),
+      signal: opts.signal,
     });
   }
 
-  async deleteNote(id: string): Promise<void> {
+  async deleteNote(id: string, opts: { signal?: AbortSignal } = {}): Promise<void> {
     await this.request<{ deleted: boolean; id: string } | undefined>(
       `/api/notes/${encodeURIComponent(id)}`,
-      { method: "DELETE" },
+      { method: "DELETE", signal: opts.signal },
     );
   }
 

--- a/src/lib/vault/queries.offline.test.tsx
+++ b/src/lib/vault/queries.offline.test.tsx
@@ -5,8 +5,9 @@ import { SyncProvider, useSync } from "@/providers/SyncProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCreateNote, useDeleteNote, useUpdateNote } from "./queries";
+import { saveToken } from "./storage";
 import { useVaultStore } from "./store";
 
 async function freshDb(): Promise<LensDB> {
@@ -135,5 +136,151 @@ describe("mutation hooks — offline dispatch", () => {
     const rows = await listPending(sharedDb, "v1");
     expect(rows[0].mutation.kind).toBe("update-note");
     sharedDb.close();
+  });
+});
+
+// These tests cover the try-with-timeout + fallback behavior added for
+// issue #61: in installed-PWA standalone mode `navigator.onLine` is
+// unreliable, so a "known-offline" fast-path isn't enough — a bounded
+// network attempt must also fall back to enqueue on failure.
+describe("mutation hooks — online with offline fallback", () => {
+  let db: LensDB;
+  let restoreOnline: () => void;
+
+  beforeEach(async () => {
+    db = await freshDb();
+    db.close();
+    localStorage.clear();
+    useVaultStore.setState({
+      vaults: {
+        v1: {
+          id: "v1",
+          url: "https://example.test",
+          name: "Test",
+          issuer: "https://example.test",
+          clientId: "cid",
+          scope: "full",
+          addedAt: "2026-01-01T00:00:00Z",
+          lastUsedAt: "2026-01-01T00:00:00Z",
+        },
+      },
+      activeVaultId: "v1",
+    });
+    // A token has to exist for useActiveVaultClient to build a real client,
+    // which is what exercises the timeout / network-error paths.
+    saveToken("v1", { accessToken: "tok", scope: "full", vault: "https://example.test" });
+    restoreOnline = setOnline(true);
+  });
+
+  afterEach(() => {
+    restoreOnline();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to enqueue when a network POST rejects while onLine is true", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new TypeError("Failed to fetch"))),
+    );
+
+    const { result } = renderHook(() => useCreateWithSync(), { wrapper: wrapper() });
+    await waitFor(() => {
+      expect(result.current.sync.db).not.toBeNull();
+    });
+
+    let created: unknown;
+    await act(async () => {
+      created = await result.current.mutation.mutateAsync({
+        content: "# from false-online",
+        path: "Inbox/fallback",
+      });
+    });
+    const note = created as { id: string };
+    expect(isLocalId(note.id)).toBe(true);
+
+    const sharedDb = await openLensDB();
+    await waitFor(async () => {
+      expect(await countPending(sharedDb, "v1")).toBeGreaterThan(0);
+    });
+    const rows = await listPending(sharedDb, "v1");
+    expect(rows[0].mutation.kind).toBe("create-note");
+    sharedDb.close();
+  });
+
+  it("falls back to enqueue when the network POST exceeds the offline timeout", async () => {
+    // Fetch never settles — only an AbortSignal abort will end it.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+      }),
+    );
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const { result } = renderHook(() => useCreateWithSync(), { wrapper: wrapper() });
+    await waitFor(() => {
+      expect(result.current.sync.db).not.toBeNull();
+    });
+
+    let createdPromise: Promise<unknown> | undefined;
+    act(() => {
+      createdPromise = result.current.mutation.mutateAsync({
+        content: "# slow",
+        path: "Inbox/slow",
+      });
+    });
+
+    // Advance past the 8s fallback window so the AbortController fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9_000);
+    });
+
+    const created = (await createdPromise) as { id: string };
+    expect(isLocalId(created.id)).toBe(true);
+
+    vi.useRealTimers();
+    const sharedDb = await openLensDB();
+    await waitFor(async () => {
+      expect(await countPending(sharedDb, "v1")).toBeGreaterThan(0);
+    });
+    sharedDb.close();
+  });
+});
+
+describe("mutation hooks — no offline queue available", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+
+  // When the sync DB never opens (private-mode IDB failure, or provider not
+  // mounted) AND there's no active vault client, a known-offline mutation
+  // can't enqueue and can't POST — it must throw so the UI surfaces the
+  // real failure instead of hanging on "Creating…".
+  function wrapperNoSync(): ({ children }: { children: ReactNode }) => ReactNode {
+    return ({ children }) => {
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      });
+      return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+    };
+  }
+
+  it("useCreateNote throws when offline, db is null, and no vault is active", async () => {
+    const restore = setOnline(false);
+    try {
+      const { result } = renderHook(() => useCreateNote(), { wrapper: wrapperNoSync() });
+      await expect(result.current.mutateAsync({ content: "# x", path: "Inbox/x" })).rejects.toThrow(
+        /No active vault/,
+      );
+    } finally {
+      restore();
+    }
   });
 });

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -162,11 +162,45 @@ export function useNote(id: string | undefined) {
   });
 }
 
-// When offline, enqueue instead of throwing. Call sites keep the same signature;
-// the returned Note is optimistic (local id + local timestamps) and is replaced
-// by the server-authored one when the drain lands.
+// Offline policy for mutations: we don't trust `navigator.onLine` alone. In the
+// installed-PWA standalone mode (caught 2026-04-21, issue #61) airplane mode
+// leaves `onLine === true` on Android Chrome, and a service worker can also
+// intercept the POST and never settle its fetch promise. So the policy is:
+//
+//   1. If we can see we're offline AND we have somewhere to enqueue, skip the
+//      network attempt entirely — cheap, no-wait enqueue.
+//   2. Otherwise try the network with a bounded AbortController timeout.
+//   3. If the network call rejects (error, abort, or timeout) and we have the
+//      sync DB available, enqueue the mutation and return the optimistic row.
+//   4. If there's nowhere to enqueue, re-throw — that's a genuine config fail.
+//
+// Callers keep the same signature; the returned Note is optimistic (local id +
+// local timestamps) and is replaced by the server-authored one when the drain
+// lands.
+const OFFLINE_FALLBACK_MS = 8_000;
+
 function isOffline(): boolean {
   return typeof navigator !== "undefined" && navigator.onLine === false;
+}
+
+async function withOfflineFallback<T>(
+  online: (signal: AbortSignal) => Promise<T>,
+  enqueueFallback: (() => Promise<T>) | null,
+): Promise<T> {
+  if (enqueueFallback && isOffline()) {
+    return enqueueFallback();
+  }
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(new Error("offline-timeout")), OFFLINE_FALLBACK_MS);
+  try {
+    return await online(ctrl.signal);
+  } catch (err) {
+    if (enqueueFallback) return enqueueFallback();
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function optimisticCreatedNote(payload: CreateNotePayload, localId: string): Note {
@@ -219,12 +253,17 @@ export function useUpdateNote(id: string | undefined) {
   return useMutation({
     mutationFn: async (payload: UpdateNotePayload) => {
       if (!id) throw new Error("No note id");
-      if (isOffline() && db && activeId) {
-        const existing = qc.getQueryData<Note>(["note", activeId, id]);
-        return enqueueUpdate(db, activeId, id, payload, existing);
-      }
-      if (!client) throw new Error("No active vault");
-      return client.updateNote(id, payload);
+      const fallback =
+        db && activeId
+          ? () => {
+              const existing = qc.getQueryData<Note>(["note", activeId, id]);
+              return enqueueUpdate(db, activeId, id, payload, existing);
+            }
+          : null;
+      return withOfflineFallback((signal) => {
+        if (!client) throw new Error("No active vault");
+        return client.updateNote(id, payload, { signal });
+      }, fallback);
     },
     onSuccess: (updated) => {
       qc.setQueryData(["note", activeId, id], updated);
@@ -246,11 +285,11 @@ export function useCreateNote() {
 
   return useMutation({
     mutationFn: async (payload: CreateNotePayload) => {
-      if (isOffline() && db && activeId) {
-        return enqueueCreate(db, activeId, payload);
-      }
-      if (!client) throw new Error("No active vault");
-      return client.createNote(payload);
+      const fallback = db && activeId ? () => enqueueCreate(db, activeId, payload) : null;
+      return withOfflineFallback((signal) => {
+        if (!client) throw new Error("No active vault");
+        return client.createNote(payload, { signal });
+      }, fallback);
     },
     onSuccess: (created) => {
       qc.setQueryData(["note", activeId, created.id], created);
@@ -373,13 +412,18 @@ export function useDeleteNote() {
 
   return useMutation({
     mutationFn: async (id: string) => {
-      if (isOffline() && db && activeId) {
-        await enqueue(db, { kind: "delete-note", targetId: id }, { vaultId: activeId });
+      const fallback =
+        db && activeId
+          ? async () => {
+              await enqueue(db, { kind: "delete-note", targetId: id }, { vaultId: activeId });
+              return id;
+            }
+          : null;
+      return withOfflineFallback(async (signal) => {
+        if (!client) throw new Error("No active vault");
+        await client.deleteNote(id, { signal });
         return id;
-      }
-      if (!client) throw new Error("No active vault");
-      await client.deleteNote(id);
-      return id;
+      }, fallback);
     },
     onSuccess: (id) => {
       qc.removeQueries({ queryKey: ["note", activeId, id] });


### PR DESCRIPTION
## Why

Aaron hit this on his phone 24h before launch (issue #61): installed PWA + airplane mode + tap Create → the button stays **"Creating…"** forever. Voice memos still work, online create still works, offline *navigation* still works — only offline text create was broken.

The root cause is that `navigator.onLine` is not a reliable signal inside an Android Chrome standalone PWA. Airplane mode on with `onLine === true` means the mutation's up-front "am I offline?" branch is skipped, so we fall through to `client.createNote()`, which posts and then waits forever for a response that will never arrive. A service worker that intercepts the POST for background-sync has the same visible effect. Either way: fetch promise never settles, React Query never flips `isPending` to false, user stares at a hung button.

## What changes

The up-front "decide by `navigator.onLine`" branch becomes a **try-with-timeout + graceful fallback to enqueue**. Applied to `useCreateNote`, `useUpdateNote`, and `useDeleteNote` via a shared `withOfflineFallback(online, enqueueFallback)` helper in `queries.ts`:

1. Known-offline AND we have somewhere to enqueue → enqueue immediately (cheap fast-path, unchanged semantics).
2. Otherwise try the network with an 8s `AbortController` timeout.
3. On any network-ish failure (error / abort / timeout) AND the sync DB is available → enqueue and return an optimistic Note.
4. No fallback possible → re-throw. That's a genuine "no active vault" config failure, not a network one, and should be surfaced rather than silently retried.

`VaultClient.createNote / updateNote / deleteNote` grow an `{ signal?: AbortSignal }` option so the mutation layer can cancel the in-flight fetch when the fallback timer fires.

Untouched on purpose: sync-drainer, MemoCapture, and `useLinkAttachment` (voice memos already work — the `link-attachment` row carries the transcribe flag and is queue-first by design).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 517/517 passing, including three new cases in `queries.offline.test.tsx`:
  - `navigator.onLine === true`, fetch rejects → enqueue path taken, optimistic local-id Note returned
  - `navigator.onLine === true`, fetch exceeds 8s timeout → AbortController fires, enqueue fallback kicks in
  - `db === null`, no active vault, offline → mutation throws (genuine failure, not a hang)
- [x] `bunx biome check` clean
- [ ] Follow-up manual verification on installed PWA + airplane mode once merged

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)