### PR TITLE
feat(lens): IA v2 — tag sidebar, mobile tabs, mobile visual pass

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,3 +1,4 @@
+import { BottomTabBar } from "@/components/BottomTabBar";
 import { Header } from "@/components/Header";
 import { QuickSwitchMount } from "@/components/QuickSwitchMount";
 import { Toaster } from "@/components/Toaster";
@@ -47,7 +48,7 @@ export function App() {
     <QueryProvider>
       <SyncProvider>
         <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "") || undefined}>
-          <div className="min-h-dvh bg-bg text-fg">
+          <div className="min-h-dvh bg-bg text-fg pb-16 md:pb-0">
             <Toaster />
             <UpdateBanner />
             <Header />
@@ -77,6 +78,7 @@ export function App() {
                 <Route path="*" element={<Navigate to="/" replace />} />
               </Routes>
             </main>
+            <BottomTabBar />
             <footer className="mx-auto max-w-5xl px-6 py-10 text-center text-sm text-fg-dim">
               <p>
                 Part of the{" "}

--- a/src/app/routes/Activity.tsx
+++ b/src/app/routes/Activity.tsx
@@ -30,10 +30,10 @@ export function Activity() {
   if (!activeVault) return <Navigate to="/" replace />;
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-10">
-      <header className="mb-6">
+    <div className="mx-auto max-w-3xl px-4 py-6 md:px-6 md:py-10">
+      <header className="mb-5 md:mb-6">
         <p className="text-xs uppercase tracking-wider text-fg-dim">Activity</p>
-        <h1 className="font-serif text-3xl tracking-tight">Recent changes</h1>
+        <h1 className="font-serif text-2xl tracking-tight md:text-3xl">Recent changes</h1>
         <p className="mt-1 text-sm text-fg-muted">
           Last 30 days, newest first. Deletions aren't tracked yet.
         </p>

--- a/src/app/routes/Calendar.tsx
+++ b/src/app/routes/Calendar.tsx
@@ -51,7 +51,7 @@ export function Calendar() {
   const isCurrent = `${parsed.year}-${pad2(parsed.month)}` === currentKey;
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-10">
+    <div className="mx-auto max-w-4xl px-4 py-6 md:px-6 md:py-10">
       <header className="mb-6 flex flex-wrap items-baseline justify-between gap-3">
         <div>
           <p className="text-xs uppercase tracking-wider text-fg-dim">Calendar</p>

--- a/src/app/routes/Capture.tsx
+++ b/src/app/routes/Capture.tsx
@@ -34,7 +34,7 @@ export function Capture() {
   if (!activeVault) return <Navigate to="/" replace />;
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-8">
+    <div className="mx-auto max-w-2xl px-4 py-5 md:px-6 md:py-8">
       <div
         role="tablist"
         aria-label="Capture mode"

--- a/src/app/routes/MemoCapture.tsx
+++ b/src/app/routes/MemoCapture.tsx
@@ -359,7 +359,7 @@ export function MemoCapture({ embedded = false }: { embedded?: boolean } = {}) {
 
   if (embedded) return inner;
   return (
-    <div className="mx-auto max-w-2xl px-6 py-8">
+    <div className="mx-auto max-w-2xl px-4 py-5 md:px-6 md:py-8">
       <nav className="mb-4 text-sm text-fg-dim">
         <Link to="/" className="hover:text-accent">
           ← All notes

--- a/src/app/routes/NoteEditor.tsx
+++ b/src/app/routes/NoteEditor.tsx
@@ -26,7 +26,7 @@ export function NoteEditor() {
   if (!activeVault) return <Navigate to="/" replace />;
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-8">
+    <div className="mx-auto max-w-6xl px-4 py-5 md:px-6 md:py-8">
       <nav className="mb-4 text-sm text-fg-dim">
         <Link
           to={decodedId ? `/n/${encodeURIComponent(decodedId)}` : "/"}

--- a/src/app/routes/NoteNew.tsx
+++ b/src/app/routes/NoteNew.tsx
@@ -138,7 +138,7 @@ export function NoteNew() {
   } as Note);
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-8">
+    <div className="mx-auto max-w-6xl px-4 py-5 md:px-6 md:py-8">
       <nav className="mb-4 text-sm text-fg-dim">
         <Link to="/" className="hover:text-accent">
           ← All notes

--- a/src/app/routes/NoteView.tsx
+++ b/src/app/routes/NoteView.tsx
@@ -24,7 +24,7 @@ export function NoteView() {
   if (!activeVault) return <Navigate to="/" replace />;
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-10">
+    <div className="mx-auto max-w-6xl px-4 py-6 md:px-6 md:py-10">
       <nav className="mb-6 text-sm text-fg-dim">
         <Link to="/" className="hover:text-accent">
           ← All notes

--- a/src/app/routes/Notes.test.tsx
+++ b/src/app/routes/Notes.test.tsx
@@ -60,6 +60,17 @@ function Wrapper({ children }: { children: ReactNode }) {
   );
 }
 
+function openFoldersAccordion() {
+  const details = document
+    .getElementById("notes-sidebar")
+    ?.querySelector("details") as HTMLDetailsElement | null;
+  if (!details) throw new Error("Folders accordion not found");
+  act(() => {
+    details.open = true;
+    details.dispatchEvent(new Event("toggle"));
+  });
+}
+
 function lastNotesUrl(fetchImpl: ReturnType<typeof installFetch>): string {
   // The saved-views sidebar also queries /api/notes (tag=view & views path
   // prefix). Filter those out so assertions target the primary list query.
@@ -309,6 +320,10 @@ describe("Notes route", () => {
 
     render(<Notes />, { wrapper: Wrapper });
 
+    // Folders accordion is collapsed by default — the tree is lazy-fetched
+    // on open.
+    await screen.findByText("A/note-0.md");
+    openFoldersAccordion();
     expect(await screen.findByRole("complementary", { name: /path tree/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^A\b/ })).toBeInTheDocument();
   });
@@ -347,6 +362,8 @@ describe("Notes route", () => {
     });
 
     render(<Notes />, { wrapper: Wrapper });
+    await screen.findByText("Solo/note.md");
+    openFoldersAccordion();
     expect(await screen.findByRole("complementary", { name: /path tree/i })).toBeInTheDocument();
   });
 
@@ -505,6 +522,10 @@ describe("Notes route", () => {
 
     render(<Notes />, { wrapper: Wrapper });
 
+    // Folders accordion starts closed; open it so the tree query fires.
+    await screen.findByText("Canon/note-0.md");
+    openFoldersAccordion();
+
     const canonNode = await screen.findByRole("button", { name: /^Canon\b/ });
     fireEvent.click(canonNode);
 
@@ -513,6 +534,38 @@ describe("Notes route", () => {
     });
     await waitFor(() => {
       expect(lastNotesUrl(fetchImpl)).toContain("path_prefix=Canon");
+    });
+  });
+
+  it("does not fetch the path-tree query while the Folders accordion is closed", async () => {
+    const fetchImpl = installFetch({
+      notes: ["A", "B", "C", "D", "E"].map((root, i) => ({
+        id: `n${i}`,
+        path: `${root}/note-${i}.md`,
+        createdAt: "2026-04-18T10:00:00.000Z",
+        tags: [],
+      })),
+      tags: [],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    // Wait for the main notes list to settle so we know queries had a chance.
+    await screen.findByText("A/note-0.md");
+
+    const pathTreeCalls = fetchImpl.mock.calls
+      .map((c) => String(c[0]))
+      .filter((u) => u.includes("/api/notes") && u.includes("limit=5000"));
+    expect(pathTreeCalls.length).toBe(0);
+
+    // Opening the accordion should trigger the fetch.
+    openFoldersAccordion();
+
+    await waitFor(() => {
+      const after = fetchImpl.mock.calls
+        .map((c) => String(c[0]))
+        .filter((u) => u.includes("/api/notes") && u.includes("limit=5000"));
+      expect(after.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/app/routes/Notes.test.tsx
+++ b/src/app/routes/Notes.test.tsx
@@ -226,8 +226,10 @@ describe("Notes route", () => {
     render(<Notes />, { wrapper: Wrapper });
 
     // Strip buttons render as pressable chips, not links, so tag filters apply
-    // in-place rather than routing away.
-    const dailyChip = await screen.findByRole("button", { name: /#daily/i });
+    // in-place rather than routing away. Sidebar TagBrowser also renders a
+    // #daily button — scope the query to the strip explicitly.
+    const strip = await screen.findByRole("navigation", { name: /pinned tags/i });
+    const dailyChip = within(strip).getByRole("button", { name: /#daily/i });
     expect(dailyChip).toHaveAttribute("aria-pressed", "false");
     fireEvent.click(dailyChip);
     await waitFor(() => expect(dailyChip).toHaveAttribute("aria-pressed", "true"));
@@ -237,7 +239,8 @@ describe("Notes route", () => {
     installFetch({ notes: [], tags: [{ name: "daily", count: 2 }] });
     render(<Notes />, { wrapper: Wrapper });
     await screen.findByRole("list", { name: "Notes" }).catch(() => null);
-    expect(screen.queryByRole("button", { name: /#daily/i })).not.toBeInTheDocument();
+    // The sidebar tag browser renders #daily too — scope to the strip.
+    expect(screen.queryByRole("navigation", { name: /pinned tags/i })).not.toBeInTheDocument();
   });
 
   it("hides archived notes by default and shows them when toggled on", async () => {
@@ -455,6 +458,38 @@ describe("Notes route", () => {
     });
     expect(patchCalls[0]?.url).toMatch(/\/api\/notes\/n1$/);
     expect(patchCalls[0]?.body).toEqual({ tags: { add: ["project"] } });
+  });
+
+  it("sidebar renders the tag browser above the collapsed Folders details", async () => {
+    installFetch({
+      notes: ["A", "B", "C", "D", "E"].map((root, i) => ({
+        id: `n${i}`,
+        path: `${root}/note-${i}.md`,
+        createdAt: "2026-04-18T10:00:00.000Z",
+        tags: [],
+      })),
+      tags: [{ name: "idea", count: 2 }],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    const tagNav = await screen.findByRole("navigation", { name: /browse by tag/i });
+    const sidebar = document.getElementById("notes-sidebar");
+    expect(sidebar).not.toBeNull();
+    expect(sidebar?.contains(tagNav)).toBe(true);
+    // Folders is now a collapsed <details>. Waits for the async path-tree
+    // fetch to settle before the wrapper is mounted.
+    const details = await waitFor(() => {
+      const d = (sidebar as HTMLElement).querySelector("details");
+      expect(d).not.toBeNull();
+      return d as HTMLDetailsElement;
+    });
+    expect(details.open).toBe(false);
+    const summary = details.querySelector("summary");
+    expect(summary?.textContent).toContain("Folders");
+    // Tag-browser nav appears earlier in document order than the Folders group.
+    const comparison = tagNav.compareDocumentPosition(details);
+    expect(comparison & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("clicking a tree folder writes path_prefix to the URL", async () => {

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -145,8 +145,13 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
   // Path tree: independent capped fetch (separate from the filtered list) so
   // the tree stays stable as the user narrows results. Disabled on preset
   // routes (no sidebar) and when the user has set the mode to `never`.
+  // Only fetches once the Folders accordion is opened — demoting it into a
+  // collapsed <details> would otherwise fire the 5000-note query on every
+  // Notes load, which is worst-of-both-worlds (hidden but still expensive).
   const { mode: pathTreeMode } = usePathTreeMode(activeVault?.id ?? null);
-  const treeEnabled = !preset && pathTreeMode !== "never";
+  const [foldersOpen, setFoldersOpen] = useState(false);
+  const showFoldersAccordion = !preset && pathTreeMode !== "never";
+  const treeEnabled = showFoldersAccordion && foldersOpen;
   const treeNotes = useNotesForPathTree(treeEnabled);
   const treePaths = useMemo(() => (treeNotes.data ?? []).map((n) => n.path), [treeNotes.data]);
   const showPathTree =
@@ -292,8 +297,12 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
                 isPending={savedViews.isPending}
                 error={savedViews.error}
               />
-              {showPathTree ? (
-                <details className="group">
+              {showFoldersAccordion ? (
+                <details
+                  className="group"
+                  open={foldersOpen}
+                  onToggle={(e) => setFoldersOpen(e.currentTarget.open)}
+                >
                   <summary className="flex cursor-pointer list-none items-center justify-between rounded-md px-1 py-1 text-xs uppercase tracking-wider text-fg-dim hover:text-accent">
                     <span>Folders</span>
                     <span
@@ -304,12 +313,20 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
                     </span>
                   </summary>
                   <div className="mt-2">
-                    <PathTree
-                      paths={treePaths}
-                      vaultId={activeVault.id}
-                      currentPrefix={pathPrefix}
-                      onSelect={(p) => setPathPrefix(p)}
-                    />
+                    {showPathTree ? (
+                      <PathTree
+                        paths={treePaths}
+                        vaultId={activeVault.id}
+                        currentPrefix={pathPrefix}
+                        onSelect={(p) => setPathPrefix(p)}
+                      />
+                    ) : treeNotes.isLoading ? (
+                      <p className="px-1 text-xs text-fg-dim">Loading…</p>
+                    ) : (
+                      <p className="px-1 text-xs text-fg-dim">
+                        Not enough folder variety to show a tree yet.
+                      </p>
+                    )}
                   </div>
                 </details>
               ) : null}
@@ -553,7 +570,7 @@ function NoteRow({
       <div className="flex items-stretch">
         <Link
           to={`/n/${encodeURIComponent(note.id)}`}
-          className="block flex-1 min-w-0 px-3 py-2.5 hover:bg-bg/60 focus:bg-bg/60 focus:outline-none md:px-4 md:py-3"
+          className="block flex-1 min-w-0 min-h-11 px-3 py-2.5 hover:bg-bg/60 focus:bg-bg/60 focus:outline-none md:min-h-0 md:px-4 md:py-3"
         >
           <div className="flex items-baseline justify-between gap-4">
             <span className="flex min-w-0 items-baseline gap-1.5">

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -1,4 +1,5 @@
 import { PathTree } from "@/components/PathTree";
+import { TagBrowser } from "@/components/TagBrowser";
 import { normalizeTag } from "@/components/TagEditor";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { meetsAutoThreshold, usePathTreeMode } from "@/lib/path-tree";
@@ -207,11 +208,11 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
   const filteringActive = isFiltersNonEmpty(currentFilters);
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-10">
-      <header className="mb-6 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-3">
+    <div className="mx-auto max-w-6xl px-4 py-6 md:px-6 md:py-10">
+      <header className="mb-5 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-3 md:mb-6">
         <div>
           <p className="text-xs uppercase tracking-wider text-fg-dim">{activeVault.name}</p>
-          <h1 className="font-serif text-3xl tracking-tight">{title}</h1>
+          <h1 className="font-serif text-2xl tracking-tight md:text-3xl">{title}</h1>
           {subtitle ? <p className="mt-1 text-sm text-fg-muted">{subtitle}</p> : null}
         </div>
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
@@ -273,20 +274,45 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
               id="notes-sidebar"
               className={`space-y-6 md:sticky md:top-6 md:self-start ${sidebarOpen ? "" : "hidden md:block"}`}
             >
-              {showPathTree ? (
-                <PathTree
-                  paths={treePaths}
-                  vaultId={activeVault.id}
-                  currentPrefix={pathPrefix}
-                  onSelect={(p) => setPathPrefix(p)}
-                />
-              ) : null}
+              <TagBrowser
+                tags={tags.data ?? []}
+                pinnedTags={pinnedTags}
+                selected={selectedTags}
+                onToggle={(name) =>
+                  setSelectedTags((cur) =>
+                    cur.includes(name) ? cur.filter((t) => t !== name) : [...cur, name],
+                  )
+                }
+                onClear={() => setSelectedTags([])}
+                isLoading={tags.isPending}
+              />
               <BuiltInViewsSidebar />
               <SavedViewsSidebar
                 views={savedViews.data}
                 isPending={savedViews.isPending}
                 error={savedViews.error}
               />
+              {showPathTree ? (
+                <details className="group">
+                  <summary className="flex cursor-pointer list-none items-center justify-between rounded-md px-1 py-1 text-xs uppercase tracking-wider text-fg-dim hover:text-accent">
+                    <span>Folders</span>
+                    <span
+                      aria-hidden="true"
+                      className="font-mono text-xs transition-transform group-open:rotate-90"
+                    >
+                      ▸
+                    </span>
+                  </summary>
+                  <div className="mt-2">
+                    <PathTree
+                      paths={treePaths}
+                      vaultId={activeVault.id}
+                      currentPrefix={pathPrefix}
+                      onSelect={(p) => setPathPrefix(p)}
+                    />
+                  </div>
+                </details>
+              ) : null}
             </div>
           </div>
         ) : null}
@@ -527,7 +553,7 @@ function NoteRow({
       <div className="flex items-stretch">
         <Link
           to={`/n/${encodeURIComponent(note.id)}`}
-          className="block flex-1 min-w-0 px-4 py-3 hover:bg-bg/60 focus:bg-bg/60 focus:outline-none"
+          className="block flex-1 min-w-0 px-3 py-2.5 hover:bg-bg/60 focus:bg-bg/60 focus:outline-none md:px-4 md:py-3"
         >
           <div className="flex items-baseline justify-between gap-4">
             <span className="flex min-w-0 items-baseline gap-1.5">
@@ -699,7 +725,7 @@ function PinnedTagsStrip({
   const countFor = (name: string) =>
     tagCounts.find((t) => t.name.toLowerCase() === name.toLowerCase())?.count;
   return (
-    <div className="mb-6 flex flex-wrap items-center gap-2">
+    <nav aria-label="Pinned tags" className="mb-6 flex flex-wrap items-center gap-2">
       <span className="text-xs uppercase tracking-wider text-fg-dim">Pinned tags</span>
       {pinnedTags.map((name) => {
         const active = selected.length === 1 && selected[0] === name;
@@ -723,7 +749,7 @@ function PinnedTagsStrip({
           </button>
         );
       })}
-    </div>
+    </nav>
   );
 }
 

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -20,14 +20,14 @@ export function Settings() {
   if (!activeVault) return <Navigate to="/" replace />;
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-12">
+    <div className="mx-auto max-w-2xl px-4 py-7 md:px-6 md:py-12">
       <header className="mb-8">
         <nav className="mb-3 text-sm text-fg-dim">
           <Link to="/" className="hover:text-accent">
             ← Home
           </Link>
         </nav>
-        <h1 className="font-serif text-3xl tracking-tight">Settings</h1>
+        <h1 className="font-serif text-2xl tracking-tight md:text-3xl">Settings</h1>
         <p className="mt-1 text-sm text-fg-muted">
           Configuring <span className="text-fg">{activeVault.name}</span>.
         </p>

--- a/src/app/routes/Tags.tsx
+++ b/src/app/routes/Tags.tsx
@@ -45,11 +45,11 @@ export function Tags() {
   const offline = !isOnline;
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-10">
-      <header className="mb-6 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-3">
+    <div className="mx-auto max-w-4xl px-4 py-6 md:px-6 md:py-10">
+      <header className="mb-5 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-3 md:mb-6">
         <div>
           <p className="text-xs uppercase tracking-wider text-fg-dim">{activeVault.name}</p>
-          <h1 className="font-serif text-3xl tracking-tight">Tags</h1>
+          <h1 className="font-serif text-2xl tracking-tight md:text-3xl">Tags</h1>
         </div>
         <button
           type="button"

--- a/src/app/routes/Today.tsx
+++ b/src/app/routes/Today.tsx
@@ -32,7 +32,7 @@ export function Today() {
   if (!activeVault) return <Navigate to="/" replace />;
   if (!parsed) {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-10">
+      <div className="mx-auto max-w-3xl px-4 py-6 md:px-6 md:py-10">
         <p className="text-sm text-red-400">Invalid date in URL: {targetKey}</p>
         <Link to="/today" className="text-sm text-accent hover:underline">
           Back to today
@@ -47,11 +47,13 @@ export function Today() {
   const monthKey = targetKey.slice(0, 7);
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-10">
+    <div className="mx-auto max-w-3xl px-4 py-6 md:px-6 md:py-10">
       <header className="mb-6 flex flex-wrap items-baseline justify-between gap-3">
         <div>
           <p className="text-xs uppercase tracking-wider text-fg-dim">{isToday ? "Today" : "On"}</p>
-          <h1 className="font-serif text-3xl tracking-tight">{formatLongDate(targetKey)}</h1>
+          <h1 className="font-serif text-2xl tracking-tight md:text-3xl">
+            {formatLongDate(targetKey)}
+          </h1>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-sm">
           <Link

--- a/src/components/BottomTabBar.test.tsx
+++ b/src/components/BottomTabBar.test.tsx
@@ -1,0 +1,98 @@
+import { BottomTabBar } from "@/components/BottomTabBar";
+import { useQuickSwitchOpen } from "@/lib/quick-switch/open-store";
+import { useVaultStore } from "@/lib/vault/store";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+function seedVault() {
+  useVaultStore.setState({
+    vaults: {
+      v1: {
+        id: "v1",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-22T00:00:00.000Z",
+        lastUsedAt: "2026-04-22T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v1",
+  });
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <BottomTabBar />
+    </MemoryRouter>,
+  );
+}
+
+describe("BottomTabBar", () => {
+  beforeEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useQuickSwitchOpen.setState({ open: false });
+    seedVault();
+  });
+
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useQuickSwitchOpen.setState({ open: false });
+  });
+
+  it("renders Home, Tags, Capture, Search, Settings tabs when a vault is active", () => {
+    renderAt("/");
+    const nav = screen.getByRole("navigation", { name: /primary/i });
+    expect(within(nav).getByLabelText(/home/i)).toBeInTheDocument();
+    expect(within(nav).getByLabelText(/^tags$/i)).toBeInTheDocument();
+    expect(within(nav).getByLabelText(/capture/i)).toBeInTheDocument();
+    expect(within(nav).getByLabelText(/search/i)).toBeInTheDocument();
+    expect(within(nav).getByLabelText(/settings/i)).toBeInTheDocument();
+  });
+
+  it("does not render when no active vault", () => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    renderAt("/");
+    expect(screen.queryByRole("navigation", { name: /primary/i })).toBeNull();
+  });
+
+  it("is hidden on md+ viewports via md:hidden class", () => {
+    renderAt("/");
+    const nav = screen.getByRole("navigation", { name: /primary/i });
+    expect(nav.className).toMatch(/\bmd:hidden\b/);
+  });
+
+  it("marks the Home tab active on /", () => {
+    renderAt("/");
+    const home = screen.getByLabelText(/home/i);
+    expect(home).toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks the Tags tab active on /tags", () => {
+    renderAt("/tags");
+    const tags = screen.getByLabelText(/^tags$/i);
+    expect(tags).toHaveAttribute("aria-current", "page");
+  });
+
+  it("keeps Home tab active on /n/:id (reading a note is still under Home)", () => {
+    renderAt("/n/abc");
+    const home = screen.getByLabelText(/home/i);
+    expect(home).toHaveAttribute("aria-current", "page");
+  });
+
+  it("opens the quick-switch via the Search tab", () => {
+    renderAt("/");
+    expect(useQuickSwitchOpen.getState().open).toBe(false);
+    fireEvent.click(screen.getByLabelText(/search/i));
+    expect(useQuickSwitchOpen.getState().open).toBe(true);
+  });
+
+  it("Capture tab navigates to /capture", () => {
+    renderAt("/");
+    const capture = screen.getByLabelText(/capture/i);
+    expect(capture).toHaveAttribute("href", "/capture");
+  });
+});

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -1,0 +1,156 @@
+import { useQuickSwitchOpen } from "@/lib/quick-switch/open-store";
+import { useVaultStore } from "@/lib/vault";
+import type { ReactNode } from "react";
+import { Link, useLocation } from "react-router";
+
+// Mobile-only fixed bottom navigation. Primary wayfinding on phones;
+// replaces the header-hamburger-as-only-nav pattern that shipped before the
+// IA shift. Hidden on >= md breakpoints where the desktop sidebar + header
+// handle navigation.
+//
+// Each tab is a 56px-tall touch target with an icon and a label. Icons are
+// inline SVGs (no new deps) sized 20px. Active tab is determined by
+// `location.pathname` with a loose-prefix match so e.g. `/n/:id` still
+// highlights the Home tab.
+
+export function BottomTabBar() {
+  const hasActiveVault = useVaultStore((s) => s.activeVaultId !== null);
+  const setSwitcherOpen = useQuickSwitchOpen((s) => s.setOpen);
+  const location = useLocation();
+
+  if (!hasActiveVault) return null;
+
+  const path = location.pathname;
+  const isHome =
+    path === "/" || path.startsWith("/n/") || path === "/pinned" || path === "/archived";
+  const isTags = path === "/tags";
+  const isCapture = path === "/capture" || path === "/new";
+  const isSettings = path === "/settings";
+
+  return (
+    <nav
+      aria-label="Primary"
+      className="fixed inset-x-0 bottom-0 z-20 border-t border-border bg-bg/95 backdrop-blur md:hidden"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
+      <ul className="mx-auto flex max-w-5xl items-stretch justify-around">
+        <Tab to="/" label="Home" active={isHome} icon={<IconHome />} />
+        <Tab to="/tags" label="Tags" active={isTags} icon={<IconTag />} />
+        <Tab to="/capture" label="Capture" active={isCapture} icon={<IconPlus />} />
+        <TabButton label="Search" icon={<IconSearch />} onClick={() => setSwitcherOpen(true)} />
+        <Tab to="/settings" label="Settings" active={isSettings} icon={<IconCog />} />
+      </ul>
+    </nav>
+  );
+}
+
+function Tab({
+  to,
+  label,
+  icon,
+  active,
+}: {
+  to: string;
+  label: string;
+  icon: ReactNode;
+  active: boolean;
+}) {
+  return (
+    <li className="flex-1">
+      <Link
+        to={to}
+        aria-label={label}
+        aria-current={active ? "page" : undefined}
+        className={`flex h-14 flex-col items-center justify-center gap-0.5 text-[11px] ${
+          active ? "text-accent" : "text-fg-muted hover:text-accent"
+        }`}
+      >
+        <span aria-hidden="true">{icon}</span>
+        <span>{label}</span>
+      </Link>
+    </li>
+  );
+}
+
+function TabButton({
+  label,
+  icon,
+  onClick,
+}: {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <li className="flex-1">
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={label}
+        className="flex h-14 w-full flex-col items-center justify-center gap-0.5 text-[11px] text-fg-muted hover:text-accent"
+      >
+        <span aria-hidden="true">{icon}</span>
+        <span>{label}</span>
+      </button>
+    </li>
+  );
+}
+
+// Inline SVGs — lucide-react isn't a dependency and keeps the bundle tight.
+// 20px square, 1.75 stroke, matches the weight of the rest of the UI.
+const SVG_PROPS = {
+  width: 20,
+  height: 20,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.75,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+} as const;
+
+function IconHome() {
+  return (
+    <svg {...SVG_PROPS} aria-hidden="true">
+      <path d="M3 10.5 12 3l9 7.5" />
+      <path d="M5 9.5V21h14V9.5" />
+      <path d="M10 21v-6h4v6" />
+    </svg>
+  );
+}
+
+function IconTag() {
+  return (
+    <svg {...SVG_PROPS} aria-hidden="true">
+      <path d="M20.5 12.5 12.5 20.5a2 2 0 0 1-2.83 0L3 13.83V3h10.83L20.5 9.67a2 2 0 0 1 0 2.83Z" />
+      <circle cx="7.5" cy="7.5" r="1.25" fill="currentColor" />
+    </svg>
+  );
+}
+
+function IconPlus() {
+  return (
+    <svg {...SVG_PROPS} aria-hidden="true">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 8v8M8 12h8" />
+    </svg>
+  );
+}
+
+function IconSearch() {
+  return (
+    <svg {...SVG_PROPS} aria-hidden="true">
+      <circle cx="11" cy="11" r="7" />
+      <path d="m20 20-3.5-3.5" />
+    </svg>
+  );
+}
+
+function IconCog() {
+  return (
+    <svg {...SVG_PROPS} aria-hidden="true">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.7 1.7 0 0 0-1.87-.34 1.7 1.7 0 0 0-1.03 1.56V21a2 2 0 1 1-4 0v-.09a1.7 1.7 0 0 0-1.11-1.56 1.7 1.7 0 0 0-1.87.34l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-1.56-1.03H3a2 2 0 1 1 0-4h.09A1.7 1.7 0 0 0 4.6 9 1.7 1.7 0 0 0 4.26 7.13L4.2 7.07A2 2 0 1 1 7.03 4.24l.06.06A1.7 1.7 0 0 0 9 4.64 1.7 1.7 0 0 0 10 3.09V3a2 2 0 1 1 4 0v.09a1.7 1.7 0 0 0 1 1.55 1.7 1.7 0 0 0 1.87-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.7 1.7 0 0 0 19.4 9a1.7 1.7 0 0 0 1.56 1h.04a2 2 0 1 1 0 4h-.09a1.7 1.7 0 0 0-1.51 1Z" />
+    </svg>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,8 +38,11 @@ export function Header() {
       className="sticky top-0 z-10 border-b border-border bg-bg/90 backdrop-blur"
       style={{ paddingTop: "env(safe-area-inset-top)" }}
     >
-      <nav className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-6 py-4 md:py-5">
-        <Link to="/" className="font-serif text-xl tracking-tight text-fg hover:text-accent">
+      <nav className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3 md:px-6 md:py-5">
+        <Link
+          to="/"
+          className="font-serif text-lg tracking-tight text-fg hover:text-accent md:text-xl"
+        >
           Parachute Lens
         </Link>
 
@@ -119,26 +122,14 @@ export function Header() {
       </nav>
 
       {menuOpen ? (
-        <div id="mobile-menu" className="border-t border-border bg-bg/95 px-6 py-4 md:hidden">
+        <div id="mobile-menu" className="border-t border-border bg-bg/95 px-4 py-4 md:hidden">
           {hasVaults ? (
             <div className="flex flex-col gap-3">
-              <Link to="/" className="py-1 text-sm text-fg hover:text-accent">
-                Notes
-              </Link>
-              <Link to="/tags" className="py-1 text-sm text-fg hover:text-accent">
-                Tags
-              </Link>
               <Link to="/graph" className="py-1 text-sm text-fg hover:text-accent">
                 Graph
               </Link>
               <Link to="/activity" className="py-1 text-sm text-fg hover:text-accent">
                 Activity
-              </Link>
-              <Link to="/capture" className="py-1 text-sm text-fg hover:text-accent">
-                + Capture
-              </Link>
-              <Link to="/settings" className="py-1 text-sm text-fg hover:text-accent">
-                Settings
               </Link>
               <button
                 type="button"

--- a/src/components/QuickSwitch.test.tsx
+++ b/src/components/QuickSwitch.test.tsx
@@ -1,5 +1,6 @@
 import { QuickSwitch } from "@/components/QuickSwitch";
 import { QuickSwitchMount } from "@/components/QuickSwitchMount";
+import { useQuickSwitchOpen } from "@/lib/quick-switch/open-store";
 import { pushRecent } from "@/lib/quick-switch/recents";
 import { useVaultStore } from "@/lib/vault/store";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -169,11 +170,13 @@ describe("QuickSwitchMount", () => {
   beforeEach(() => {
     localStorage.clear();
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useQuickSwitchOpen.setState({ open: false });
     seedStore();
   });
   afterEach(() => {
     vi.unstubAllGlobals();
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useQuickSwitchOpen.setState({ open: false });
     localStorage.clear();
   });
 

--- a/src/components/QuickSwitchMount.tsx
+++ b/src/components/QuickSwitchMount.tsx
@@ -1,14 +1,20 @@
 import { QuickSwitch } from "@/components/QuickSwitch";
+import { useQuickSwitchOpen } from "@/lib/quick-switch/open-store";
 import { useVaultStore } from "@/lib/vault";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 // Global Cmd/Ctrl+K listener + conditional mount of the switcher. Kept
 // separate from the switcher itself so tests can render just the dialog
 // without the global-listener side effects, and so the listener doesn't
 // have to re-run every time the switcher re-renders from inside.
+//
+// Open state lives in `useQuickSwitchOpen` so other surfaces (e.g. the
+// mobile bottom-tab Search button) can open the switcher too.
 
 export function QuickSwitchMount() {
-  const [open, setOpen] = useState(false);
+  const open = useQuickSwitchOpen((s) => s.open);
+  const setOpen = useQuickSwitchOpen((s) => s.setOpen);
+  const toggle = useQuickSwitchOpen((s) => s.toggle);
   const hasActiveVault = useVaultStore((s) => s.activeVaultId !== null);
 
   useEffect(() => {
@@ -17,12 +23,12 @@ export function QuickSwitchMount() {
       // letter — should never open the switcher.
       if (e.key === "k" && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
         e.preventDefault();
-        setOpen((v) => !v);
+        toggle();
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [toggle]);
 
   if (!open || !hasActiveVault) return null;
   return <QuickSwitch onClose={() => setOpen(false)} />;

--- a/src/components/TagBrowser.test.tsx
+++ b/src/components/TagBrowser.test.tsx
@@ -1,0 +1,123 @@
+import { TagBrowser } from "@/components/TagBrowser";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+describe("TagBrowser", () => {
+  const baseProps = {
+    onToggle: () => {},
+    onClear: () => {},
+  };
+
+  it("renders tags sorted by count descending by default", () => {
+    render(
+      <TagBrowser
+        {...baseProps}
+        tags={[
+          { name: "idea", count: 2 },
+          { name: "journal", count: 8 },
+          { name: "project", count: 5 },
+        ]}
+        pinnedTags={[]}
+        selected={[]}
+      />,
+    );
+    const buttons = screen.getAllByRole("button").filter((b) => b.title?.startsWith("#"));
+    expect(buttons.map((b) => b.title)).toEqual(["#journal", "#project", "#idea"]);
+  });
+
+  it("floats pinned tags to the top regardless of count", () => {
+    render(
+      <TagBrowser
+        {...baseProps}
+        tags={[
+          { name: "big", count: 100 },
+          { name: "small", count: 1 },
+        ]}
+        pinnedTags={["small"]}
+        selected={[]}
+      />,
+    );
+    const buttons = screen.getAllByRole("button").filter((b) => b.title?.startsWith("#"));
+    expect(buttons[0]?.title).toBe("#small");
+  });
+
+  it("groups slash-delimited tags under a collapsible parent", () => {
+    render(
+      <TagBrowser
+        {...baseProps}
+        tags={[
+          { name: "summary/daily", count: 10 },
+          { name: "summary/weekly", count: 3 },
+        ]}
+        pinnedTags={[]}
+        selected={[]}
+      />,
+    );
+    // Group is collapsed by default — children hidden.
+    expect(screen.queryByTitle("#summary/daily")).toBeNull();
+    const expand = screen.getByRole("button", { name: /Expand summary/i });
+    fireEvent.click(expand);
+    expect(screen.getByTitle("#summary/daily")).toBeInTheDocument();
+    expect(screen.getByTitle("#summary/weekly")).toBeInTheDocument();
+  });
+
+  it("fires onToggle with the tag name on click", () => {
+    const onToggle = vi.fn();
+    render(
+      <TagBrowser
+        {...baseProps}
+        onToggle={onToggle}
+        tags={[{ name: "journal", count: 3 }]}
+        pinnedTags={[]}
+        selected={[]}
+      />,
+    );
+    fireEvent.click(screen.getByTitle("#journal"));
+    expect(onToggle).toHaveBeenCalledWith("journal");
+  });
+
+  it("auto-expands a group when one of its children is selected", () => {
+    render(
+      <TagBrowser
+        {...baseProps}
+        tags={[
+          { name: "summary/daily", count: 10 },
+          { name: "summary/weekly", count: 3 },
+        ]}
+        pinnedTags={[]}
+        selected={["summary/daily"]}
+      />,
+    );
+    const daily = screen.getByTitle("#summary/daily");
+    expect(daily).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows a Clear button when selection is non-empty", () => {
+    const onClear = vi.fn();
+    render(
+      <TagBrowser
+        {...baseProps}
+        onClear={onClear}
+        tags={[{ name: "idea", count: 2 }]}
+        pinnedTags={[]}
+        selected={["idea"]}
+      />,
+    );
+    const clear = screen.getByRole("button", { name: /clear/i });
+    fireEvent.click(clear);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the tag-browser nav with Tags heading at the top of the sidebar", () => {
+    render(
+      <TagBrowser
+        {...baseProps}
+        tags={[{ name: "idea", count: 2 }]}
+        pinnedTags={[]}
+        selected={[]}
+      />,
+    );
+    const nav = screen.getByRole("navigation", { name: /browse by tag/i });
+    expect(within(nav).getByText(/^Tags$/)).toBeInTheDocument();
+  });
+});

--- a/src/components/TagBrowser.tsx
+++ b/src/components/TagBrowser.tsx
@@ -1,0 +1,306 @@
+import type { TagSummary } from "@/lib/vault/types";
+import { useMemo, useState } from "react";
+
+// Tag-primary browser for the Notes sidebar. Shows all tags in the vault
+// with per-tag counts, groups slash-delimited tags under a collapsible
+// parent (e.g. `summary/daily`, `summary/weekly` → "summary" group), and
+// drives the existing `selectedTags` multi-select used by the notes list
+// query. Pinned tags float to the top; everything else is sorted by count
+// descending so the biggest buckets are most discoverable.
+
+interface Props {
+  tags: TagSummary[];
+  pinnedTags: string[];
+  selected: string[];
+  onToggle: (name: string) => void;
+  onClear: () => void;
+  isLoading?: boolean;
+}
+
+interface GroupedTag {
+  kind: "leaf";
+  name: string;
+  label: string;
+  count: number;
+  pinned: boolean;
+}
+
+interface GroupedTagNode {
+  kind: "group";
+  prefix: string;
+  totalCount: number;
+  // The parent tag itself, if it exists as a concrete tag (e.g. "summary").
+  selfTag?: TagSummary & { pinned: boolean };
+  children: Array<TagSummary & { pinned: boolean }>;
+}
+
+type Entry = GroupedTag | GroupedTagNode;
+
+function groupAndRank(tags: TagSummary[], pinnedSet: Set<string>): Entry[] {
+  // Partition into slash-prefixed vs flat. A slash-prefixed tag contributes
+  // to a group only if at least 2 tags share its first segment (so we don't
+  // wrap a single `summary/daily` into a pointless "summary" group of one).
+  const firstSegmentIndex = new Map<string, TagSummary[]>();
+  for (const t of tags) {
+    const slash = t.name.indexOf("/");
+    if (slash > 0) {
+      const head = t.name.slice(0, slash);
+      const bucket = firstSegmentIndex.get(head) ?? [];
+      bucket.push(t);
+      firstSegmentIndex.set(head, bucket);
+    }
+  }
+
+  const groupedHeads = new Set<string>();
+  for (const [head, members] of firstSegmentIndex) {
+    if (members.length >= 2) groupedHeads.add(head);
+  }
+
+  const groups = new Map<string, GroupedTagNode>();
+  const leaves: GroupedTag[] = [];
+
+  for (const t of tags) {
+    const slash = t.name.indexOf("/");
+    const head = slash > 0 ? t.name.slice(0, slash) : t.name;
+    const isGroupMember = slash > 0 && groupedHeads.has(head);
+
+    if (isGroupMember) {
+      let group = groups.get(head);
+      if (!group) {
+        group = { kind: "group", prefix: head, totalCount: 0, children: [] };
+        groups.set(head, group);
+      }
+      group.children.push({ ...t, pinned: pinnedSet.has(t.name) });
+      group.totalCount += t.count;
+    } else if (groupedHeads.has(t.name)) {
+      // This tag is the concrete parent of a group (e.g. `summary` itself
+      // exists as a tag, and so do `summary/daily`, `summary/weekly`).
+      let group = groups.get(t.name);
+      if (!group) {
+        group = { kind: "group", prefix: t.name, totalCount: 0, children: [] };
+        groups.set(t.name, group);
+      }
+      group.selfTag = { ...t, pinned: pinnedSet.has(t.name) };
+      group.totalCount += t.count;
+    } else {
+      leaves.push({
+        kind: "leaf",
+        name: t.name,
+        label: t.name,
+        count: t.count,
+        pinned: pinnedSet.has(t.name),
+      });
+    }
+  }
+
+  // Sort children of each group by count desc, with pinned first.
+  for (const g of groups.values()) {
+    g.children.sort((a, b) => {
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+      return b.count - a.count || a.name.localeCompare(b.name);
+    });
+  }
+
+  // Merge + rank top-level entries. Use max child count (or self count) as
+  // the group's ranking signal rather than total — a group with many tiny
+  // children shouldn't jump above a single heavy tag.
+  const entries: Entry[] = [...leaves, ...Array.from(groups.values())];
+
+  const rankOf = (e: Entry): { pinned: boolean; count: number; label: string } => {
+    if (e.kind === "leaf") return { pinned: e.pinned, count: e.count, label: e.label };
+    const anyPinned = (e.selfTag?.pinned ?? false) || e.children.some((c) => c.pinned);
+    const heaviest = Math.max(e.selfTag?.count ?? 0, ...e.children.map((c) => c.count)) || 0;
+    return { pinned: anyPinned, count: heaviest, label: e.prefix };
+  };
+
+  entries.sort((a, b) => {
+    const ra = rankOf(a);
+    const rb = rankOf(b);
+    if (ra.pinned !== rb.pinned) return ra.pinned ? -1 : 1;
+    return rb.count - ra.count || ra.label.localeCompare(rb.label);
+  });
+
+  return entries;
+}
+
+export function TagBrowser({ tags, pinnedTags, selected, onToggle, onClear, isLoading }: Props) {
+  const pinnedSet = useMemo(() => new Set(pinnedTags.map((p) => p.toLowerCase())), [pinnedTags]);
+  const selectedSet = useMemo(() => new Set(selected.map((s) => s.toLowerCase())), [selected]);
+  const entries = useMemo(() => groupAndRank(tags, pinnedSet), [tags, pinnedSet]);
+
+  // Per-group open state. Default all groups to collapsed so the sidebar
+  // stays scannable at a glance — users expand what they care about.
+  const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
+  const toggleGroup = (head: string) => {
+    setOpenGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(head)) next.delete(head);
+      else next.add(head);
+      return next;
+    });
+  };
+
+  return (
+    <nav aria-label="Browse by tag">
+      <div className="mb-2 flex items-baseline justify-between">
+        <h2 className="text-xs uppercase tracking-wider text-fg-dim">Tags</h2>
+        {selected.length > 0 ? (
+          <button type="button" onClick={onClear} className="text-xs text-fg-dim hover:text-accent">
+            Clear
+          </button>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <p className="text-xs text-fg-dim">Loading…</p>
+      ) : entries.length === 0 ? (
+        <p className="text-xs text-fg-dim">No tags in this vault.</p>
+      ) : (
+        <ul className="max-h-[60vh] space-y-0.5 overflow-y-auto pr-1">
+          {entries.map((entry) =>
+            entry.kind === "leaf" ? (
+              <li key={entry.name}>
+                <TagRow
+                  name={entry.name}
+                  label={entry.label}
+                  count={entry.count}
+                  pinned={entry.pinned}
+                  active={selectedSet.has(entry.name.toLowerCase())}
+                  onToggle={() => onToggle(entry.name)}
+                />
+              </li>
+            ) : (
+              <li key={entry.prefix}>
+                <TagGroup
+                  group={entry}
+                  isOpen={openGroups.has(entry.prefix)}
+                  onToggleOpen={() => toggleGroup(entry.prefix)}
+                  selectedSet={selectedSet}
+                  onToggleTag={onToggle}
+                />
+              </li>
+            ),
+          )}
+        </ul>
+      )}
+    </nav>
+  );
+}
+
+function TagRow({
+  name,
+  label,
+  count,
+  pinned,
+  active,
+  onToggle,
+}: {
+  name: string;
+  label: string;
+  count: number;
+  pinned: boolean;
+  active: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      title={`#${name}`}
+      className={`flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left text-sm ${
+        active ? "bg-accent/15 text-accent" : "text-fg-muted hover:bg-bg/60 hover:text-accent"
+      }`}
+    >
+      {pinned ? (
+        <span aria-hidden="true" className="shrink-0 text-accent">
+          ★
+        </span>
+      ) : null}
+      <span className="flex-1 truncate">#{label}</span>
+      <span className="shrink-0 text-xs text-fg-dim">{count}</span>
+    </button>
+  );
+}
+
+function TagGroup({
+  group,
+  isOpen,
+  onToggleOpen,
+  selectedSet,
+  onToggleTag,
+}: {
+  group: GroupedTagNode;
+  isOpen: boolean;
+  onToggleOpen: () => void;
+  selectedSet: Set<string>;
+  onToggleTag: (name: string) => void;
+}) {
+  const anyChildSelected = group.children.some((c) => selectedSet.has(c.name.toLowerCase()));
+  const selfSelected = group.selfTag ? selectedSet.has(group.selfTag.name.toLowerCase()) : false;
+  // Force open whenever a descendant (or the self-tag) is selected, so the
+  // user can see what's active without having to manually expand.
+  const effectiveOpen = isOpen || anyChildSelected || selfSelected;
+  const groupPinned = (group.selfTag?.pinned ?? false) || group.children.some((c) => c.pinned);
+
+  return (
+    <div>
+      <div className="flex items-center gap-1 rounded-md px-1 py-0.5">
+        <button
+          type="button"
+          onClick={onToggleOpen}
+          aria-expanded={effectiveOpen}
+          aria-label={`${effectiveOpen ? "Collapse" : "Expand"} ${group.prefix}`}
+          className="flex h-5 w-5 shrink-0 items-center justify-center text-fg-dim hover:text-accent"
+        >
+          <span aria-hidden="true" className="font-mono text-xs">
+            {effectiveOpen ? "▾" : "▸"}
+          </span>
+        </button>
+        {group.selfTag ? (
+          <TagRow
+            name={group.selfTag.name}
+            label={group.prefix}
+            count={group.selfTag.count}
+            pinned={group.selfTag.pinned}
+            active={selfSelected}
+            onToggle={() => onToggleTag(group.selfTag!.name)}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={onToggleOpen}
+            className="flex flex-1 items-center gap-1.5 truncate rounded-md px-2 py-1 text-left text-sm text-fg-muted hover:bg-bg/60 hover:text-accent"
+          >
+            {groupPinned ? (
+              <span aria-hidden="true" className="shrink-0 text-accent">
+                ★
+              </span>
+            ) : null}
+            <span className="flex-1 truncate">#{group.prefix}/</span>
+            <span className="shrink-0 text-xs text-fg-dim">{group.totalCount}</span>
+          </button>
+        )}
+      </div>
+      {effectiveOpen ? (
+        <ul className="ml-4 space-y-0.5 border-l border-border pl-2">
+          {group.children.map((c) => {
+            const leafLabel = c.name.slice(group.prefix.length + 1) || c.name;
+            return (
+              <li key={c.name}>
+                <TagRow
+                  name={c.name}
+                  label={leafLabel}
+                  count={c.count}
+                  pinned={c.pinned}
+                  active={selectedSet.has(c.name.toLowerCase())}
+                  onToggle={() => onToggleTag(c.name)}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/quick-switch/open-store.ts
+++ b/src/lib/quick-switch/open-store.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+
+// Open-state for the Cmd/Ctrl+K spotlight. Split out from `QuickSwitchMount`
+// so the mobile bottom-tab Search button (and any other surface) can trigger
+// the switcher without passing callbacks through the tree.
+interface QuickSwitchOpenState {
+  open: boolean;
+  setOpen(next: boolean): void;
+  toggle(): void;
+}
+
+export const useQuickSwitchOpen = create<QuickSwitchOpenState>((set) => ({
+  open: false,
+  setOpen(next) {
+    set({ open: next });
+  },
+  toggle() {
+    set((s) => ({ open: !s.open }));
+  },
+}));


### PR DESCRIPTION
## Summary

- **Tag-primary sidebar.** Notes home now shows a `TagBrowser` at the top (all tags with counts, multi-select, collapsible slash-delimited groups like `summary/daily` → summary). The path tree is demoted into a collapsed `<details>` "Folders" section at the bottom — still there when you want it, no longer the default.
- **Mobile bottom tab bar.** Fixed `md:hidden` nav with Home / Tags / Capture / Search / Settings. Search opens the existing Cmd+K switcher via a new tiny `open-store` (zustand) so surfaces beyond `QuickSwitchMount` can trigger it. Active tab highlighted; safe-area padding on iOS.
- **Slim mobile header.** The tab bar owns primary nav now, so the hamburger menu is trimmed to vault switching, graph/activity, manage, install, theme.
- **Real mobile visual pass.** Compact `px-4 py-6` defaults across all routes, `text-2xl` mobile headings that grow to `text-3xl` at `md`, tighter note rows, `pb-16 md:pb-0` so tab bar doesn't cover content.
- Builds on #65 (tag-first IA sprinkle) to complete the shift — tag sidebar, mobile tabs, real visual pass.

## Test plan

- [x] `bun run lint` — only pre-existing TranscriptionStatus.test.tsx drift remains
- [x] `bun run typecheck` — clean
- [x] `bun test` — 573 tests pass including new TagBrowser (7) + BottomTabBar (8)
- [x] `bun run build` — clean, PWA regenerated
- [ ] Manual: desktop Notes home shows tag browser → saved views → built-in views → Folders (collapsed)
- [ ] Manual @ 360px / 414px / 768px: tab bar sticks to bottom, active tab highlights, Search opens switcher, Capture/Tags/Settings route correctly
- [ ] Manual: note editor margins feel generous, tag chips wrap, note rows scan cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)