### PR TITLE
fix(lens): clamp horizontal overflow at the app shell

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -68,6 +68,20 @@ describe("App", () => {
     expect(window.location.pathname).toMatch(/^\/lens\/?$/);
   });
 
+  it("clamps horizontal overflow at the shell so a stray wide descendant can't scroll the viewport", () => {
+    render(<App />);
+    // Belt-and-suspenders against mobile overflow regressions. If any
+    // descendant (a long unbreakable path, a rogue min-width, a missing
+    // min-w-0 in a deep flex chain) ever exceeds the viewport width, the
+    // shell clips it to the viewport instead of turning the whole page into
+    // a horizontal scroller. jsdom doesn't compute layout, so this is a
+    // class-presence check, not a measured scrollWidth assertion — the
+    // manual-testing steps live in the PR body.
+    const shell = screen.getByRole("link", { name: /parachute lens/i }).closest("div.min-h-dvh");
+    expect(shell).not.toBeNull();
+    expect(shell?.className).toMatch(/\boverflow-x-hidden\b/);
+  });
+
   it("static route /settings wins over the dynamic /:id deep-link shim", () => {
     useVaultStore.setState({
       vaults: {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -48,7 +48,7 @@ export function App() {
     <QueryProvider>
       <SyncProvider>
         <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "") || undefined}>
-          <div className="min-h-dvh bg-bg text-fg pb-16 md:pb-0">
+          <div className="min-h-dvh overflow-x-hidden bg-bg text-fg pb-16 md:pb-0">
             <Toaster />
             <UpdateBanner />
             <Header />


### PR DESCRIPTION
## Summary

- PR #72 fixed the tag-chip and long-path overflow sources in `NoteRow`, but Aaron still reports note cards running off the right edge on mobile.
- I could not reproduce the specific descendant without a live vault on a 360px viewport, so this PR lands the belt-and-suspenders the team-lead asked for: `overflow-x-hidden` on the app shell `<div>` in `App.tsx`. That bounds any rogue wide descendant to the viewport instead of turning the whole page into a horizontal scroller.
- Regression test asserts the class is present on the shell. jsdom does not compute layout, so this is a class-presence check rather than a measured `scrollWidth` assertion.

## Investigation notes

Re-audited the candidate culprits flagged by the team-lead as "still possible":

- **Filter bar inputs** — `flex-1 min-w-48` = 192px min-width search + TagFilter summary + optional "Save view" button. `flex-wrap` is on the container, and at a 328px content width (360 − 32px page padding), 192 + gap + ~80 still fits on one line. Not the culprit.
- **Preview text with unbreakable URL** — `<p className="mt-1.5 truncate ...">` is a block child of `<Link block flex-1 min-w-0>`. The Link is bounded by the outer flex; the `<p>` inherits that width and `truncate` engages. Should not overflow.
- **Path-tree folder label** — `PathTree.tsx:109-117` has a `flex flex-1 ... truncate` button where the parent `<div flex items-center gap-1>` has no `min-w-0`. If a user opens the sidebar *and* expands folders *and* a deep path has a long name, it could push. Not fixed here — keeping the diff minimal — but a candidate if the safety net doesn't fully clean up visually.
- **`<main>`** — no `overflow-x` constraint. The shell `overflow-x-hidden` now covers it.

The shell fix bounds anything I missed to the viewport. If Aaron still sees subtle inner overflow inside a card *after* this ships, the next iteration should target `PathTree` and the `TagFilter` label (`<label flex>` without `min-w-0` around a `<span flex-1 truncate>`).

## Test plan

- [x] `bun run test` — 576 tests pass
- [x] `bun run typecheck` clean
- [ ] Lint has 1 pre-existing error in `TranscriptionStatus.test.tsx` (unchanged by this PR; called out in #67 follow-up territory)
- [ ] **Manual (Aaron):** Chrome devtools 360px viewport, `/lens/`, scroll the notes list. Horizontal scrollbar on the page should be impossible. If a card still visually looks cut off *inside* its own width, report the specific note and we iterate on `PathTree` / `TagFilter`.
- [ ] **Manual (Aaron):** On iPhone PWA, swipe horizontally anywhere on `/lens/` — no horizontal pan should be possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)