### PR TITLE
hotfix: unblock tsc strict on new queue.test mock.calls tuples

### DIFF
--- a/src/lib/sync/queue.test.ts
+++ b/src/lib/sync/queue.test.ts
@@ -481,7 +481,7 @@ describe("drain — update-settings (merge-on-409 invariant)", () => {
     const out = await drain({ db, client, vaultId: "v1", blobStore: createIdbBlobStore(db) });
     expect(out.drained).toBe(1);
     expect(createNote).toHaveBeenCalledOnce();
-    const arg = createNote.mock.calls[0]?.[0] as unknown as {
+    const arg = (createNote.mock.calls as unknown as unknown[][])[0]?.[0] as {
       path: string;
       metadata: { lens: { tagRoles: { pinned: string } } };
     };
@@ -585,7 +585,7 @@ describe("drain — update-settings (merge-on-409 invariant)", () => {
     expect(out.drained).toBe(1);
     // 3 merge-retries + 1 initial = 4 conditional PATCHes, +1 forced PATCH.
     expect(updateNote.mock.calls.length).toBe(5);
-    const lastCall = updateNote.mock.calls.at(-1)! as [
+    const lastCall = (updateNote.mock.calls as unknown as unknown[][]).at(-1)! as [
       string,
       { metadata: unknown; if_updated_at?: string; force?: boolean },
     ];


### PR DESCRIPTION
## Summary
- Two mock.calls indexing sites in queue.test.ts error under tsc strict (vi.fn inferred `[]` param tuple → indexing fails). Widen via `unknown[][]` cast. Test behavior unchanged.

## Why
PR #64 merged with the new tests; `bun run build` (runs `tsc -b` before vite) now errors and dist rebuilds fail on main. Unblocking the Aaron-facing PWA refresh 24h before launch.

## Test plan
- [x] `bun run build` succeeds (dist rebuilds with sw.js + workbox + manifests)
- [x] Tests still exercise the same assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)