### PR TITLE
docs: update parachute-cli refs to parachute-hub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.1",
+  "version": "0.3.2-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/scripts/services-manifest.ts
+++ b/scripts/services-manifest.ts
@@ -1,10 +1,10 @@
 // Per-host service registry shared across the Parachute ecosystem. Vault and
 // scribe each carry their own copy of this helper rather than depending on
-// `@openparachute/cli`. Notes does the same so launch surfaces (CLI expose,
+// `@openparachute/hub`. Notes does the same so launch surfaces (hub expose,
 // Funnel, dashboards) can find a running dev server without coordination.
 //
 // The schema (name/port/paths/health/version) and validation are locked by
-// `@openparachute/cli`'s `services-manifest.ts`. If you change them here,
+// `@openparachute/hub`'s `services-manifest.ts`. If you change them here,
 // keep them in sync there.
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";

--- a/src/lib/vault/probe.ts
+++ b/src/lib/vault/probe.ts
@@ -14,8 +14,8 @@ export interface ProbeResult {
 
 const DEFAULT_TIMEOUT_MS = 2500;
 
-// Canonical Parachute hub address on a local install. The CLI binds the hub
-// to 127.0.0.1:1939 (see parachute-cli/src/service-spec.ts). Hardcoded here
+// Canonical Parachute hub address on a local install. The hub binds itself
+// to 127.0.0.1:1939 (see parachute-hub/src/service-spec.ts). Hardcoded here
 // because the browser has no other way to discover it — `~/.parachute/hub.port`
 // is on disk, not visible to JS. Used as a fallback when the same-origin
 // probe fails (e.g. Notes is served standalone at :1942 instead of behind


### PR DESCRIPTION
## Summary

The hub repo was renamed `parachute-cli` → `parachute-hub` and the npm package `@openparachute/cli` → `@openparachute/hub` on 2026-04-26. This PR sweeps stale references in `parachute-notes`.

Scope was docs/comments only — no source, type, or component changes.

## Per-file changes

- **`scripts/services-manifest.ts`** — header comment: replace `@openparachute/cli` (×2) with `@openparachute/hub`; update "CLI expose" → "hub expose" in the launch-surfaces list (the role/repo framing, not the `parachute` binary name).
- **`src/lib/vault/probe.ts`** — comment block at the `LOCAL_HUB_URL` constant: replace `parachute-cli/src/service-spec.ts` path ref with `parachute-hub/src/service-spec.ts`; reframe "The CLI binds the hub to 127.0.0.1:1939" as "The hub binds itself to 127.0.0.1:1939" (the daemon, not the CLI command, is what binds the port).
- **`package.json`** — bump `0.3.1` → `0.3.2-rc.1` per RC versioning policy.

## Out of scope (unchanged)

- The `parachute` binary name (still `parachute`).
- React components, TypeScript types, build config, schemas.

## Verification

- `git grep -E "parachute-cli|@openparachute/cli"` returns no matches post-change.
- `bun run typecheck` ✓ clean.
- `bun run test` ✓ 587/587 passing on `main`. (Local run on this branch reports failures only because vitest is also crawling a stale `.claude/worktrees/lens-settings-note/` from my dev environment — the duplicate copies of source files trip the test loader. Untracked, unrelated to this PR.)
- `bun run lint` reports 1 preexisting biome formatting nit in `src/components/TranscriptionStatus.test.tsx` that exists on `main` — left alone, out of scope here.

## Test plan

- [ ] `git grep -E "parachute-cli|@openparachute/cli"` shows no matches
- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes against a clean checkout

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>