### PR TITLE
fix(lens): note cards + tag chips stay inside the viewport at 360px

### DIFF
--- a/src/app/routes/NoteView.tsx
+++ b/src/app/routes/NoteView.tsx
@@ -172,7 +172,7 @@ function HeaderTags({ tags }: { tags: string[] }) {
         <Link
           key={t}
           to={`/?tag=${encodeURIComponent(t)}`}
-          className="rounded-full border border-accent/40 bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent hover:border-accent hover:bg-accent/20"
+          className="max-w-full break-all rounded-full border border-accent/40 bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent hover:border-accent hover:bg-accent/20"
         >
           #{t}
         </Link>

--- a/src/app/routes/Notes.test.tsx
+++ b/src/app/routes/Notes.test.tsx
@@ -568,4 +568,40 @@ describe("Notes route", () => {
       expect(after.length).toBeGreaterThan(0);
     });
   });
+
+  it("constrains long paths and tag chips inside the note row instead of overflowing", async () => {
+    // A real-world long path and a slash-delimited tag with no whitespace
+    // would previously push the card past the right edge on 360px viewports.
+    const longPath =
+      "Work/Projects/Parachute/launch-week/summary-with-a-very-long-filename-2026-04-22.md";
+    const longTag = "summary/monthly-2026-01-draft-v2-extended";
+    installFetch({
+      notes: [
+        {
+          id: "n1",
+          path: longPath,
+          tags: [longTag],
+          createdAt: "2026-04-18T10:00:00.000Z",
+        },
+      ],
+      tags: [{ name: longTag, count: 1 }],
+    });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    const pathSpan = await screen.findByText(longPath);
+    // The path must live inside a flex-item with min-w-0 AND truncate;
+    // otherwise truncate never engages and the cell expands to content.
+    expect(pathSpan.className).toMatch(/\bmin-w-0\b/);
+    expect(pathSpan.className).toMatch(/\btruncate\b/);
+
+    // The tag chip must cap to parent width and break long unbroken strings
+    // so it can't blow out the card on mobile. Scope to the note row since
+    // TagBrowser in the sidebar also renders the tag label.
+    const row = pathSpan.closest("li") as HTMLElement;
+    expect(row).not.toBeNull();
+    const chip = within(row).getByText(`#${longTag}`);
+    expect(chip.className).toMatch(/\bmax-w-full\b/);
+    expect(chip.className).toMatch(/\bbreak-all\b/);
+  });
 });

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -579,7 +579,7 @@ function NoteRow({
                   ★
                 </span>
               ) : null}
-              <span className="truncate font-mono text-sm text-fg">{label}</span>
+              <span className="min-w-0 truncate font-mono text-sm text-fg">{label}</span>
             </span>
             <span className="shrink-0 text-xs text-fg-dim">{relativeTime(stamp)}</span>
           </div>
@@ -588,7 +588,7 @@ function NoteRow({
               {note.tags.map((t) => (
                 <span
                   key={t}
-                  className="rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-xs text-accent"
+                  className="max-w-full break-all rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-xs text-accent"
                 >
                   #{t}
                 </span>
@@ -754,12 +754,12 @@ function PinnedTagsStrip({
             onClick={() => onPick(name)}
             className={
               active
-                ? "inline-flex items-center gap-1 rounded-full border border-accent bg-accent px-2.5 py-1 text-xs font-medium text-white"
-                : "inline-flex items-center gap-1 rounded-full border border-accent/40 bg-accent/10 px-2.5 py-1 text-xs text-accent hover:border-accent hover:bg-accent/20"
+                ? "inline-flex max-w-full items-center gap-1 rounded-full border border-accent bg-accent px-2.5 py-1 text-xs font-medium text-white"
+                : "inline-flex max-w-full items-center gap-1 rounded-full border border-accent/40 bg-accent/10 px-2.5 py-1 text-xs text-accent hover:border-accent hover:bg-accent/20"
             }
             aria-pressed={active}
           >
-            <span>#{name}</span>
+            <span className="min-w-0 break-all">#{name}</span>
             {count !== undefined ? (
               <span className={active ? "text-white/80" : "text-accent/70"}>{count}</span>
             ) : null}

--- a/src/app/routes/VaultGraph.tsx
+++ b/src/app/routes/VaultGraph.tsx
@@ -127,8 +127,8 @@ function TagFilter({
             onClick={() => toggle(t)}
             className={
               active
-                ? "rounded-full border border-accent bg-accent/10 px-2 py-0.5 text-accent"
-                : "rounded-full border border-border bg-card px-2 py-0.5 hover:text-accent"
+                ? "max-w-full break-all rounded-full border border-accent bg-accent/10 px-2 py-0.5 text-accent"
+                : "max-w-full break-all rounded-full border border-border bg-card px-2 py-0.5 hover:text-accent"
             }
           >
             {t}

--- a/src/components/TagEditor.tsx
+++ b/src/components/TagEditor.tsx
@@ -13,9 +13,9 @@ export function TagEditor({ tags, input, onInputChange, onAdd, onRemove }: Props
       {tags.map((t) => (
         <span
           key={t}
-          className="inline-flex items-center gap-1 rounded-full border border-border bg-bg/60 px-2 py-0.5 text-xs text-fg-muted"
+          className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-bg/60 px-2 py-0.5 text-xs text-fg-muted"
         >
-          {t}
+          <span className="min-w-0 break-all">{t}</span>
           <button
             type="button"
             onClick={() => onRemove(t)}


### PR DESCRIPTION
## Summary

Aaron reported note cards running off the right edge on mobile. Two overlapping root causes:

### 1. NoteRow truncate cascade was broken

The path label lives inside a nested flex chain: outer div (`flex items-baseline justify-between`) → inner span (`flex min-w-0 items-baseline gap-1.5`) → label span (`truncate`). A flex item's default `min-width: auto` resolves to content width, so the label expanded to full path length and `truncate` never engaged.

**Fix:** add `min-w-0` to the label span so truncate can actually shrink it under pressure.

### 2. Tag chips are single unbreakable inline spans

A tag like `summary/monthly-2026-01-draft-v2` produced a chip wider than the card. `flex-wrap` on the chip container only wraps chip-to-chip — it doesn't shrink an individual chip. So one long tag = one overflowing row.

**Fix:** add `max-w-full break-all` to chip spans so a long tag now wraps inside its own pill.

Applied the same chip treatment to every place we render a tag pill:

- `NoteRow` tag chips (`src/app/routes/Notes.tsx`)
- `NoteView` HeaderTags (`src/app/routes/NoteView.tsx`)
- `PinnedTagsStrip` button pill (`src/app/routes/Notes.tsx`)
- `VaultGraph` tag filter chips (`src/app/routes/VaultGraph.tsx`)
- `TagEditor` removable chip (`src/components/TagEditor.tsx`)

## Test plan

- [x] New unit test: renders a NoteRow with a deliberately long path + slash-delimited tag, asserts `min-w-0 truncate` on the path span and `max-w-full break-all` on the chip. Locks the classes in place so a future pass can't silently drop them.
- [x] Full suite: 575 tests pass (+1)
- [x] Lint: only pre-existing TranscriptionStatus.test.tsx drift remains
- [x] Typecheck clean
- [x] Production build clean
- [ ] Manual @ 360px against local build: long-path note card no longer overflows; long-tag chip wraps inside its pill; PinnedTagsStrip pill shrinks; NoteView tag chips wrap; TagEditor chip wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)