### PR TITLE
fix(TagBrowser): show summed count on collapsed group badges

### DIFF
--- a/src/components/TagBrowser.test.tsx
+++ b/src/components/TagBrowser.test.tsx
@@ -21,8 +21,14 @@ describe("TagBrowser", () => {
         selected={[]}
       />,
     );
-    const buttons = screen.getAllByRole("button").filter((b) => b.title?.startsWith("#"));
-    expect(buttons.map((b) => b.title)).toEqual(["#journal", "#project", "#idea"]);
+    const buttons = screen
+      .getAllByRole("button")
+      .filter((b) => b.title?.startsWith("#"));
+    expect(buttons.map((b) => b.title)).toEqual([
+      "#journal",
+      "#project",
+      "#idea",
+    ]);
   });
 
   it("floats pinned tags to the top regardless of count", () => {
@@ -37,7 +43,9 @@ describe("TagBrowser", () => {
         selected={[]}
       />,
     );
-    const buttons = screen.getAllByRole("button").filter((b) => b.title?.startsWith("#"));
+    const buttons = screen
+      .getAllByRole("button")
+      .filter((b) => b.title?.startsWith("#"));
     expect(buttons[0]?.title).toBe("#small");
   });
 
@@ -59,6 +67,40 @@ describe("TagBrowser", () => {
     fireEvent.click(expand);
     expect(screen.getByTitle("#summary/daily")).toBeInTheDocument();
     expect(screen.getByTitle("#summary/weekly")).toBeInTheDocument();
+  });
+
+  // TODO Test group-badge shows summed child count
+  it("shows the summed child count on a collapsed group badge", () => {
+    render(
+      <TagBrowser
+        {...baseProps}
+        tags={[
+          { name: "summary/daily", count: 10 },
+          { name: "summary/weekly", count: 3 },
+        ]}
+        pinnedTags={[]}
+        selected={[]}
+      />,
+    );
+
+    expect(screen.getByText("13")).toBeInTheDocument();
+  });
+
+  it("includes the parent tag count in the collapsed group badge when parent tag exists", () => {
+    render(
+      <TagBrowser
+        {...baseProps}
+        tags={[
+          { name: "summary", count: 2 },
+          { name: "summary/daily", count: 10 },
+          { name: "summary/weekly", count: 3 },
+        ]}
+        pinnedTags={[]}
+        selected={[]}
+      />,
+    );
+
+    expect(screen.getByText("15")).toBeInTheDocument();
   });
 
   it("fires onToggle with the tag name on click", () => {

--- a/src/components/TagBrowser.tsx
+++ b/src/components/TagBrowser.tsx
@@ -106,10 +106,15 @@ function groupAndRank(tags: TagSummary[], pinnedSet: Set<string>): Entry[] {
   // children shouldn't jump above a single heavy tag.
   const entries: Entry[] = [...leaves, ...Array.from(groups.values())];
 
-  const rankOf = (e: Entry): { pinned: boolean; count: number; label: string } => {
-    if (e.kind === "leaf") return { pinned: e.pinned, count: e.count, label: e.label };
-    const anyPinned = (e.selfTag?.pinned ?? false) || e.children.some((c) => c.pinned);
-    const heaviest = Math.max(e.selfTag?.count ?? 0, ...e.children.map((c) => c.count)) || 0;
+  const rankOf = (
+    e: Entry,
+  ): { pinned: boolean; count: number; label: string } => {
+    if (e.kind === "leaf")
+      return { pinned: e.pinned, count: e.count, label: e.label };
+    const anyPinned =
+      (e.selfTag?.pinned ?? false) || e.children.some((c) => c.pinned);
+    const heaviest =
+      Math.max(e.selfTag?.count ?? 0, ...e.children.map((c) => c.count)) || 0;
     return { pinned: anyPinned, count: heaviest, label: e.prefix };
   };
 
@@ -123,10 +128,26 @@ function groupAndRank(tags: TagSummary[], pinnedSet: Set<string>): Entry[] {
   return entries;
 }
 
-export function TagBrowser({ tags, pinnedTags, selected, onToggle, onClear, isLoading }: Props) {
-  const pinnedSet = useMemo(() => new Set(pinnedTags.map((p) => p.toLowerCase())), [pinnedTags]);
-  const selectedSet = useMemo(() => new Set(selected.map((s) => s.toLowerCase())), [selected]);
-  const entries = useMemo(() => groupAndRank(tags, pinnedSet), [tags, pinnedSet]);
+export function TagBrowser({
+  tags,
+  pinnedTags,
+  selected,
+  onToggle,
+  onClear,
+  isLoading,
+}: Props) {
+  const pinnedSet = useMemo(
+    () => new Set(pinnedTags.map((p) => p.toLowerCase())),
+    [pinnedTags],
+  );
+  const selectedSet = useMemo(
+    () => new Set(selected.map((s) => s.toLowerCase())),
+    [selected],
+  );
+  const entries = useMemo(
+    () => groupAndRank(tags, pinnedSet),
+    [tags, pinnedSet],
+  );
 
   // Per-group open state. Default all groups to collapsed so the sidebar
   // stays scannable at a glance — users expand what they care about.
@@ -145,7 +166,11 @@ export function TagBrowser({ tags, pinnedTags, selected, onToggle, onClear, isLo
       <div className="mb-2 flex items-baseline justify-between">
         <h2 className="text-xs uppercase tracking-wider text-fg-dim">Tags</h2>
         {selected.length > 0 ? (
-          <button type="button" onClick={onClear} className="text-xs text-fg-dim hover:text-accent">
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs text-fg-dim hover:text-accent"
+          >
             Clear
           </button>
         ) : null}
@@ -209,7 +234,9 @@ function TagRow({
       aria-pressed={active}
       title={`#${name}`}
       className={`flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left text-sm ${
-        active ? "bg-accent/15 text-accent" : "text-fg-muted hover:bg-bg/60 hover:text-accent"
+        active
+          ? "bg-accent/15 text-accent"
+          : "text-fg-muted hover:bg-bg/60 hover:text-accent"
       }`}
     >
       {pinned ? (
@@ -236,12 +263,17 @@ function TagGroup({
   selectedSet: Set<string>;
   onToggleTag: (name: string) => void;
 }) {
-  const anyChildSelected = group.children.some((c) => selectedSet.has(c.name.toLowerCase()));
-  const selfSelected = group.selfTag ? selectedSet.has(group.selfTag.name.toLowerCase()) : false;
+  const anyChildSelected = group.children.some((c) =>
+    selectedSet.has(c.name.toLowerCase()),
+  );
+  const selfSelected = group.selfTag
+    ? selectedSet.has(group.selfTag.name.toLowerCase())
+    : false;
   // Force open whenever a descendant (or the self-tag) is selected, so the
   // user can see what's active without having to manually expand.
   const effectiveOpen = isOpen || anyChildSelected || selfSelected;
-  const groupPinned = (group.selfTag?.pinned ?? false) || group.children.some((c) => c.pinned);
+  const groupPinned =
+    (group.selfTag?.pinned ?? false) || group.children.some((c) => c.pinned);
 
   return (
     <div>
@@ -261,7 +293,7 @@ function TagGroup({
           <TagRow
             name={group.selfTag.name}
             label={group.prefix}
-            count={group.selfTag.count}
+            count={group.totalCount}
             pinned={group.selfTag.pinned}
             active={selfSelected}
             onToggle={() => onToggleTag(group.selfTag!.name)}
@@ -278,7 +310,9 @@ function TagGroup({
               </span>
             ) : null}
             <span className="flex-1 truncate">#{group.prefix}/</span>
-            <span className="shrink-0 text-xs text-fg-dim">{group.totalCount}</span>
+            <span className="shrink-0 text-xs text-fg-dim">
+              {group.totalCount}
+            </span>
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add tests covering collapsed group badge counts
- fix collapsed group badge to show the summed total count when a parent tag exists

## Details
This covers:
- child-only grouped tags showing the summed child count
- grouped tags with a parent tag showing the parent count plus child counts

Previously, when a parent tag existed, the collapsed group row displayed `group.selfTag.count` instead of the already-computed `group.totalCount`.