### PR TITLE
feat(notes): reverse the Lens→Notes rename back to Notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,16 @@
-# parachute-lens
+# parachute-notes
 
-A browser-based companion for any Parachute Vault. Vite + React + TypeScript, installable PWA, served at `/lens/` under the ecosystem origin. OAuth 2.1 + PKCE + RFC 7591 DCR against the vault (discovery now probes hub-origin per PR #55).
+A browser-based companion for any Parachute Vault. Vite + React + TypeScript, installable PWA, served at `/notes/` under the ecosystem origin. OAuth 2.1 + PKCE + RFC 7591 DCR against the vault (discovery now probes hub-origin per PR #55).
+
+> **Naming history.** The package and mount path were briefly renamed `lens` / `/lens/` in rc.1 before the team reverted to "Notes" on 2026-04-22 ahead of launch. Internal identifiers that hold user data across that rename are preserved intentionally: the IndexedDB name stays `parachute-lens`, the `lens:*` localStorage key prefix stays, and the settings note is read from its legacy path once on 404 fallback. See PR #74 for the full revert.
 
 ## Mount-path architecture
 
-Lens lives at `/lens/` externally and uses mount-relative internal routes.
+Notes lives at `/notes/` externally and uses mount-relative internal routes.
 
-- **Vite `base`** = `/lens/` — asset URLs, PWA manifest scope, service worker
-- **BrowserRouter `basename`** = `/lens` (from `import.meta.env.BASE_URL`)
-- **Internal routes** — `/`, `/:id`, `/:id/edit`, `/pinned`, `/tags`, `/new`, `/add` — no `/lens/` prefix. React Router v7 ranked routing picks static routes over `/:id` correctly.
+- **Vite `base`** = `/notes/` — asset URLs, PWA manifest scope, service worker
+- **BrowserRouter `basename`** = `/notes` (from `import.meta.env.BASE_URL`)
+- **Internal routes** — `/`, `/:id`, `/:id/edit`, `/pinned`, `/tags`, `/new`, `/add` — no `/notes/` prefix. React Router v7 ranked routing picks static routes over `/:id` correctly.
 - **OAuth redirect URI** — `BASE_URL + "oauth/callback"` via `basePathPrefix()` in `src/lib/vault/oauth.ts`
 - **Deep-link shim** — `/:id` + `/:id/edit` redirect to the right internal routes (PR #54) for pre-refactor bookmarks
 
@@ -27,7 +29,9 @@ Instead, add the tag to the `TagRoles` object and read it at the point of use.
 
 - Type + helpers: `src/lib/vault/tag-roles.ts`
 - Settings UI: `TagRolesSection` in `src/app/routes/Settings.tsx`
-- Storage key: `lens:tag-roles:<vaultId>` in `localStorage` (per-vault)
+- Vault storage: `.parachute/notes/settings` note, `metadata.notes` sub-object
+  (legacy reads at `.parachute/lens/settings` / `metadata.lens` fall through
+  once, then get rewritten at the new path on next change)
 
 ### Current roles
 
@@ -55,25 +59,18 @@ Instead, add the tag to the `TagRoles` object and read it at the point of use.
 
 ### Pattern: per-vault UI/integration settings in general
 
-Other per-vault settings follow the same shape:
+Other per-vault settings follow the same shape via the `useVaultSettings` hook,
+which stores a single JSON blob inside the `.parachute/notes/settings` note
+and merges-on-409 across devices. Reach for it (not a new store pattern) when
+you need "a small JSON blob that belongs to a single vault and rarely
+changes."
 
-- Plain `load<Feature>(vaultId)` / `save<Feature>(vaultId, x)` /
-  `delete<Feature>(vaultId)` around `localStorage` with a key of
-  `lens:<feature>:<vaultId>`.
-- A thin `use<Feature>(vaultId)` hook that re-reads on `vaultId` change and
-  returns `{ value, setValue }`.
-- No zustand for these — localStorage is the source of truth and the hook is
-  just a convenience.
+## Transcription is vault-level, not Notes-level
 
-Reach for this primitive (not a new store pattern) when you need "a small
-JSON blob that belongs to a single vault and rarely changes."
-
-## Transcription is vault-level, not Lens-level
-
-Lens uploads audio attachments. When the attachment POST body carries
+Notes uploads audio attachments. When the attachment POST body carries
 `{ transcribe: true }`, the vault's transcription-worker picks the job up
 and (if scribe is wired) overwrites the note's `_Transcript pending._`
-placeholder with the actual transcript. Lens has no scribe client, no
+placeholder with the actual transcript. Notes has no scribe client, no
 scribe settings UI, and no direct knowledge of whether transcription is
 configured — that's the vault's concern. If a user wants voice memos with
 transcripts, they configure scribe in the vault once, not per-device.
@@ -86,4 +83,4 @@ When a PR is merged, locally:
 git checkout main && git pull
 ```
 
-Aaron runs lens via `bun link` + `parachute start lens` in development — the linked install follows whatever branch is checked out. Leaving the repo on a feature branch after merge means Aaron's running stale feature-branch code, not the merged main. Caught 2026-04-21.
+Aaron runs Notes via `bun link` + `parachute start notes` in development — the linked install follows whatever branch is checked out. Leaving the repo on a feature branch after merge means Aaron's running stale feature-branch code, not the merged main. Caught 2026-04-21.

--- a/MOBILE_SMOKE.md
+++ b/MOBILE_SMOKE.md
@@ -1,23 +1,23 @@
 # Mobile smoke — PWA install + voice memo + offline
 
-Test Lens as a PWA on a real phone. Android first (you have one), iPhone handed off to Jon.
+Test Notes as a PWA on a real phone. Android first (you have one), iPhone handed off to Jon.
 
-Prereq: tailnet chain is up (`parachute expose tailnet` on your Mac, hub + lens + vault + scribe all running), phone is on your tailnet.
+Prereq: tailnet chain is up (`parachute expose tailnet` on your Mac, hub + notes + vault + scribe all running), phone is on your tailnet.
 
 ## Android (Chrome)
 
 ### 1. Load + install
 
-- [ ] Open Chrome, go to `https://parachute.<tailnet>.ts.net/lens/`
+- [ ] Open Chrome, go to `https://parachute.<tailnet>.ts.net/notes/`
 - [ ] Page loads, renders notes UI (header, sidebar, list)
-- [ ] Chrome's "Install Parachute Lens" prompt appears in the address bar or menu
+- [ ] Chrome's "Install Parachute Notes" prompt appears in the address bar or menu
 - [ ] Tap "Install", confirm
-- [ ] Home-screen icon appears, labeled "Parachute Lens"
+- [ ] Home-screen icon appears, labeled "Parachute Notes"
 - [ ] Tap the home-screen icon → app opens fullscreen (no browser chrome)
 
 ### 2. OAuth (if not already connected)
 
-- [ ] "Add vault" screen appears (or "Connect" — whichever route lens has)
+- [ ] "Add vault" screen appears (or "Connect" — whichever route Notes has)
 - [ ] Paste vault URL: `https://parachute.<tailnet>.ts.net/vault/default/`
 - [ ] Consent screen shows
 - [ ] Password (+ 2FA if configured) succeeds
@@ -49,7 +49,7 @@ Prereq: tailnet chain is up (`parachute expose tailnet` on your Mac, hub + lens 
 - [ ] Tap-and-hold record button, say "testing voice memo one two three"
 - [ ] Release → progress indicator shows "uploading"
 - [ ] Note appears with audio attachment
-- [ ] If the vault has scribe configured, transcript replaces `_Transcript pending._` in the note within ~10s (transcription is vault-level — Lens just flags `transcribe: true` on the attachment)
+- [ ] If the vault has scribe configured, transcript replaces `_Transcript pending._` in the note within ~10s (transcription is vault-level — Notes just flags `transcribe: true` on the attachment)
 
 ### 6. Offline
 
@@ -102,6 +102,6 @@ Same steps as Android, with iOS-specific checks:
 - Install prompt never appears → manifest.json or service worker issue. Open DevTools → Application tab → Manifest, Service Workers.
 - OAuth fails → check `/.well-known/oauth-authorization-server` resolves, check mixed-content (HTTPS required for PKCE).
 - Voice memo records but upload fails → check CORS on vault, network tab for actual request.
-- Transcript never appears → scribe not wired on the vault side (Lens just flags `transcribe: true` on the attachment; the vault's transcription-worker is what invokes scribe). Check the vault's `SCRIBE_URL` / scribe config.
+- Transcript never appears → scribe not wired on the vault side (Notes just flags `transcribe: true` on the attachment; the vault's transcription-worker is what invokes scribe). Check the vault's `SCRIBE_URL` / scribe config.
 
 Report outcomes as a checklist back in this file or as a GitHub issue, with device + OS version.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Parachute Lens
+# Parachute Notes
 
 The default frontend for [Parachute](https://parachute.computer). Browse, edit, and capture in any [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault), from any device.
 
-Parachute Lens is a static single-page app that speaks directly to your vault over its HTTP API. Point it at any vault URL, do OAuth, and browse, edit, create, and visualize your notes. No opinion about how you organize your vault — just a good lens onto what's there.
+Parachute Notes is a static single-page app that speaks directly to your vault over its HTTP API. Point it at any vault URL, do OAuth, and browse, edit, create, and visualize your notes. No opinion about how you organize your vault — just a clear window onto what's there.
 
 ## Status
 
 v1 shipped; v0.2 in progress — offline-capable PWA.
 
-## Install Parachute Lens
+## Install Parachute Notes
 
-Parachute Lens is installable as a Progressive Web App. Once installed, it runs in its own window, launches from your home screen or dock, and (from v0.2 onward) keeps working when you're offline.
+Parachute Notes is installable as a Progressive Web App. Once installed, it runs in its own window, launches from your home screen or dock, and (from v0.2 onward) keeps working when you're offline.
 
-- **Desktop Chrome / Edge** — visit your hosted Parachute Lens, click **Install app** in the header, or use the browser's install icon in the address bar.
+- **Desktop Chrome / Edge** — visit your hosted Parachute Notes, click **Install app** in the header, or use the browser's install icon in the address bar.
 - **Android Chrome** — tap **Install app**, or use the browser menu → **Install app**.
-- **iOS Safari** — tap the Share icon, then **Add to Home Screen**. (Safari doesn't expose a JS install prompt, so Parachute Lens shows a hint with the steps.)
+- **iOS Safari** — tap the Share icon, then **Add to Home Screen**. (Safari doesn't expose a JS install prompt, so Parachute Notes shows a hint with the steps.)
 
 A few iOS quirks worth knowing:
 

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
     <meta name="color-scheme" content="light dark" />
     <meta
       name="description"
-      content="Parachute Lens — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault."
+      content="Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault."
     />
-    <title>Parachute Lens</title>
+    <title>Parachute Notes</title>
     <script>
       (function () {
         try {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@openparachute/lens",
-  "version": "0.3.0-rc.1",
+  "name": "@openparachute/notes",
+  "version": "0.3.0-rc.2",
   "private": false,
   "type": "module",
-  "description": "Parachute Lens — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
+  "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParachuteComputer/parachute-lens.git"
+    "url": "https://github.com/ParachuteComputer/parachute-notes.git"
   },
   "files": ["dist", "README.md", "LICENSE"],
   "scripts": {

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <title>Parachute Lens</title>
+  <title>Parachute Notes</title>
   <rect width="512" height="512" rx="96" ry="96" fill="#4a7c59" />
   <circle cx="256" cy="256" r="130" fill="none" stroke="#faf8f4" stroke-width="32" />
   <circle cx="256" cy="256" r="44" fill="#faf8f4" />

--- a/scripts/info-endpoint-plugin.test.ts
+++ b/scripts/info-endpoint-plugin.test.ts
@@ -2,26 +2,26 @@ import { describe, expect, it } from "vitest";
 import { type ServiceInfo, buildServiceInfo, infoEndpointPlugin } from "./info-endpoint-plugin";
 
 const exampleInfo: ServiceInfo = {
-  name: "parachute-lens",
-  displayName: "Lens",
+  name: "parachute-notes",
+  displayName: "Notes",
   tagline: "Web client for your Parachute Vault",
   version: "0.0.1",
-  iconUrl: "/lens/icon.svg",
+  iconUrl: "/notes/icon.svg",
   kind: "frontend",
 };
 
 describe("buildServiceInfo", () => {
   it("threads basePath into iconUrl and carries kind through", () => {
     const info = buildServiceInfo({
-      name: "parachute-lens",
-      displayName: "Lens",
+      name: "parachute-notes",
+      displayName: "Notes",
       tagline: "Web client for your Parachute Vault",
       version: "0.0.1",
-      basePath: "/lens",
+      basePath: "/notes",
       iconFile: "icon.svg",
       kind: "frontend",
     });
-    expect(info.iconUrl).toBe("/lens/icon.svg");
+    expect(info.iconUrl).toBe("/notes/icon.svg");
     expect(info.kind).toBe("frontend");
   });
 
@@ -31,11 +31,11 @@ describe("buildServiceInfo", () => {
       displayName: "X",
       tagline: "t",
       version: "1",
-      basePath: "/lens/",
+      basePath: "/notes/",
       iconFile: "/icon.svg",
       kind: "frontend",
     });
-    expect(info.iconUrl).toBe("/lens/icon.svg");
+    expect(info.iconUrl).toBe("/notes/icon.svg");
   });
 
   it("accepts alternate kinds for non-frontend services", () => {
@@ -54,7 +54,7 @@ describe("buildServiceInfo", () => {
 
 describe("infoEndpointPlugin", () => {
   it("emits .parachute/info.json into the bundle on build", () => {
-    const plugin = infoEndpointPlugin({ basePath: "/lens", ...exampleInfo });
+    const plugin = infoEndpointPlugin({ basePath: "/notes", ...exampleInfo });
     const emitted: Array<{ type: string; fileName?: string; source?: string | Uint8Array }> = [];
     const ctx = {
       emitFile(file: { type: string; fileName?: string; source?: string | Uint8Array }) {
@@ -78,7 +78,7 @@ describe("infoEndpointPlugin", () => {
   });
 
   it("serves the same JSON via dev server middleware at basePath/.parachute/info.json", () => {
-    const plugin = infoEndpointPlugin({ basePath: "/lens", ...exampleInfo });
+    const plugin = infoEndpointPlugin({ basePath: "/notes", ...exampleInfo });
     const uses: Array<{ path: string; handler: (req: unknown, res: MockRes) => void }> = [];
     const fakeServer = {
       middlewares: {
@@ -94,7 +94,7 @@ describe("infoEndpointPlugin", () => {
     configure.call(plugin as any, fakeServer as any);
 
     expect(uses).toHaveLength(1);
-    expect(uses[0]?.path).toBe("/lens/.parachute/info.json");
+    expect(uses[0]?.path).toBe("/notes/.parachute/info.json");
 
     const res = new MockRes();
     uses[0]?.handler({}, res);

--- a/scripts/info-endpoint-plugin.ts
+++ b/scripts/info-endpoint-plugin.ts
@@ -41,7 +41,7 @@ export function infoEndpointPlugin(options: PluginOptions): Plugin {
   }
 
   return {
-    name: "parachute-lens-info-endpoint",
+    name: "parachute-notes-info-endpoint",
     configureServer: attach,
     configurePreviewServer: attach,
     generateBundle() {

--- a/scripts/notes-service-plugin.ts
+++ b/scripts/notes-service-plugin.ts
@@ -15,7 +15,7 @@ interface PluginOptions {
   tagline?: string;
 }
 
-// Lens is an SPA — no long-running Node entrypoint that would otherwise own
+// Notes is an SPA — no long-running Node entrypoint that would otherwise own
 // the manifest write. Hook the Vite dev + preview servers instead so the
 // manifest reflects the actual listening port. We deliberately do NOT write
 // during `vite build` (no port to advertise; the CLI's expose tool registers
@@ -23,7 +23,7 @@ interface PluginOptions {
 //
 // Best-effort: a manifest write failure (PARACHUTE_HOME unwritable, schema
 // drift, malformed pre-existing file) only logs a warning. Don't break dev.
-export function lensServicePlugin(options: PluginOptions): Plugin {
+export function notesServicePlugin(options: PluginOptions): Plugin {
   const { name, version, basePath, displayName, tagline } = options;
   const healthPath = basePath.endsWith("/") ? basePath : `${basePath}/`;
 
@@ -54,7 +54,7 @@ export function lensServicePlugin(options: PluginOptions): Plugin {
   }
 
   return {
-    name: "parachute-lens-service-manifest",
+    name: "parachute-notes-service-manifest",
     apply: (_config, env) => env.command === "serve",
     configureServer: attach,
     configurePreviewServer: attach,

--- a/scripts/services-manifest.test.ts
+++ b/scripts/services-manifest.test.ts
@@ -11,18 +11,18 @@ import {
 } from "./services-manifest";
 
 function tempPath(): { path: string; cleanup: () => void } {
-  const dir = mkdtempSync(join(tmpdir(), "plens-manifest-"));
+  const dir = mkdtempSync(join(tmpdir(), "pnotes-manifest-"));
   const path = join(dir, "services.json");
   return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 }
 
-const lens: ServiceEntry = {
-  name: "parachute-lens",
+const notes: ServiceEntry = {
+  name: "parachute-notes",
   port: 1942,
-  paths: ["/lens/"],
-  health: "/lens/",
+  paths: ["/notes/"],
+  health: "/notes/",
   version: "0.0.1",
-  displayName: "Lens",
+  displayName: "Notes",
   tagline: "Web client for your Parachute Vault",
 };
 
@@ -47,9 +47,9 @@ describe("services-manifest", () => {
   it("upsertService creates the file if missing", () => {
     const { path, cleanup } = tempPath();
     try {
-      const m = upsertService(lens, path);
-      expect(m.services).toEqual([lens]);
-      expect(readManifest(path)).toEqual({ services: [lens] });
+      const m = upsertService(notes, path);
+      expect(m.services).toEqual([notes]);
+      expect(readManifest(path)).toEqual({ services: [notes] });
     } finally {
       cleanup();
     }
@@ -58,8 +58,8 @@ describe("services-manifest", () => {
   it("upsertService updates by name and never duplicates", () => {
     const { path, cleanup } = tempPath();
     try {
-      upsertService(lens, path);
-      const updated = { ...lens, port: 4200, version: "0.1.0" };
+      upsertService(notes, path);
+      const updated = { ...notes, port: 4200, version: "0.1.0" };
       upsertService(updated, path);
       const m = readManifest(path);
       expect(m.services).toHaveLength(1);
@@ -73,11 +73,11 @@ describe("services-manifest", () => {
     const { path, cleanup } = tempPath();
     try {
       writeFileSync(path, `${JSON.stringify({ services: [vault] }, null, 2)}\n`);
-      upsertService(lens, path);
+      upsertService(notes, path);
       const m = readManifest(path);
       expect(m.services).toHaveLength(2);
       expect(m.services.find((s) => s.name === "parachute-vault")).toEqual(vault);
-      expect(m.services.find((s) => s.name === "parachute-lens")).toEqual(lens);
+      expect(m.services.find((s) => s.name === "parachute-notes")).toEqual(notes);
     } finally {
       cleanup();
     }
@@ -86,9 +86,9 @@ describe("services-manifest", () => {
   it("upsertService writes pretty-printed JSON with trailing newline", () => {
     const { path, cleanup } = tempPath();
     try {
-      upsertService(lens, path);
+      upsertService(notes, path);
       const raw = readFileSync(path, "utf8");
-      expect(raw).toBe(`${JSON.stringify({ services: [lens] }, null, 2)}\n`);
+      expect(raw).toBe(`${JSON.stringify({ services: [notes] }, null, 2)}\n`);
     } finally {
       cleanup();
     }
@@ -108,7 +108,7 @@ describe("services-manifest", () => {
     const { path, cleanup } = tempPath();
     try {
       writeFileSync(path, `${JSON.stringify({ services: [vault] }, null, 2)}\n`);
-      const bad = { ...lens, port: -1 };
+      const bad = { ...notes, port: -1 };
       expect(() => upsertService(bad as ServiceEntry, path)).toThrow(ServicesManifestError);
       expect(readManifest(path)).toEqual({ services: [vault] });
     } finally {
@@ -131,9 +131,9 @@ describe("services-manifest", () => {
   it("rejects non-string displayName / tagline", () => {
     const { path, cleanup } = tempPath();
     try {
-      const badDisplay = { ...lens, displayName: 42 } as unknown as ServiceEntry;
+      const badDisplay = { ...notes, displayName: 42 } as unknown as ServiceEntry;
       expect(() => upsertService(badDisplay, path)).toThrow(/displayName/);
-      const badTagline = { ...lens, tagline: 42 } as unknown as ServiceEntry;
+      const badTagline = { ...notes, tagline: 42 } as unknown as ServiceEntry;
       expect(() => upsertService(badTagline, path)).toThrow(/tagline/);
     } finally {
       cleanup();
@@ -141,13 +141,13 @@ describe("services-manifest", () => {
   });
 
   it("default path honors PARACHUTE_HOME set at runtime", () => {
-    const dir = mkdtempSync(join(tmpdir(), "plens-home-"));
+    const dir = mkdtempSync(join(tmpdir(), "pnotes-home-"));
     const prior = process.env.PARACHUTE_HOME;
     process.env.PARACHUTE_HOME = dir;
     try {
       expect(servicesManifestPath()).toBe(join(dir, "services.json"));
-      upsertService(lens);
-      expect(readManifest()).toEqual({ services: [lens] });
+      upsertService(notes);
+      expect(readManifest()).toEqual({ services: [notes] });
     } finally {
       // biome-ignore lint/performance/noDelete: process.env coerces assignments to strings; only delete actually unsets the key
       if (prior === undefined) delete process.env.PARACHUTE_HOME;

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -15,9 +15,9 @@ describe("App", () => {
     localStorage.clear();
     sessionStorage.clear();
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
-    // BrowserRouter is mounted with basename="/lens" (BASE_URL from Vite).
-    // Tests simulate the external mount by placing the browser under /lens/.
-    window.history.replaceState({}, "", "/lens/");
+    // BrowserRouter is mounted with basename="/notes" (BASE_URL from Vite).
+    // Tests simulate the external mount by placing the browser under /notes/.
+    window.history.replaceState({}, "", "/notes/");
     stubFetch();
   });
 
@@ -26,9 +26,9 @@ describe("App", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders the Parachute Lens wordmark and the connect CTA when no vaults exist", async () => {
+  it("renders the Parachute Notes wordmark and the connect CTA when no vaults exist", async () => {
     render(<App />);
-    expect(screen.getByRole("link", { name: /parachute lens/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /parachute notes/i })).toBeInTheDocument();
     // Home holds back the CTA until the origin probe settles to avoid
     // flashing "Connect a vault" before swapping to "Looks like there's a
     // vault at …". Wait for the probe to resolve before asserting the CTA.
@@ -38,34 +38,34 @@ describe("App", () => {
     expect(screen.getByText(/no vault connected/i)).toBeInTheDocument();
   });
 
-  it("resolves the root list view at external /lens/ without double-prefixing", () => {
+  it("resolves the root list view at external /notes/ without double-prefixing", () => {
     render(<App />);
-    // Regression guard against the /lens/lens bug: with basename="/lens"
+    // Regression guard against the /notes/notes bug: with basename="/notes"
     // stripping the external prefix, the internal path is "/" and the index
-    // dispatcher (Home for no vault) renders. The URL must stay /lens/, not
-    // become /lens/lens.
-    expect(screen.getByRole("link", { name: /parachute lens/i })).toBeInTheDocument();
-    expect(window.location.pathname).toBe("/lens/");
+    // dispatcher (Home for no vault) renders. The URL must stay /notes/, not
+    // become /notes/notes.
+    expect(screen.getByRole("link", { name: /parachute notes/i })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/notes/");
   });
 
-  it("resolves NoteView at external /lens/n/<id>", () => {
-    window.history.replaceState({}, "", "/lens/n/some-id");
+  it("resolves NoteView at external /notes/n/<id>", () => {
+    window.history.replaceState({}, "", "/notes/n/some-id");
     render(<App />);
     // With no vault the NoteView route redirects internally to "/" (basename
-    // strips /lens). The critical regression guard: the external URL must
-    // sit under /lens, never /lens/lens.
-    expect(window.location.pathname.startsWith("/lens")).toBe(true);
-    expect(window.location.pathname.startsWith("/lens/lens")).toBe(false);
+    // strips /notes). The critical regression guard: the external URL must
+    // sit under /notes, never /notes/notes.
+    expect(window.location.pathname.startsWith("/notes")).toBe(true);
+    expect(window.location.pathname.startsWith("/notes/notes")).toBe(false);
   });
 
-  it("catch-all redirects to the root list, not /lens/lens", () => {
-    window.history.replaceState({}, "", "/lens/some-unknown-internal-path");
+  it("catch-all redirects to the root list, not /notes/notes", () => {
+    window.history.replaceState({}, "", "/notes/some-unknown-internal-path");
     render(<App />);
-    // The `*` route navigates to internal `/`. With basename=/lens this is
-    // external /lens (with or without trailing slash — both resolve the root
-    // list). The bug Aaron hit (/lens/lens) would surface here if basename
+    // The `*` route navigates to internal `/`. With basename=/notes this is
+    // external /notes (with or without trailing slash — both resolve the root
+    // list). The bug Aaron hit (/notes/notes) would surface here if basename
     // and route paths disagreed.
-    expect(window.location.pathname).toMatch(/^\/lens\/?$/);
+    expect(window.location.pathname).toMatch(/^\/notes\/?$/);
   });
 
   it("clamps horizontal overflow at the shell so a stray wide descendant can't scroll the viewport", () => {
@@ -77,7 +77,7 @@ describe("App", () => {
     // a horizontal scroller. jsdom doesn't compute layout, so this is a
     // class-presence check, not a measured scrollWidth assertion — the
     // manual-testing steps live in the PR body.
-    const shell = screen.getByRole("link", { name: /parachute lens/i }).closest("div.min-h-dvh");
+    const shell = screen.getByRole("link", { name: /parachute notes/i }).closest("div.min-h-dvh");
     expect(shell).not.toBeNull();
     expect(shell?.className).toMatch(/\boverflow-x-hidden\b/);
   });
@@ -98,13 +98,13 @@ describe("App", () => {
       },
       activeVaultId: "v1",
     });
-    window.history.replaceState({}, "", "/lens/settings");
+    window.history.replaceState({}, "", "/notes/settings");
     render(<App />);
     // Regression guard against future route-table accidents: RR7's ranked
     // routing must hold `/settings` (and every other named static route)
     // above the `/:id` pre-#49 bookmark shim. If this ever fails, the shim
     // would start swallowing real internal pages.
     expect(screen.getByRole("heading", { level: 1, name: /settings/i })).toBeInTheDocument();
-    expect(window.location.pathname).toBe("/lens/settings");
+    expect(window.location.pathname).toBe("/notes/settings");
   });
 });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -24,7 +24,7 @@ import { VaultGraph } from "./routes/VaultGraph";
 import { Vaults } from "./routes/Vaults";
 
 // Index dispatcher: render the notes list when a vault is connected, else the
-// landing page. Both live at internal `/`, which maps to external `/lens/`
+// landing page. Both live at internal `/`, which maps to external `/notes/`
 // via BrowserRouter's basename. Keeps Notes free of "no vault?" presentation
 // concerns and Home free of any redirect logic.
 function NotesIndex() {
@@ -33,10 +33,11 @@ function NotesIndex() {
 }
 
 // Shim for pre-mount external bookmarks. When the app lived at the origin root,
-// links were `/<id>` and `/<id>/edit`. After Lens moved under `/lens/`,
-// Tailscale strips that prefix, leaving internal `/<id>` and `/<id>/edit` —
-// which the catch-all would otherwise bounce to `/`. Redirect them to the
-// canonical `/n/<id>` routes so old bookmarks survive.
+// links were `/<id>` and `/<id>/edit`. After the frontend moved under its own
+// mount (now `/notes/`), Tailscale strips that prefix, leaving internal
+// `/<id>` and `/<id>/edit` — which the catch-all would otherwise bounce to
+// `/`. Redirect them to the canonical `/n/<id>` routes so old bookmarks
+// survive.
 function NoteIdRedirect({ suffix = "" }: { suffix?: string }) {
   const { id } = useParams<{ id: string }>();
   if (!id) return <Navigate to="/" replace />;

--- a/src/app/routes/AddVault.tsx
+++ b/src/app/routes/AddVault.tsx
@@ -55,7 +55,7 @@ export function AddVault() {
       <h1 className="mb-2 font-serif text-4xl tracking-tight">Connect a vault</h1>
       <p className="mb-8 text-fg-muted">
         Paste the URL of a Parachute Vault. You'll be taken to its consent page to authorize
-        Parachute Lens.
+        Parachute Notes.
       </p>
 
       <form onSubmit={onSubmit} className="space-y-4">

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -14,7 +14,7 @@ export function Home() {
       <p className="mb-8 font-serif text-xl italic text-fg-muted">
         The default frontend for Parachute.
       </p>
-      <h1 className="mb-4 font-serif text-5xl tracking-tight">Lens</h1>
+      <h1 className="mb-4 font-serif text-5xl tracking-tight">Notes</h1>
 
       {/* Hold back the CTA while probing so we don't flash "Connect a vault"
           and then swap it for "Looks like there's a vault at ..." once the

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -54,7 +54,7 @@ function InstallStateSection() {
         <span className="mr-2 inline-block rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-300">
           Installed
         </span>
-        Parachute Lens is running as an installed app on this device.
+        Parachute Notes is running as an installed app on this device.
       </p>
     </section>
   );

--- a/src/base-url.test.ts
+++ b/src/base-url.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, it } from "vitest";
 // strips the external prefix on read and prepends it on write. Moving the
 // mount is a one-line change here — not a route-by-route search-and-replace.
 describe("import.meta.env.BASE_URL", () => {
-  it("defaults to /lens/ — Lens is mounted under /lens by the hub", () => {
-    expect(import.meta.env.BASE_URL).toBe("/lens/");
+  it("defaults to /notes/ — Notes is mounted under /notes by the hub", () => {
+    expect(import.meta.env.BASE_URL).toBe("/notes/");
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,7 +43,7 @@ export function Header() {
           to="/"
           className="font-serif text-lg tracking-tight text-fg hover:text-accent md:text-xl"
         >
-          Parachute Lens
+          Parachute Notes
         </Link>
 
         {/* Desktop nav */}

--- a/src/components/InstallPrompt.test.tsx
+++ b/src/components/InstallPrompt.test.tsx
@@ -74,7 +74,7 @@ describe("InstallPrompt", () => {
     await act(async () => {
       fireEvent.click(btn);
     });
-    expect(screen.getByText(/add parachute lens to your home screen/i)).toBeInTheDocument();
+    expect(screen.getByText(/add parachute notes to your home screen/i)).toBeInTheDocument();
     expect(screen.getByText(/share icon/i)).toBeInTheDocument();
   });
 });

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -57,14 +57,14 @@ export function InstallPrompt() {
           className="fixed inset-0 z-50 m-auto max-w-sm rounded-md border border-border bg-card p-6 text-fg shadow-lg backdrop:bg-black/40"
         >
           <h2 id="ios-install-title" className="mb-3 font-serif text-xl">
-            Add Parachute Lens to your home screen
+            Add Parachute Notes to your home screen
           </h2>
           <ol className="mb-5 list-decimal space-y-2 pl-5 text-sm text-fg-muted">
             <li>Tap the Share icon in Safari's toolbar.</li>
             <li>
               Choose <strong className="text-fg">Add to Home Screen</strong>.
             </li>
-            <li>Tap Add. Parachute Lens will open standalone from your home screen.</li>
+            <li>Tap Add. Parachute Notes will open standalone from your home screen.</li>
           </ol>
           <div className="flex justify-end">
             <button

--- a/src/components/TranscriptionStatus.tsx
+++ b/src/components/TranscriptionStatus.tsx
@@ -1,4 +1,4 @@
-// Single-purpose chip for voice-memo notes. Lens seeds the note with
+// Single-purpose chip for voice-memo notes. Notes seeds the draft with
 // `_Transcript pending._` at capture time (see `memoNoteContent()` in
 // `src/lib/capture/recorder.ts`); vault's transcription-worker swaps it
 // for either the transcript or `_Transcription unavailable._` when it

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -19,7 +19,7 @@ export function UpdateBanner() {
 
   return (
     <output className="fixed inset-x-0 bottom-4 z-40 mx-auto flex max-w-sm items-center justify-between gap-3 rounded-md border border-border bg-card px-4 py-3 shadow-lg">
-      <p className="text-sm text-fg">A new version of Parachute Lens is available.</p>
+      <p className="text-sm text-fg">A new version of Parachute Notes is available.</p>
       <div className="flex gap-2">
         <button
           type="button"

--- a/src/lib/sync/db.ts
+++ b/src/lib/sync/db.ts
@@ -1,6 +1,10 @@
 import { type DBSchema, type IDBPDatabase, openDB } from "idb";
 import type { BlobPathMapRow, IdMapRow, MetaRow, PendingRow } from "./types";
 
+// Preserved across the 2026-04-22 Lens→Notes rename: IndexedDB databases are
+// origin+name scoped, so renaming would orphan Aaron's (and any rc.1 user's)
+// offline queue, id-map, blob store, and queued mutations. The product's
+// external identity is "Notes"; this internal handle stays.
 export const DB_NAME = "parachute-lens";
 // Bump on schema changes and add a case to `migrate()`. Read schemaVersion from
 // `meta` if you need to introspect which migrations have run.

--- a/src/lib/sync/queue.test.ts
+++ b/src/lib/sync/queue.test.ts
@@ -459,7 +459,7 @@ describe("drain — update-settings (merge-on-409 invariant)", () => {
   });
   afterEach(() => db.close());
 
-  const settingsPath = ".parachute/lens/settings";
+  const settingsPath = ".parachute/notes/settings";
 
   it("POSTs when the settings note doesn't exist", async () => {
     const createNote = vi.fn(async () => ({ id: "srv", createdAt: "t1" }) as Note);
@@ -483,10 +483,10 @@ describe("drain — update-settings (merge-on-409 invariant)", () => {
     expect(createNote).toHaveBeenCalledOnce();
     const arg = (createNote.mock.calls as unknown as unknown[][])[0]?.[0] as {
       path: string;
-      metadata: { lens: { tagRoles: { pinned: string } } };
+      metadata: { notes: { tagRoles: { pinned: string } } };
     };
     expect(arg.path).toBe(settingsPath);
-    expect(arg.metadata.lens.tagRoles.pinned).toBe("fav");
+    expect(arg.metadata.notes.tagRoles.pinned).toBe("fav");
   });
 
   it("merges the patch onto the refetched server state, preserving a concurrent peer's write", async () => {
@@ -538,10 +538,10 @@ describe("drain — update-settings (merge-on-409 invariant)", () => {
     expect(updateNote).toHaveBeenCalledOnce();
     const call = updateNote.mock.calls[0] as unknown as [
       string,
-      { metadata: { lens: { tagRoles: Record<string, string> } }; if_updated_at?: string },
+      { metadata: { notes: { tagRoles: Record<string, string> } }; if_updated_at?: string },
     ];
-    expect(call[1].metadata.lens.tagRoles.pinned).toBe("A-pinned");
-    expect(call[1].metadata.lens.tagRoles.archived).toBe("B-archived");
+    expect(call[1].metadata.notes.tagRoles.pinned).toBe("A-pinned");
+    expect(call[1].metadata.notes.tagRoles.archived).toBe("B-archived");
     expect(call[1].if_updated_at).toBe("t1");
   });
 

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -305,7 +305,7 @@ async function drainUpdateSettings(
         await client.createNote({
           path: notePath,
           content: "",
-          metadata: { lens: applySettingsPatch(DEFAULT_LENS_SETTINGS, patch) },
+          metadata: { notes: applySettingsPatch(DEFAULT_LENS_SETTINGS, patch) },
         });
         return;
       } catch (err) {
@@ -321,7 +321,7 @@ async function drainUpdateSettings(
     const baseline = note.updatedAt ?? note.createdAt;
     try {
       await client.updateNote(notePath, {
-        metadata: { lens: merged },
+        metadata: { notes: merged },
         if_updated_at: baseline,
       });
       return;
@@ -333,7 +333,7 @@ async function drainUpdateSettings(
         // Exhausted polite retries. Force the write — merged against the
         // latest server state we fetched, so this is still the "safest
         // possible overwrite" rather than a blind one.
-        await client.updateNote(notePath, { metadata: { lens: merged }, force: true });
+        await client.updateNote(notePath, { metadata: { notes: merged }, force: true });
         return;
       }
       throw err;

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -67,7 +67,7 @@ export interface PendingLinkAttachment {
   mimeType: string;
   // When true, ask the vault to transcribe this attachment and overwrite the
   // note's `_Transcript pending._` placeholder with the transcript. Vault's
-  // transcription-worker does the actual work — Lens just flags intent.
+  // transcription-worker does the actual work — Notes just flags intent.
   transcribe?: boolean;
 }
 

--- a/src/lib/vault/discovery.test.ts
+++ b/src/lib/vault/discovery.test.ts
@@ -68,7 +68,7 @@ describe("registerClient", () => {
       {
         json: {
           client_id: "abc-123",
-          client_name: "Parachute Lens",
+          client_name: "Parachute Notes",
           redirect_uris: ["http://localhost/oauth/callback"],
         },
       },
@@ -86,7 +86,7 @@ describe("registerClient", () => {
     expect(init.method).toBe("POST");
     const body = JSON.parse(init.body as string);
     expect(body.redirect_uris).toEqual(["http://localhost/oauth/callback"]);
-    expect(body.client_name).toBe("Parachute Lens");
+    expect(body.client_name).toBe("Parachute Notes");
   });
 
   it("throws on non-OK response", async () => {

--- a/src/lib/vault/discovery.ts
+++ b/src/lib/vault/discovery.ts
@@ -42,7 +42,7 @@ export async function discoverAuthServer(
 }
 
 /**
- * Register Lens as a dynamic OAuth client (RFC 7591). Vault validates the
+ * Register Notes as a dynamic OAuth client (RFC 7591). Vault validates the
  * client_id against its oauth_clients table at each /oauth/authorize, so
  * we must register before we can redirect the user.
  */
@@ -55,7 +55,7 @@ export async function registerClient(
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
     body: JSON.stringify({
-      client_name: "Parachute Lens",
+      client_name: "Parachute Notes",
       redirect_uris: [redirectUri],
       grant_types: ["authorization_code"],
       response_types: ["code"],

--- a/src/lib/vault/oauth.test.ts
+++ b/src/lib/vault/oauth.test.ts
@@ -18,7 +18,7 @@ const validMetadata = {
 
 const clientReg = {
   client_id: "client-123",
-  client_name: "Parachute Lens",
+  client_name: "Parachute Notes",
   redirect_uris: ["http://localhost:3000/oauth/callback"],
 };
 
@@ -53,7 +53,7 @@ describe("beginOAuth", () => {
     expect(url.searchParams.get("response_type")).toBe("code");
     expect(url.searchParams.get("client_id")).toBe("client-123");
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
-    expect(url.searchParams.get("redirect_uri")).toBe("http://localhost:3000/lens/oauth/callback");
+    expect(url.searchParams.get("redirect_uri")).toBe("http://localhost:3000/notes/oauth/callback");
     expect(url.searchParams.get("scope")).toBe("full");
 
     const challenge = url.searchParams.get("code_challenge");
@@ -86,17 +86,17 @@ describe("redirectUriForOrigin under VITE_BASE_PATH", () => {
     );
   });
 
-  it("includes the base path when Lens is mounted under a sub-path", () => {
-    vi.stubEnv("BASE_URL", "/lens/");
+  it("includes the base path when Notes is mounted under a sub-path", () => {
+    vi.stubEnv("BASE_URL", "/notes/");
     expect(redirectUriForOrigin("http://host.example")).toBe(
-      "http://host.example/lens/oauth/callback",
+      "http://host.example/notes/oauth/callback",
     );
   });
 
   it("strips a single trailing slash on the origin and the base", () => {
-    vi.stubEnv("BASE_URL", "/lens/");
+    vi.stubEnv("BASE_URL", "/notes/");
     expect(redirectUriForOrigin("http://host.example/")).toBe(
-      "http://host.example/lens/oauth/callback",
+      "http://host.example/notes/oauth/callback",
     );
   });
 });

--- a/src/lib/vault/oauth.ts
+++ b/src/lib/vault/oauth.ts
@@ -6,8 +6,8 @@ import { normalizeVaultUrl } from "./url";
 
 const REDIRECT_PATH = "/oauth/callback";
 
-// Lens is mounted under `import.meta.env.BASE_URL` (defaults to `/`, can be
-// `/lens/` when the CLI's expose tooling path-routes us). The OAuth callback
+// Notes is mounted under `import.meta.env.BASE_URL` (defaults to `/`, can be
+// `/notes/` when the CLI's expose tooling path-routes us). The OAuth callback
 // must include that prefix so the authorization server bounces the browser
 // back to a URL the SPA actually serves.
 function basePathPrefix(): string {

--- a/src/lib/vault/probe.ts
+++ b/src/lib/vault/probe.ts
@@ -22,7 +22,7 @@ const DEFAULT_TIMEOUT_MS = 2500;
 //      case: the hub origin *itself* proxies OAuth metadata (so direct
 //      discovery would succeed at the hub origin, which isn't a vault),
 //      but only the registry reveals the actual vault resource URL
-//      (`${origin}/vault/<name>`). Preferring the registry ensures Lens
+//      (`${origin}/vault/<name>`). Preferring the registry ensures Notes
 //      ends up pointing at the vault and not at the portal.
 //   2. Direct OAuth discovery fallback:
 //      `${input}/.well-known/oauth-authorization-server`. Covers the

--- a/src/lib/vault/settings.test.ts
+++ b/src/lib/vault/settings.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_LENS_SETTINGS,
+  LEGACY_SETTINGS_NOTE_PATH,
   SETTINGS_NOTE_PATH,
   SETTINGS_SCHEMA_VERSION,
   type SettingsCacheEntry,
@@ -19,7 +20,13 @@ describe("settings note path is stable", () => {
   it("pins the vault path so concurrent devices agree", () => {
     // Changing this would make already-deployed installs lose their settings.
     // Bump schemaVersion and migrate instead if the shape needs to change.
-    expect(SETTINGS_NOTE_PATH).toBe(".parachute/lens/settings");
+    expect(SETTINGS_NOTE_PATH).toBe(".parachute/notes/settings");
+  });
+
+  it("remembers the prior Lens-branded path for read-only fallback", () => {
+    // Aaron's running machine (and anyone who ran the brief Lens-branded
+    // window) has settings under the legacy path. We read but never write it.
+    expect(LEGACY_SETTINGS_NOTE_PATH).toBe(".parachute/lens/settings");
   });
 });
 
@@ -62,7 +69,7 @@ describe("extractLensSettings", () => {
     expect(extractLensSettings(note)).toEqual(DEFAULT_LENS_SETTINGS);
   });
 
-  it("returns defaults when metadata.lens is missing", () => {
+  it("returns defaults when the notes/lens sub-object is missing", () => {
     const note: Note = {
       id: "n1",
       createdAt: "2026-04-22T00:00:00Z",
@@ -71,12 +78,12 @@ describe("extractLensSettings", () => {
     expect(extractLensSettings(note)).toEqual(DEFAULT_LENS_SETTINGS);
   });
 
-  it("reads the lens sub-object from metadata", () => {
+  it("reads the notes sub-object from metadata", () => {
     const note: Note = {
       id: "n1",
       createdAt: "2026-04-22T00:00:00Z",
       metadata: {
-        lens: {
+        notes: {
           schemaVersion: 1,
           tagRoles: { pinned: "favs", archived: "done" },
         },
@@ -86,6 +93,35 @@ describe("extractLensSettings", () => {
     expect(out.tagRoles.pinned).toBe("favs");
     expect(out.tagRoles.archived).toBe("done");
     expect(out.tagRoles.captureVoice).toBe(DEFAULT_TAG_ROLES.captureVoice);
+  });
+
+  it("falls back to the legacy `lens` key when `notes` is absent", () => {
+    // A settings note written under the prior Lens-branded release stores the
+    // payload at `metadata.lens`. Read-through keeps existing installs working
+    // until the next write, which will re-key under `notes`.
+    const note: Note = {
+      id: "n1",
+      createdAt: "2026-04-22T00:00:00Z",
+      metadata: {
+        lens: {
+          schemaVersion: 1,
+          tagRoles: { pinned: "legacy-fav" },
+        },
+      },
+    };
+    expect(extractLensSettings(note).tagRoles.pinned).toBe("legacy-fav");
+  });
+
+  it("prefers `notes` over `lens` when both are present", () => {
+    const note: Note = {
+      id: "n1",
+      createdAt: "2026-04-22T00:00:00Z",
+      metadata: {
+        lens: { schemaVersion: 1, tagRoles: { pinned: "old" } },
+        notes: { schemaVersion: 1, tagRoles: { pinned: "new" } },
+      },
+    };
+    expect(extractLensSettings(note).tagRoles.pinned).toBe("new");
   });
 });
 
@@ -248,7 +284,7 @@ describe("concurrent-write invariant (merge-on-409)", () => {
       createdAt: "2026-04-22T09:00:00Z",
       updatedAt: "2026-04-22T10:30:00Z",
       metadata: {
-        lens: {
+        notes: {
           schemaVersion: 1,
           tagRoles: { ...DEFAULT_TAG_ROLES, pinned: "A-pinned" },
         },

--- a/src/lib/vault/settings.ts
+++ b/src/lib/vault/settings.ts
@@ -8,12 +8,18 @@ import { DEFAULT_TAG_ROLES, type TagRoles, loadTagRoles, normalizeTagRoles } fro
 import type { Note } from "./types";
 
 // Per-vault settings live in a single note at this path. We stash the payload
-// in the note's metadata (under a `lens` key, so other modules could
+// in the note's metadata (under a `notes` key, so other modules could
 // theoretically share the file) and leave the note body empty. See
 // CLAUDE.md — "Tag roles" section for the motivation: without a vault-hosted
 // canonical copy, per-device localStorage can't sync across Aaron's laptop /
 // tablet / phone.
-export const SETTINGS_NOTE_PATH = ".parachute/lens/settings";
+export const SETTINGS_NOTE_PATH = ".parachute/notes/settings";
+
+// Prior location used by the Lens-branded frontend. Read on fetch-fallback so
+// existing installs (Aaron's running machine, anyone who hit main during the
+// brief Lens-branded window) keep their settings through the rebrand. We never
+// write here — the legacy note becomes harmless dead data after migration.
+export const LEGACY_SETTINGS_NOTE_PATH = ".parachute/lens/settings";
 
 export const SETTINGS_SCHEMA_VERSION = 1;
 
@@ -55,7 +61,9 @@ export function extractLensSettings(note: Note | null | undefined): LensSettings
     return { ...DEFAULT_LENS_SETTINGS, tagRoles: { ...DEFAULT_TAG_ROLES } };
   }
   const meta = note.metadata as Record<string, unknown>;
-  return normalizeLensSettings(meta.lens);
+  // Read `notes` first, fall back to the legacy `lens` key so a settings note
+  // written under the prior rename is still understood until it's next rewritten.
+  return normalizeLensSettings(meta.notes ?? meta.lens);
 }
 
 export function applySettingsPatch(base: LensSettings, patch: LensSettingsPatch): LensSettings {
@@ -239,7 +247,7 @@ async function writeSettingsToVault(
     const initial = applySettingsPatch(state.serverSettings ?? DEFAULT_LENS_SETTINGS, patch);
     try {
       const created = await client.createNote(
-        { path: SETTINGS_NOTE_PATH, content: "", metadata: { lens: initial } },
+        { path: SETTINGS_NOTE_PATH, content: "", metadata: { notes: initial } },
         { signal },
       );
       return {
@@ -264,7 +272,7 @@ async function writeSettingsToVault(
       const optimisticMerge = applySettingsPatch(state.serverSettings, patch);
       const updated = await client.updateNote(
         SETTINGS_NOTE_PATH,
-        { metadata: { lens: optimisticMerge }, if_updated_at: state.serverUpdatedAt },
+        { metadata: { notes: optimisticMerge }, if_updated_at: state.serverUpdatedAt },
         { signal },
       );
       return {
@@ -303,7 +311,7 @@ async function patchWithRefetch(
   if (!note) {
     const initial = applySettingsPatch(DEFAULT_LENS_SETTINGS, patch);
     const created = await client.createNote(
-      { path: SETTINGS_NOTE_PATH, content: "", metadata: { lens: initial } },
+      { path: SETTINGS_NOTE_PATH, content: "", metadata: { notes: initial } },
       { signal },
     );
     return {
@@ -317,7 +325,7 @@ async function patchWithRefetch(
   const baseline = note.updatedAt ?? note.createdAt;
   const updated = await client.updateNote(
     SETTINGS_NOTE_PATH,
-    { metadata: { lens: merged }, if_updated_at: baseline },
+    { metadata: { notes: merged }, if_updated_at: baseline },
     { signal },
   );
   return {
@@ -385,10 +393,24 @@ export function useVaultSettings(vaultId: string | null): UseVaultSettingsResult
         }
         return { server: null, serverUpdatedAt: null, noteExists: false as const };
       } catch (err) {
-        if (err instanceof VaultNotFoundError) {
-          return { server: null, serverUpdatedAt: null, noteExists: false as const };
+        if (!(err instanceof VaultNotFoundError)) throw err;
+        // New-path 404 → try the legacy Lens-branded path. If it exists, seed
+        // the server view from it but report `noteExists: false` so the next
+        // write POSTs a fresh note at the new path instead of PATCHing the
+        // legacy one. The legacy note stays in place as harmless dead data.
+        try {
+          const legacy = await client!.getNote(LEGACY_SETTINGS_NOTE_PATH);
+          if (legacy) {
+            return {
+              server: extractLensSettings(legacy),
+              serverUpdatedAt: null,
+              noteExists: false as const,
+            };
+          }
+        } catch (legacyErr) {
+          if (!(legacyErr instanceof VaultNotFoundError)) throw legacyErr;
         }
-        throw err;
+        return { server: null, serverUpdatedAt: null, noteExists: false as const };
       }
     },
     retry: false,
@@ -437,13 +459,16 @@ export function useVaultSettings(vaultId: string | null): UseVaultSettingsResult
       return;
     }
 
-    // No local pending change — trust the server.
+    // No local pending change — trust the server. Respect `remote.noteExists`
+    // (not hardcoded true) because the legacy-path fallback loads server
+    // content from `.parachute/lens/settings` but reports `noteExists: false`
+    // so the next write POSTs at the new path rather than PATCHing the legacy.
     const nextEntry: SettingsCacheEntry = remote.server
       ? {
           settings: remote.server,
           serverSettings: remote.server,
           serverUpdatedAt: remote.serverUpdatedAt,
-          noteExists: true,
+          noteExists: remote.noteExists,
           dirtyPatch: null,
         }
       : {
@@ -555,7 +580,7 @@ export function useVaultSettings(vaultId: string | null): UseVaultSettingsResult
 }
 
 // ---------------------------------------------------------------------------
-// Tag-roles wrapper — keeps the pre-existing surface the rest of Lens uses.
+// Tag-roles wrapper — keeps the pre-existing surface the rest of Notes uses.
 // Lives here, not in tag-roles.ts, to avoid a cycle (settings imports from
 // tag-roles for types and normalization helpers).
 // ---------------------------------------------------------------------------

--- a/src/lib/vault/tag-roles.ts
+++ b/src/lib/vault/tag-roles.ts
@@ -4,12 +4,15 @@
 // defaults preserve sensible behavior for a fresh vault.
 //
 // Storage: starting in v0.3.0-rc.2, tag roles live inside the vault settings
-// note (`.parachute/lens/settings`) so they sync across the same user's
-// devices. The legacy per-vault localStorage key `lens:tag-roles:<vaultId>`
-// is still read on first boot as a migration seed; leave it in place one
-// release cycle so a downgrade doesn't lose the data. The `useTagRoles` hook
-// now lives in `./settings.ts` (delegating to `useVaultSettings`) — keeping it
-// out of this file breaks a tag-roles → settings → tag-roles import cycle.
+// note (`.parachute/notes/settings`) so they sync across the same user's
+// devices. The prior release (the briefly-Lens-branded rc.1) wrote to
+// `.parachute/lens/settings`; `useVaultSettings` reads that path on 404
+// fallback to migrate. The older per-vault localStorage key
+// `lens:tag-roles:<vaultId>` is still read on first boot as a migration seed;
+// leave it in place one release cycle so a downgrade doesn't lose data. The
+// `useTagRoles` hook now lives in `./settings.ts` (delegating to
+// `useVaultSettings`) — keeping it out of this file breaks a tag-roles →
+// settings → tag-roles import cycle.
 //
 // Remapping a role never retags existing notes — the role just points at the
 // new tag going forward.

--- a/src/pwa-manifest.test.ts
+++ b/src/pwa-manifest.test.ts
@@ -34,14 +34,14 @@ describe("PWA_MANIFEST", () => {
 
 describe("buildPwaManifest under a sub-path", () => {
   it("threads the base into id, start_url, and scope so installed PWAs land on the right route", () => {
-    const m = buildPwaManifest("/lens/");
-    expect(m.id).toBe("/lens/");
-    expect(m.start_url).toBe("/lens/");
-    expect(m.scope).toBe("/lens/");
+    const m = buildPwaManifest("/notes/");
+    expect(m.id).toBe("/notes/");
+    expect(m.start_url).toBe("/notes/");
+    expect(m.scope).toBe("/notes/");
   });
 
   it("normalizes a base passed without a trailing slash", () => {
-    const m = buildPwaManifest("/lens");
-    expect(m.start_url).toBe("/lens/");
+    const m = buildPwaManifest("/notes");
+    expect(m.start_url).toBe("/notes/");
   });
 });

--- a/src/pwa-manifest.ts
+++ b/src/pwa-manifest.ts
@@ -2,13 +2,13 @@ import type { ManifestOptions } from "vite-plugin-pwa";
 
 // Build the PWA manifest at config-load time. `id`/`start_url`/`scope` must
 // reflect the deployed base path; otherwise an installed PWA would launch at
-// `/` and 404 when Lens is mounted under e.g. `/lens/`.
+// `/` and 404 when Notes is mounted under e.g. `/notes/`.
 export function buildPwaManifest(base = "/"): Partial<ManifestOptions> {
   const normalized = base.endsWith("/") ? base : `${base}/`;
   return {
     id: normalized,
-    name: "Parachute Lens",
-    short_name: "Lens",
+    name: "Parachute Notes",
+    short_name: "Notes",
     description:
       "The default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
     theme_color: "#4a7c59",
@@ -19,7 +19,7 @@ export function buildPwaManifest(base = "/"): Partial<ManifestOptions> {
     scope: normalized,
     // Icon `src` values are intentionally bare (no leading `/`). They resolve
     // relative to the manifest URL, which itself sits under the deployed base
-    // path (e.g. `/lens/manifest.webmanifest`). That keeps the icons portable
+    // path (e.g. `/notes/manifest.webmanifest`). That keeps the icons portable
     // across mounts without rewriting each path — don't add a leading slash.
     icons: [
       { src: "pwa-64x64.png", sizes: "64x64", type: "image/png" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,20 +5,20 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { buildServiceInfo, infoEndpointPlugin } from "./scripts/info-endpoint-plugin";
-import { lensServicePlugin } from "./scripts/lens-service-plugin";
+import { notesServicePlugin } from "./scripts/notes-service-plugin";
 import { buildPwaManifest } from "./src/pwa-manifest";
 
 // Set VITE_EXPOSE=true to bind the dev server to all interfaces and accept any
 // Host header — useful when reaching the dev server over a tailnet. Off by default.
 const devExposure = process.env.VITE_EXPOSE === "true";
 
-// Lens is one of N frontends mounted under a shared root: the CLI hub page
-// owns `/`, and each frontend lives under its own slug. Default to `/lens`
-// here so dev, build, and `parachute start lens` all agree.
+// Notes is one of N frontends mounted under a shared root: the CLI hub page
+// owns `/`, and each frontend lives under its own slug. Default to `/notes`
+// here so dev, build, and `parachute start notes` all agree.
 // Override with VITE_BASE_PATH=/ if you want the legacy stand-alone shape.
-const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/lens");
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/notes");
 
-const DISPLAY_NAME = "Lens";
+const DISPLAY_NAME = "Notes";
 const TAGLINE = "Web client for your Parachute Vault";
 
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, "./package.json"), "utf8")) as {
@@ -26,14 +26,14 @@ const pkg = JSON.parse(readFileSync(path.resolve(__dirname, "./package.json"), "
 };
 
 const serviceInfo = buildServiceInfo({
-  name: "parachute-lens",
+  name: "parachute-notes",
   displayName: DISPLAY_NAME,
   tagline: TAGLINE,
   version: pkg.version,
   basePath,
   iconFile: "icon.svg",
-  // Lens has a real UI — the hub should render it as a clickable card that
-  // navigates into `/lens/`, not a detail panel.
+  // Notes has a real UI — the hub should render it as a clickable card that
+  // navigates into `/notes/`, not a detail panel.
   kind: "frontend",
 });
 
@@ -48,8 +48,8 @@ export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
-    lensServicePlugin({
-      name: "parachute-lens",
+    notesServicePlugin({
+      name: "parachute-notes",
       version: pkg.version,
       basePath,
       displayName: DISPLAY_NAME,
@@ -85,9 +85,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  // Lens' canonical Parachute slot is 1942 (vault is 1940; the 1939–1949
+  // Notes' canonical Parachute slot is 1942 (vault is 1940; the 1939–1949
   // range is reserved for first-party services). Pin it so the manifest
-  // write in `lens-service-plugin.ts` advertises a stable port — Vite's
+  // write in `notes-service-plugin.ts` advertises a stable port — Vite's
   // 5173 default would otherwise drift if anything else grabs that port.
   server: {
     port: 1942,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   // Mirror the production default so `import.meta.env.BASE_URL` in tests
   // reflects what the SPA actually sees at runtime.
-  base: "/lens/",
+  base: "/notes/",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Team decided on 2026-04-22 that the frontend ships as **Notes**, not Lens. Reverts the rc.1 Lens rename ~20h before launch.

## User-visible

- **Package**: `@openparachute/lens` → `@openparachute/notes`, `0.3.0-rc.1` → `0.3.0-rc.2`
- **Mount path**: `/lens/` → `/notes/` (Vite `base`, BrowserRouter `basename`, PWA `scope` / `id` / `start_url`, OAuth redirect URI)
- **Wordmark**, install copy, update-banner copy, AddVault / Settings copy — all → "Parachute Notes" / "Notes"
- **OAuth `client_name`**: `Parachute Lens` → `Parachute Notes`. Existing DCR registrations survive (keyed by `client_id`, not name)
- **services.json** service name: `parachute-lens` → `parachute-notes`, paths `/notes/`
- **`scripts/lens-service-plugin.ts`** → `notes-service-plugin.ts` (plugin identifier + exported function renamed)

## Migration for rc.1 installs (Aaron's running machine, mostly)

- Settings note path: `.parachute/lens/settings` → `.parachute/notes/settings`. `useVaultSettings.fetchQuery` reads the new path first; on 404 it falls back to the legacy path so existing settings survive. The first write after migration POSTs a fresh note at the new path. Legacy note stays in place as harmless dead data, per team-lead.
- Settings metadata namespace key: `lens` → `notes`. `extractLensSettings` reads `meta.notes ?? meta.lens`, so legacy payloads are understood without a separate migration pass.
- Sync-queue drain (`update-settings` op) now writes `{ notes: ... }`.

## Intentionally preserved (not in team-lead's scope, flagged for visibility)

- **IndexedDB name** stays `parachute-lens` — renaming it would orphan Aaron's offline mutation queue, id-map, blob store. Internal identifier, no user-facing surface. Commented at the constant.
- **`lens:*` localStorage key prefix** stays — preserves cached theme, per-vault tag-role seeds, settings cache through the rename.

If the team wants these renamed too, it's a separate migration with its own UX cost; happy to do it in a follow-up.

## Coordination

CLI steward needs a matching Lens → Notes rename in the CLI's service spec, install docs, and `parachute start` aliases for the ecosystem to be self-consistent. Flagging as a coordination item — this PR only covers the `parachute-lens` repo.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 579/579 (added tests for legacy-key read-through + `LEGACY_SETTINGS_NOTE_PATH`)
- [x] `bun run build` clean; built `dist/.parachute/info.json` reports `parachute-notes` / `Notes`, `dist/manifest.webmanifest` reports `scope` / `start_url` / `id` = `/notes/`
- [ ] Post-merge: Aaron does `git checkout main && git pull`, restarts the running local install, confirms settings migrate from `.parachute/lens/settings` → `.parachute/notes/settings` without losing tag roles

## Known unrelated lint

`src/components/TranscriptionStatus.test.tsx` has a pre-existing Biome formatting error on `main` (short arg lines collapsed by `printWidth`). Not fixed here — same reason as PR #73, per memory "don't biome --write in drifted repos" (would reformat whole files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)