### PR TITLE
release: 0.3.2 (+ ignore .claude in lint/test)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,7 @@
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": { "enabled": true },
   "files": {
-    "ignore": ["dist", "node_modules", "coverage", ".vite"]
+    "ignore": ["dist", "node_modules", "coverage", ".vite", ".claude"]
   },
   "formatter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.2-rc.1",
+  "version": "0.3.2",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   // Mirror the production default so `import.meta.env.BASE_URL` in tests
@@ -19,5 +19,8 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     css: false,
+    // `.claude/` may host an untracked agent worktree (duplicate source copies);
+    // exclude so vitest doesn't run those duplicates as tests.
+    exclude: [...configDefaults.exclude, "**/.claude/**"],
   },
 });


### PR DESCRIPTION
## Summary

- Bump `0.3.2-rc.1` → `0.3.2` so `@openparachute/notes@latest` can advance from `0.3.0` (which still referenced `parachute-cli`) to the merged doc-sweep version (#81).
- Add `.claude/` to biome's `files.ignore` and to vitest's `test.exclude` so an untracked agent worktree under `.claude/worktrees/` doesn't pollute lint/test runs.

## Changes

- `package.json` — `0.3.2-rc.1` → `0.3.2`.
- `biome.json` — append `".claude"` to `files.ignore`.
- `vitest.config.ts` — import `configDefaults`, set `test.exclude` to `[...configDefaults.exclude, "**/.claude/**"]` so vitest defaults stay intact.

## Verification

- `bun run typecheck` ✓
- `bun run test` ✓ 587/587 (was failing 179 locally before the vitest exclude landed; now clean).
- `bun run lint` — 1 preexisting biome formatting nit in `src/components/TranscriptionStatus.test.tsx` (unchanged from `main`, unrelated to this PR; left alone).

## Publish

After merge, Aaron runs `npm publish --access public` (no `--tag`) — `@openparachute/notes@latest` moves to `0.3.2`.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes (clean even with `.claude/worktrees/` present)
- [ ] `bun run lint` no new errors beyond the preexisting `TranscriptionStatus.test.tsx` nit

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>