### PR TITLE
feat: auto-discover local vault via /.well-known/parachute.json (closes #78)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/lib/vault/probe.test.ts
+++ b/src/lib/vault/probe.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { probeVaultAtOrigin } from "./probe";
+import { probeForVault, probeVaultAtOrigin, shouldTryLocalHubFallback } from "./probe";
 
 const validMetadata = {
   issuer: "https://h.example/vault/default",
@@ -133,5 +133,93 @@ describe("probeVaultAtOrigin", () => {
       "/.well-known/oauth-authorization-server": { ok: false, status: 404 },
     });
     expect(await probeVaultAtOrigin("https://h.example", 500, fetchImpl)).toBeNull();
+  });
+});
+
+describe("shouldTryLocalHubFallback", () => {
+  it("is true for localhost origins not already on the hub port", () => {
+    expect(shouldTryLocalHubFallback("http://localhost:1942")).toBe(true);
+    expect(shouldTryLocalHubFallback("http://127.0.0.1:1942")).toBe(true);
+    expect(shouldTryLocalHubFallback("http://localhost:5173")).toBe(true);
+  });
+
+  it("is false when the page is already the hub origin (same-origin probe covered it)", () => {
+    expect(shouldTryLocalHubFallback("http://127.0.0.1:1939")).toBe(false);
+  });
+
+  it("is false for remote origins where reaching loopback would be nonsensical", () => {
+    expect(shouldTryLocalHubFallback("https://laptop.tail-foo.ts.net")).toBe(false);
+    expect(shouldTryLocalHubFallback("https://notes.example.com")).toBe(false);
+  });
+
+  it("is false for malformed input", () => {
+    expect(shouldTryLocalHubFallback("not a url")).toBe(false);
+  });
+});
+
+describe("probeForVault", () => {
+  it("falls back to the local hub when same-origin yields nothing (standalone-notes case)", async () => {
+    // Notes is being served at :1942 by `parachute start notes`. The static
+    // server doesn't serve parachute.json, so the same-origin probe finds
+    // nothing. The hub on :1939 does — and that's what we want to find.
+    const fetchImpl = routedFetch({
+      "http://localhost:1942/.well-known/parachute.json": { ok: false, status: 404 },
+      "http://localhost:1942/.well-known/oauth-authorization-server": { ok: false, status: 404 },
+      "http://127.0.0.1:1939/.well-known/parachute.json": {
+        json: { vault: { url: "http://127.0.0.1:1940/vault/default" } },
+      },
+      "http://127.0.0.1:1940/vault/default/.well-known/oauth-authorization-server": {
+        json: validMetadata,
+      },
+    });
+    const result = await probeForVault("http://localhost:1942", 500, fetchImpl);
+    expect(result).toBe("http://127.0.0.1:1940/vault/default");
+  });
+
+  it("does not fall back when the same-origin probe already succeeded", async () => {
+    // Notes is served by the hub portal at :1939/notes — same-origin probe
+    // resolves the vault. The fallback should not even be attempted (no
+    // wasted request to the same hub origin).
+    const fetchImpl = routedFetch({
+      "http://127.0.0.1:1939/.well-known/parachute.json": {
+        json: { vault: { url: "http://127.0.0.1:1940/vault/default" } },
+      },
+      "http://127.0.0.1:1940/vault/default/.well-known/oauth-authorization-server": {
+        json: validMetadata,
+      },
+    });
+    const result = await probeForVault("http://127.0.0.1:1939", 500, fetchImpl);
+    expect(result).toBe("http://127.0.0.1:1940/vault/default");
+    // The same-origin probe makes parachute.json + oauth-metadata calls (2);
+    // a fallback would add a third parachute.json call to 127.0.0.1:1939
+    // which is the same URL — but we expect exactly the same-origin pair.
+    const calls = fetchImpl.mock.calls.map((c) => String(c[0]));
+    expect(calls.filter((u) => u.includes("/.well-known/parachute.json"))).toHaveLength(1);
+  });
+
+  it("does not fall back for remote origins (no loopback reach across machines)", async () => {
+    const fetchImpl = routedFetch({
+      "https://notes.example.com/.well-known/parachute.json": { ok: false, status: 404 },
+      "https://notes.example.com/.well-known/oauth-authorization-server": {
+        ok: false,
+        status: 404,
+      },
+    });
+    const result = await probeForVault("https://notes.example.com", 500, fetchImpl);
+    expect(result).toBeNull();
+    const calls = fetchImpl.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((u) => u.includes("127.0.0.1:1939"))).toBe(false);
+  });
+
+  it("returns null when both same-origin and local hub probes fail", async () => {
+    // Hub isn't running (or CORS blocks it); fall through to manual paste.
+    const fetchImpl = routedFetch({
+      "http://localhost:1942/.well-known/parachute.json": { ok: false, status: 404 },
+      "http://localhost:1942/.well-known/oauth-authorization-server": { ok: false, status: 404 },
+      "http://127.0.0.1:1939/.well-known/parachute.json": "network-error",
+      "http://127.0.0.1:1939/.well-known/oauth-authorization-server": { ok: false, status: 404 },
+    });
+    const result = await probeForVault("http://localhost:1942", 500, fetchImpl);
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/vault/probe.ts
+++ b/src/lib/vault/probe.ts
@@ -14,6 +14,14 @@ export interface ProbeResult {
 
 const DEFAULT_TIMEOUT_MS = 2500;
 
+// Canonical Parachute hub address on a local install. The CLI binds the hub
+// to 127.0.0.1:1939 (see parachute-cli/src/service-spec.ts). Hardcoded here
+// because the browser has no other way to discover it — `~/.parachute/hub.port`
+// is on disk, not visible to JS. Used as a fallback when the same-origin
+// probe fails (e.g. Notes is served standalone at :1942 instead of behind
+// the hub portal at :1939/notes).
+const LOCAL_HUB_URL = "http://127.0.0.1:1939";
+
 // Probe an input URL for a Parachute OAuth issuer. Two paths, in this order:
 //
 //   1. Ecosystem registry: `${origin}/.well-known/parachute.json` → pick a
@@ -73,6 +81,48 @@ async function tryDiscoverAuthServer(
   }
 }
 
+// Try the same-origin probe first, then fall back to the canonical local hub.
+// The fallback covers the standalone-notes case (`parachute install notes` →
+// `http://localhost:1942/notes`): the static notes server doesn't serve
+// `parachute.json`, but the hub on 1939 does. We only attempt the fallback
+// for localhost-ish origins that aren't already on the hub port — never for
+// remote/tailscale origins, where reaching the user's loopback would be
+// nonsensical (and CORS would block it anyway).
+//
+// CORS note: the fallback is cross-origin (1942 → 1939). The hub must serve
+// `Access-Control-Allow-Origin: *` on `/.well-known/parachute.json` for the
+// browser to expose the response body. If it doesn't, the fetch rejects and
+// we fall through to manual entry — same as if the hub weren't running.
+export async function probeForVault(
+  pageOrigin: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
+): Promise<string | null> {
+  const sameOrigin = await probeVaultAtOrigin(pageOrigin, timeoutMs, fetchImpl);
+  if (sameOrigin) return sameOrigin;
+
+  if (shouldTryLocalHubFallback(pageOrigin)) {
+    const local = await probeVaultAtOrigin(LOCAL_HUB_URL, timeoutMs, fetchImpl);
+    if (local) return local;
+  }
+
+  return null;
+}
+
+export function shouldTryLocalHubFallback(pageOrigin: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(pageOrigin);
+  } catch {
+    return false;
+  }
+  const isLoopback = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  if (!isLoopback) return false;
+  // Already on the hub origin — same-origin probe already covered it.
+  if (url.origin === LOCAL_HUB_URL) return false;
+  return true;
+}
+
 // Probe the current window's origin on mount, but skip if the user already has
 // vaults in storage — their choice is already made and a probe would just be
 // noise + a wasted request.
@@ -90,7 +140,7 @@ export function useOriginVaultProbe(): ProbeResult {
     }
     let cancelled = false;
     setResult({ status: "probing", origin: null });
-    probeVaultAtOrigin(window.location.origin).then((found) => {
+    probeForVault(window.location.origin).then((found) => {
       if (cancelled) return;
       setResult(found ? { status: "found", origin: found } : { status: "not-found", origin: null });
     });


### PR DESCRIPTION
## Summary

- Adds a fallback probe to the canonical local hub (`http://127.0.0.1:1939`) when the same-origin probe finds nothing.
- Closes the gap that the original same-origin discovery (PR #45 / #60) didn't cover: when Notes is served standalone at `:1942` by `parachute start notes`, the static server doesn't serve `parachute.json`, so the same-origin probe always fails.
- After this PR, a fresh-install user opening `http://localhost:1942/notes` sees "Looks like there's a vault at …" instead of an empty paste-URL form.

## Flow

1. `useOriginVaultProbe()` now calls a new `probeForVault(window.location.origin)` rather than `probeVaultAtOrigin` directly.
2. `probeForVault` runs the same-origin probe first (existing path; the hub-portal-serving-Notes case still works in one hop).
3. If that returns null **and** the page origin is a loopback that isn't already `127.0.0.1:1939`, it probes the canonical hub.
4. If both fail, the manual paste flow shows up — same as today.

## Out of scope

- **OAuth (#79)**: the user still completes OAuth after discovery — discovery only pre-fills the URL. The `Connect` button on Home already kicks off OAuth via the existing flow.
- **Multi-vault picker UX**: `pickVault()` already prefers `default` and falls back to the first entry. Polish for multi-vault selection can layer on later.
- **CORS on the hub**: the cross-origin fallback fetch needs `Access-Control-Allow-Origin: *` on `parachute-cli/src/hub-server.ts`'s `/.well-known/parachute.json` route — currently absent. Notes silently no-ops the fallback until that lands; behaviour is identical to today's "no hub running" case. Filed separately to the team-lead.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx vitest run --dir src` — 572/572 pass (full repo `bun run test` includes a stale `.claude/worktrees/lens-settings-note/` checkout that fails on its own; unrelated to this change)
- [x] `bunx biome check --write` clean
- [ ] Manual smoke once parachute-cli ships CORS: install vault + notes, open `http://localhost:1942/notes`, confirm "Looks like there's a vault at …" appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)