### PR TITLE
feat(lens): tag-first information architecture

### DIFF
--- a/src/app/routes/NoteEditor.tsx
+++ b/src/app/routes/NoteEditor.tsx
@@ -231,6 +231,13 @@ function EditorSurface({ note }: { note: Note }) {
         </div>
 
         <div className="mt-3 flex flex-col gap-2">
+          <TagEditor
+            tags={draft.tags}
+            input={tagInput}
+            onInputChange={setTagInput}
+            onAdd={addTag}
+            onRemove={removeTag}
+          />
           <label className="flex items-baseline gap-3 text-sm">
             <span className="shrink-0 text-xs uppercase tracking-wider text-fg-dim">Path</span>
             <input
@@ -245,13 +252,6 @@ function EditorSurface({ note }: { note: Note }) {
           {pathChanged ? (
             <p className="text-xs text-accent">Renaming moves the note — its id may change.</p>
           ) : null}
-          <TagEditor
-            tags={draft.tags}
-            input={tagInput}
-            onInputChange={setTagInput}
-            onAdd={addTag}
-            onRemove={removeTag}
-          />
         </div>
       </header>
 

--- a/src/app/routes/NoteView.test.tsx
+++ b/src/app/routes/NoteView.test.tsx
@@ -114,7 +114,7 @@ describe("NoteView route", () => {
     expect(screen.getByText("Teacher and builder.")).toBeInTheDocument();
     expect(screen.getByText("Canon note on Aaron.")).toBeInTheDocument();
     // Tag chip links to the filtered list
-    const tagChip = screen.getByRole("link", { name: "canon" });
+    const tagChip = screen.getByRole("link", { name: "#canon" });
     expect(tagChip).toHaveAttribute("href", "/?tag=canon");
     // Back link to / is present
     expect(screen.getByRole("link", { name: /all notes/i })).toBeInTheDocument();

--- a/src/app/routes/NoteView.tsx
+++ b/src/app/routes/NoteView.tsx
@@ -72,10 +72,11 @@ function NoteBody({ note }: { note: Note }) {
     <article className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem]">
       <div className="min-w-0">
         <header className="mb-6 border-b border-border pb-4">
-          <p className="font-mono text-xs text-fg-dim break-all">{label}</p>
-          <h1 className="mt-1 font-serif text-3xl tracking-tight">
+          <h1 className="font-serif text-3xl tracking-tight">
             {note.path ? pathTitle(note.path) : note.id}
           </h1>
+          {note.tags && note.tags.length > 0 ? <HeaderTags tags={note.tags} /> : null}
+          <p className="mt-2 font-mono text-xs text-fg-dim break-all">{label}</p>
           {summary ? <p className="mt-3 text-fg-muted">{summary}</p> : null}
           <div className="mt-4 flex flex-wrap items-center gap-2">
             <Link
@@ -109,7 +110,6 @@ function NoteBody({ note }: { note: Note }) {
 
       <aside className="space-y-6 text-sm lg:sticky lg:top-24 lg:self-start">
         <MetadataPanel note={note} />
-        {note.tags && note.tags.length > 0 ? <TagsPanel tags={note.tags} /> : null}
         {outbound.length > 0 ? (
           <LinksPanel title="Outbound" links={outbound} peer="target" />
         ) : null}
@@ -165,22 +165,19 @@ function Row({ label, value }: { label: string; value: React.ReactNode }) {
   );
 }
 
-function TagsPanel({ tags }: { tags: string[] }) {
+function HeaderTags({ tags }: { tags: string[] }) {
   return (
-    <section className="rounded-md border border-border bg-card p-4">
-      <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">Tags</h2>
-      <div className="flex flex-wrap gap-1.5">
-        {tags.map((t) => (
-          <Link
-            key={t}
-            to={`/?tag=${encodeURIComponent(t)}`}
-            className="rounded-full border border-border bg-bg/60 px-2 py-0.5 text-xs text-fg-dim hover:text-accent"
-          >
-            {t}
-          </Link>
-        ))}
-      </div>
-    </section>
+    <div className="mt-3 flex flex-wrap gap-1.5" aria-label="Tags">
+      {tags.map((t) => (
+        <Link
+          key={t}
+          to={`/?tag=${encodeURIComponent(t)}`}
+          className="rounded-full border border-accent/40 bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent hover:border-accent hover:bg-accent/20"
+        >
+          #{t}
+        </Link>
+      ))}
+    </div>
   );
 }
 

--- a/src/app/routes/Notes.test.tsx
+++ b/src/app/routes/Notes.test.tsx
@@ -213,6 +213,33 @@ describe("Notes route", () => {
     expect(firstRow.getByLabelText(/pinned/i)).toBeInTheDocument();
   });
 
+  it("renders a Pinned tags strip on the home view when the vault has pinned tags", async () => {
+    localStorage.setItem("lens:pinned-tags:dev", JSON.stringify(["daily", "idea"]));
+    installFetch({
+      notes: [],
+      tags: [
+        { name: "daily", count: 7 },
+        { name: "idea", count: 3 },
+      ],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    // Strip buttons render as pressable chips, not links, so tag filters apply
+    // in-place rather than routing away.
+    const dailyChip = await screen.findByRole("button", { name: /#daily/i });
+    expect(dailyChip).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(dailyChip);
+    await waitFor(() => expect(dailyChip).toHaveAttribute("aria-pressed", "true"));
+  });
+
+  it("omits the pinned-tags strip when no tags are pinned", async () => {
+    installFetch({ notes: [], tags: [{ name: "daily", count: 2 }] });
+    render(<Notes />, { wrapper: Wrapper });
+    await screen.findByRole("list", { name: "Notes" }).catch(() => null);
+    expect(screen.queryByRole("button", { name: /#daily/i })).not.toBeInTheDocument();
+  });
+
   it("hides archived notes by default and shows them when toggled on", async () => {
     installFetch({
       notes: [

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -19,6 +19,7 @@ import {
   isFilteringActive,
   useNotes,
   useNotesForPathTree,
+  usePinnedTags,
   useTagRoles,
   useTags,
   useUpdateNote,
@@ -46,6 +47,7 @@ const PRESET_SUBTITLES: Partial<Record<NotesPreset, string>> = {
 export function Notes({ preset }: { preset?: NotesPreset } = {}) {
   const activeVault = useVaultStore((s) => s.getActiveVault());
   const { roles } = useTagRoles(activeVault?.id ?? null);
+  const { pinnedTags } = usePinnedTags(activeVault?.id ?? null);
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Hydrate filter state from URL on mount and when the URL changes
@@ -239,6 +241,18 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
           </Link>
         </div>
       </header>
+
+      {!preset && pinnedTags.length > 0 ? (
+        <PinnedTagsStrip
+          pinnedTags={pinnedTags}
+          tagCounts={tags.data ?? []}
+          selected={selectedTags}
+          onPick={(name) => {
+            setPathPrefix("");
+            setSelectedTags((cur) => (cur.length === 1 && cur[0] === name ? [] : [name]));
+          }}
+        />
+      ) : null}
 
       <div className={preset ? "" : "grid gap-6 md:grid-cols-[14rem_1fr]"}>
         {!preset ? (
@@ -526,20 +540,20 @@ function NoteRow({
             </span>
             <span className="shrink-0 text-xs text-fg-dim">{relativeTime(stamp)}</span>
           </div>
-          {note.preview ? (
-            <p className="mt-1 truncate text-sm text-fg-muted">{note.preview}</p>
-          ) : null}
           {note.tags && note.tags.length > 0 ? (
-            <div className="mt-2 flex flex-wrap gap-1.5">
+            <div className="mt-1.5 flex flex-wrap gap-1.5">
               {note.tags.map((t) => (
                 <span
                   key={t}
-                  className="rounded-full border border-border bg-bg/60 px-2 py-0.5 text-xs text-fg-dim"
+                  className="rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-xs text-accent"
                 >
-                  {t}
+                  #{t}
                 </span>
               ))}
             </div>
+          ) : null}
+          {note.preview ? (
+            <p className="mt-1.5 truncate text-sm text-fg-muted">{note.preview}</p>
           ) : null}
         </Link>
         {quickTagSuggestions ? (
@@ -667,6 +681,48 @@ function QuickTagControl({
           ))}
         </ul>
       ) : null}
+    </div>
+  );
+}
+
+function PinnedTagsStrip({
+  pinnedTags,
+  tagCounts,
+  selected,
+  onPick,
+}: {
+  pinnedTags: string[];
+  tagCounts: TagSummary[];
+  selected: string[];
+  onPick: (name: string) => void;
+}) {
+  const countFor = (name: string) =>
+    tagCounts.find((t) => t.name.toLowerCase() === name.toLowerCase())?.count;
+  return (
+    <div className="mb-6 flex flex-wrap items-center gap-2">
+      <span className="text-xs uppercase tracking-wider text-fg-dim">Pinned tags</span>
+      {pinnedTags.map((name) => {
+        const active = selected.length === 1 && selected[0] === name;
+        const count = countFor(name);
+        return (
+          <button
+            key={name}
+            type="button"
+            onClick={() => onPick(name)}
+            className={
+              active
+                ? "inline-flex items-center gap-1 rounded-full border border-accent bg-accent px-2.5 py-1 text-xs font-medium text-white"
+                : "inline-flex items-center gap-1 rounded-full border border-accent/40 bg-accent/10 px-2.5 py-1 text-xs text-accent hover:border-accent hover:bg-accent/20"
+            }
+            aria-pressed={active}
+          >
+            <span>#{name}</span>
+            {count !== undefined ? (
+              <span className={active ? "text-white/80" : "text-accent/70"}>{count}</span>
+            ) : null}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/app/routes/Tags.test.tsx
+++ b/src/app/routes/Tags.test.tsx
@@ -222,6 +222,25 @@ describe("Tags route", () => {
     expect(screen.getByRole("button", { name: /merge into/i })).toBeEnabled();
   });
 
+  it("pin toggle writes the per-vault pinned-tags list to localStorage", async () => {
+    installFetch({ tags: [{ name: "daily", count: 4 }] });
+    render(
+      <Wrap>
+        <Tags />
+      </Wrap>,
+    );
+    const pin = await screen.findByRole("button", { name: /pin tag daily/i });
+    expect(pin).toHaveTextContent(/pin/i);
+    fireEvent.click(pin);
+    const unpin = await screen.findByRole("button", { name: /unpin tag daily/i });
+    expect(unpin).toHaveTextContent(/pinned/i);
+    const stored = JSON.parse(localStorage.getItem("lens:pinned-tags:v1") ?? "[]");
+    expect(stored).toEqual(["daily"]);
+    fireEvent.click(unpin);
+    await screen.findByRole("button", { name: /pin tag daily/i });
+    expect(JSON.parse(localStorage.getItem("lens:pinned-tags:v1") ?? "[]")).toEqual([]);
+  });
+
   it("shows the filtered-empty state when filter matches nothing", async () => {
     installFetch({ tags: [{ name: "canon", count: 1 }] });
     render(

--- a/src/app/routes/Tags.tsx
+++ b/src/app/routes/Tags.tsx
@@ -1,5 +1,5 @@
 import { TagRenameDialog } from "@/components/TagRenameDialog";
-import { useMergeTags, useRenameTag, useTags, useVaultStore } from "@/lib/vault";
+import { useMergeTags, usePinnedTags, useRenameTag, useTags, useVaultStore } from "@/lib/vault";
 import { VaultAuthError } from "@/lib/vault/client";
 import type { TagSummary } from "@/lib/vault/types";
 import { useSync } from "@/providers/SyncProvider";
@@ -12,6 +12,7 @@ export function Tags() {
   const activeVault = useVaultStore((s) => s.getActiveVault());
   const tags = useTags();
   const { isOnline } = useSync();
+  const { isPinned, togglePin } = usePinnedTags(activeVault?.id ?? null);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<SortMode>("count");
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -113,6 +114,8 @@ export function Tags() {
               selected={selected.has(t.name)}
               onToggle={() => toggleSelected(t.name)}
               onRename={() => setRenameTarget(t.name)}
+              pinned={isPinned(t.name)}
+              onTogglePin={() => togglePin(t.name)}
               offline={offline}
             />
           ))}
@@ -165,12 +168,16 @@ function TagRow({
   selected,
   onToggle,
   onRename,
+  pinned,
+  onTogglePin,
   offline,
 }: {
   tag: TagSummary;
   selected: boolean;
   onToggle(): void;
   onRename(): void;
+  pinned: boolean;
+  onTogglePin(): void;
   offline: boolean;
 }) {
   return (
@@ -189,6 +196,20 @@ function TagRow({
         <span className="font-mono">#{tag.name}</span>
         <span className="text-xs text-fg-dim">{tag.count}</span>
       </Link>
+      <button
+        type="button"
+        onClick={onTogglePin}
+        className={
+          pinned
+            ? "text-xs font-medium text-accent hover:text-accent-hover"
+            : "text-xs text-fg-muted hover:text-accent"
+        }
+        aria-label={pinned ? `Unpin tag ${tag.name}` : `Pin tag ${tag.name}`}
+        aria-pressed={pinned}
+        title={pinned ? "Pinned to home strip — click to unpin" : "Pin to home strip"}
+      >
+        {pinned ? "★ Pinned" : "☆ Pin"}
+      </button>
       <button
         type="button"
         onClick={onRename}

--- a/src/lib/quick-switch/results.test.ts
+++ b/src/lib/quick-switch/results.test.ts
@@ -63,14 +63,29 @@ describe("computeResults", () => {
     expect(results[0]?.kind === "note" && results[0].id).toBe("titleWins");
   });
 
-  it("includes tag matches below note matches", () => {
+  it("ranks matching tags above notes that share the query (tag-first)", () => {
     const results = computeResults({
       query: "daily",
       notes: [note("n1", { path: "Daily.md" })],
       tags: [{ name: "daily", count: 12 }],
       recents: [],
     });
-    expect(results.some((r) => r.kind === "tag" && r.name === "daily")).toBe(true);
+    const firstNonCommand = results.find((r) => r.kind !== "command");
+    expect(firstNonCommand?.kind).toBe("tag");
+    expect(firstNonCommand?.kind === "tag" && firstNonCommand.name).toBe("daily");
+  });
+
+  it("interleaves commands and notes by score below the tag band", () => {
+    const results = computeResults({
+      query: "graph",
+      notes: [note("n1", { path: "graphs.md" })],
+      tags: [{ name: "graph", count: 4 }],
+      recents: [],
+    });
+    expect(results[0]?.kind).toBe("tag");
+    const belowTags = results.filter((r) => r.kind !== "tag");
+    expect(belowTags.some((r) => r.kind === "command" && r.id === "graph")).toBe(true);
+    expect(belowTags.some((r) => r.kind === "note")).toBe(true);
   });
 
   it("in command mode (> prefix) surfaces only commands", () => {

--- a/src/lib/quick-switch/results.ts
+++ b/src/lib/quick-switch/results.ts
@@ -3,11 +3,13 @@ import { fuzzyScore } from "./fuzzy";
 import type { RecentEntry } from "./recents";
 import { noteTitle } from "./title";
 
-// The switcher returns a heterogeneous list: commands first when a query
-// matches one, then notes by score, then a trailing tag section for pure-tag
-// jumps. Keeping all three in one ordered list (rather than separate sections
-// on the same view) keeps keyboard nav with ↑/↓/Enter trivial — the selected
-// index always points at a real entry.
+// The switcher returns a heterogeneous list. In a tag-first IA a tag is a
+// whole view — jumping to #daily is usually a stronger intent than opening a
+// single note whose title happens to contain "daily" — so matching tags
+// always lead. Commands and notes then interleave by fuzzy score, so a
+// strong command match ("new", "graph") can still beat weaker note hits, and
+// vice versa. Keeping all three in one ordered list keeps keyboard nav with
+// ↑/↓/Enter trivial — the selected index always points at a real entry.
 
 export type QuickSwitchEntry =
   | { kind: "note"; id: string; title: string; path?: string; score: number }
@@ -219,7 +221,7 @@ export function computeResults(inputs: Inputs): QuickSwitchEntry[] {
     ];
   });
 
-  return [...commandMatches, ...noteMatches, ...tagMatches]
-    .sort((a, b) => b.score - a.score)
-    .slice(0, MAX_RESULTS);
+  const sortedTags = [...tagMatches].sort((a, b) => b.score - a.score);
+  const rest = [...commandMatches, ...noteMatches].sort((a, b) => b.score - a.score);
+  return [...sortedTags, ...rest].slice(0, MAX_RESULTS);
 }

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -5,6 +5,7 @@ export * from "./neighborhood";
 export * from "./note-query";
 export * from "./oauth";
 export * from "./parachute-json";
+export * from "./pinned-tags";
 export * from "./pkce";
 export * from "./probe";
 export * from "./queries";

--- a/src/lib/vault/pinned-tags.test.ts
+++ b/src/lib/vault/pinned-tags.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deletePinnedTags, loadPinnedTags, savePinnedTags } from "./pinned-tags";
+
+describe("pinned tags storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns empty list when nothing is stored", () => {
+    expect(loadPinnedTags("v1")).toEqual([]);
+  });
+
+  it("round-trips an array of tag names", () => {
+    savePinnedTags("v1", ["captured", "project", "person"]);
+    expect(loadPinnedTags("v1")).toEqual(["captured", "project", "person"]);
+  });
+
+  it("scopes storage by vaultId", () => {
+    savePinnedTags("v1", ["one"]);
+    savePinnedTags("v2", ["two"]);
+    expect(loadPinnedTags("v1")).toEqual(["one"]);
+    expect(loadPinnedTags("v2")).toEqual(["two"]);
+  });
+
+  it("strips leading # and trims whitespace on save", () => {
+    savePinnedTags("v1", ["  #captured  ", "#project", " people "]);
+    expect(loadPinnedTags("v1")).toEqual(["captured", "project", "people"]);
+  });
+
+  it("dedupes case-insensitively, preserving first form", () => {
+    savePinnedTags("v1", ["Project", "project", "PROJECT"]);
+    expect(loadPinnedTags("v1")).toEqual(["Project"]);
+  });
+
+  it("drops blank entries", () => {
+    savePinnedTags("v1", ["", "  ", "#", "ok"]);
+    expect(loadPinnedTags("v1")).toEqual(["ok"]);
+  });
+
+  it("returns empty on malformed JSON", () => {
+    localStorage.setItem("lens:pinned-tags:v1", "not-json{");
+    expect(loadPinnedTags("v1")).toEqual([]);
+  });
+
+  it("returns empty on non-array stored value", () => {
+    localStorage.setItem("lens:pinned-tags:v1", JSON.stringify({ tag: "x" }));
+    expect(loadPinnedTags("v1")).toEqual([]);
+  });
+
+  it("deletePinnedTags removes the entry", () => {
+    savePinnedTags("v1", ["captured"]);
+    deletePinnedTags("v1");
+    expect(loadPinnedTags("v1")).toEqual([]);
+  });
+});

--- a/src/lib/vault/pinned-tags.ts
+++ b/src/lib/vault/pinned-tags.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from "react";
+
+// Per-vault list of "pinned" tag names. The Notes home renders these as a
+// quick-filter strip; tapping one narrows the list to that tag. Stored in
+// localStorage so the strip survives reloads without a roundtrip to the vault.
+//
+// TODO(lens-settings): once the lens-settings tentacle lands its
+// `useVaultSettings` hook with a `pinnedTags` field, migrate call sites from
+// `usePinnedTags(vaultId)` to `useVaultSettings(vaultId).pinnedTags` and
+// delete this file. Keeping the storage key narrow (`lens:pinned-tags:*`,
+// shape `string[]`) so the move is mechanical.
+
+const STORAGE_PREFIX = "lens:pinned-tags:";
+
+function keyFor(vaultId: string): string {
+  return STORAGE_PREFIX + vaultId;
+}
+
+function normalize(name: string): string {
+  return name.trim().replace(/^#/, "");
+}
+
+function dedupe(names: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of names) {
+    const n = normalize(raw);
+    if (!n) continue;
+    const key = n.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(n);
+  }
+  return out;
+}
+
+export function loadPinnedTags(vaultId: string): string[] {
+  try {
+    const raw = localStorage.getItem(keyFor(vaultId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return dedupe(parsed.filter((x): x is string => typeof x === "string"));
+  } catch {
+    return [];
+  }
+}
+
+export function savePinnedTags(vaultId: string, tags: string[]): void {
+  try {
+    localStorage.setItem(keyFor(vaultId), JSON.stringify(dedupe(tags)));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+export function deletePinnedTags(vaultId: string): void {
+  try {
+    localStorage.removeItem(keyFor(vaultId));
+  } catch {
+    // storage unavailable — best-effort only
+  }
+}
+
+// Re-reads on mount and on vaultId change. Returns `[]` (not null) so call
+// sites can map without null-checks.
+export function usePinnedTags(vaultId: string | null): {
+  pinnedTags: string[];
+  setPinnedTags: (next: string[]) => void;
+  togglePin: (tag: string) => void;
+  isPinned: (tag: string) => boolean;
+} {
+  const [pinnedTags, setState] = useState<string[]>(() => (vaultId ? loadPinnedTags(vaultId) : []));
+
+  useEffect(() => {
+    setState(vaultId ? loadPinnedTags(vaultId) : []);
+  }, [vaultId]);
+
+  const setPinnedTags = useCallback(
+    (next: string[]) => {
+      if (!vaultId) return;
+      const cleaned = dedupe(next);
+      savePinnedTags(vaultId, cleaned);
+      setState(cleaned);
+    },
+    [vaultId],
+  );
+
+  const togglePin = useCallback(
+    (tag: string) => {
+      if (!vaultId) return;
+      const t = normalize(tag);
+      if (!t) return;
+      setState((prev) => {
+        const has = prev.some((p) => p.toLowerCase() === t.toLowerCase());
+        const next = has ? prev.filter((p) => p.toLowerCase() !== t.toLowerCase()) : [...prev, t];
+        savePinnedTags(vaultId, next);
+        return next;
+      });
+    },
+    [vaultId],
+  );
+
+  const isPinned = useCallback(
+    (tag: string) => {
+      const t = normalize(tag).toLowerCase();
+      return pinnedTags.some((p) => p.toLowerCase() === t);
+    },
+    [pinnedTags],
+  );
+
+  return { pinnedTags, setPinnedTags, togglePin, isPinned };
+}


### PR DESCRIPTION
## Summary

Lens's home view, note view, editor, and quick-switch were designed around **paths** as the primary organizing axis, with tags relegated to a collapsible filter panel and thin chips at the bottom of a note row. This PR re-weights the IA so tags are first-class everywhere they show up, to match how Aaron (and likely most users who pick Lens) actually file notes.

## What changes

- **Home (Notes)**: a new Pinned tags strip at the top of the notes list lets you toggle a tag filter in-place from chips like `#daily`, `#canon`. Tag chips on each row move above the preview and wear accent-tinted styling with a `#` prefix so they read as tags at a glance, not like generic metadata pills.
- **NoteView**: tags lift out of the sidebar and sit as header chips under the title, so the first thing a reader sees under the h1 is "what is this?" The file path demotes to subtitle metadata.
- **NoteEditor**: the TagEditor swaps above the Path input. Filing a note now leads with tags; renaming/moving comes second.
- **Quick switch**: matching tags always lead the results list. Commands and notes still interleave by fuzzy score below the tag band, so a strong command match (e.g. "new", "graph") can outrank weaker note hits.
- **Tags route**: each row gets a Pin/Unpin toggle. Pinning a tag makes it show up in the home strip.

## Storage

Pinned state lives in `localStorage` per vault under `lens:pinned-tags:<vaultId>` and mirrors the existing `tag-roles` per-vault-settings shape. Once `useVaultSettings()` adds a `pinnedTags` field (lens-settings tentacle's area), this can migrate to vault-note-backed storage with no UI changes.

## What's explicitly not in scope

- Dropping paths. The path tree, prefix filter, and path-in-metadata all remain.
- Tag renaming UI changes, new tag management, wikilink behavior, editor content area.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 530 passing (up from 527; added 3 tests: pinned-tags strip render + filter, pinned-tags strip omission, Tags pin-toggle persistence)
- [x] `bun run lint` — clean on touched files (one pre-existing drift in `TranscriptionStatus.test.tsx` is unrelated and not modified here)
- [ ] Manual: open home on a vault with no pinned tags → strip absent; pin `#daily` from the Tags route → strip appears; click it → note list filters; click it again → filter clears
- [ ] Manual: open a tagged note → tag chips render under the title, not in the sidebar
- [ ] Manual: edit a note → TagEditor sits above the Path field
- [ ] Manual: cmd-K, type a query that matches a tag and a note → tag surfaces first

🤖 Generated with [Claude Code](https://claude.com/claude-code)