### PR TITLE
fix: capture if_updated_at baseline for offline note edits (0.3.4-rc.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.3-rc.1",
+  "version": "0.3.4-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/lib/sync/queue.test.ts
+++ b/src/lib/sync/queue.test.ts
@@ -452,6 +452,155 @@ describe("retryRow / discardRow / clearPendingForVault", () => {
   });
 });
 
+describe("drain — update-note (baseline + retry-on-conflict)", () => {
+  let db: LensDB;
+  beforeEach(async () => {
+    db = await freshDb();
+  });
+  afterEach(() => db.close());
+
+  it("forwards baselineUpdatedAt as if_updated_at on the PATCH", async () => {
+    await enqueue(
+      db,
+      {
+        kind: "update-note",
+        targetId: "srv-1",
+        payload: { content: "x" },
+        baselineUpdatedAt: "2026-04-25T00:00:00Z",
+      },
+      { vaultId: "v1" },
+    );
+    const updateNote = vi.fn(
+      async (id: string) => ({ id, createdAt: "t0", updatedAt: "t1" }) as Note,
+    );
+    const client = makeClient({ updateNote });
+
+    const out = await drain({ db, client, vaultId: "v1", blobStore: createIdbBlobStore(db) });
+
+    expect(out.drained).toBe(1);
+    expect(updateNote).toHaveBeenCalledWith("srv-1", {
+      content: "x",
+      if_updated_at: "2026-04-25T00:00:00Z",
+    });
+  });
+
+  it("on 428 (no baseline), uses current_updated_at from the body to retry", async () => {
+    // Legacy enqueue — no baseline. First PATCH 428s with current_updated_at
+    // in the body; the second PATCH succeeds with that as if_updated_at.
+    await enqueue(
+      db,
+      { kind: "update-note", targetId: "srv-1", payload: { content: "x" } },
+      { vaultId: "v1" },
+    );
+    let calls = 0;
+    const updateNote = vi.fn(async (id: string) => {
+      calls += 1;
+      if (calls === 1) {
+        throw new VaultConflictError({ current_updated_at: "fresh-t1" });
+      }
+      return { id, createdAt: "t0", updatedAt: "t2" } as Note;
+    });
+    const client = makeClient({ updateNote });
+
+    const out = await drain({ db, client, vaultId: "v1", blobStore: createIdbBlobStore(db) });
+
+    expect(out.drained).toBe(1);
+    expect(updateNote).toHaveBeenCalledTimes(2);
+    expect(updateNote.mock.calls[0]).toEqual(["srv-1", { content: "x" }]);
+    expect(updateNote.mock.calls[1]).toEqual([
+      "srv-1",
+      { content: "x", if_updated_at: "fresh-t1" },
+    ]);
+  });
+
+  it("on 409 with stale baseline, refetches when current_updated_at is absent", async () => {
+    // Some failure modes don't include current_updated_at in the body. Fall
+    // back to a getNote() refetch and retry with the fresh updatedAt.
+    await enqueue(
+      db,
+      {
+        kind: "update-note",
+        targetId: "srv-1",
+        payload: { content: "x" },
+        baselineUpdatedAt: "stale-t0",
+      },
+      { vaultId: "v1" },
+    );
+    let calls = 0;
+    const updateNote = vi.fn(async (id: string) => {
+      calls += 1;
+      if (calls === 1) throw new VaultConflictError({});
+      return { id, createdAt: "t0", updatedAt: "t2" } as Note;
+    });
+    const getNote = vi.fn(
+      async (id: string) => ({ id, createdAt: "t0", updatedAt: "fetched-t1" }) as Note,
+    );
+    const client = makeClient({ updateNote, getNote });
+
+    const out = await drain({ db, client, vaultId: "v1", blobStore: createIdbBlobStore(db) });
+
+    expect(out.drained).toBe(1);
+    expect(getNote).toHaveBeenCalledOnce();
+    expect(updateNote.mock.calls[1]).toEqual([
+      "srv-1",
+      { content: "x", if_updated_at: "fetched-t1" },
+    ]);
+  });
+
+  it("after exhausting merge-retries, falls back to force: true", async () => {
+    await enqueue(
+      db,
+      {
+        kind: "update-note",
+        targetId: "srv-1",
+        payload: { content: "x" },
+        baselineUpdatedAt: "t0",
+      },
+      { vaultId: "v1" },
+    );
+    let calls = 0;
+    const updateNote = vi.fn(async (id: string) => {
+      calls += 1;
+      if (calls >= 5) return { id, createdAt: "t0", updatedAt: "t-final" } as Note;
+      throw new VaultConflictError({ current_updated_at: `t-${calls}` });
+    });
+    const client = makeClient({ updateNote });
+
+    const out = await drain({ db, client, vaultId: "v1", blobStore: createIdbBlobStore(db) });
+
+    expect(out.drained).toBe(1);
+    // 4 conditional PATCHes (initial + 3 retries) + 1 forced PATCH.
+    expect(updateNote.mock.calls.length).toBe(5);
+    const lastCall = updateNote.mock.calls.at(-1) as unknown as [
+      string,
+      { content?: string; if_updated_at?: string; force?: boolean },
+    ];
+    expect(lastCall[1].force).toBe(true);
+    expect(lastCall[1].if_updated_at).toBeUndefined();
+    expect(lastCall[1].content).toBe("x");
+  });
+
+  it("drops the row when refetch shows the note has vanished", async () => {
+    await enqueue(
+      db,
+      { kind: "update-note", targetId: "srv-1", payload: { content: "x" } },
+      { vaultId: "v1" },
+    );
+    const updateNote = vi.fn(async () => {
+      // 428 with no current_updated_at → refetch path.
+      throw new VaultConflictError({});
+    });
+    const getNote = vi.fn(async () => null);
+    const client = makeClient({ updateNote, getNote });
+
+    const out = await drain({ db, client, vaultId: "v1", blobStore: createIdbBlobStore(db) });
+
+    // 404-equivalent: outer drain drops the row.
+    expect(out.drained).toBe(1);
+    expect(await countPending(db, "v1")).toBe(0);
+  });
+});
+
 describe("drain — update-settings (merge-on-409 invariant)", () => {
   let db: LensDB;
   beforeEach(async () => {

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -1,4 +1,5 @@
 import {
+  type UpdateNotePayload,
   VaultAuthError,
   type VaultClient,
   VaultConflictError,
@@ -190,7 +191,7 @@ async function runMutation(ctx: DrainContext, row: PendingRow): Promise<void> {
       if (!targetId) {
         throw new DeferRowError(`Awaiting local id ${m.targetId}`);
       }
-      await ctx.client.updateNote(targetId, m.payload);
+      await drainUpdateNote(ctx.client, targetId, m.payload, m.baselineUpdatedAt);
       return;
     }
     case "update-settings": {
@@ -277,6 +278,57 @@ export async function discardRow(db: LensDB, seq: number): Promise<void> {
 // device but low enough that a genuinely pathological conflict loop doesn't
 // starve the drain.
 const SETTINGS_MERGE_RETRIES = 3;
+
+// Mirror of SETTINGS_MERGE_RETRIES for note PATCH; same rationale.
+const NOTE_MERGE_RETRIES = 3;
+
+// Drain handler for `update-note`. Sends the PATCH with the enqueue-time
+// `if_updated_at` baseline; on 428 (no baseline) or 409 (stale baseline) we
+// pull a fresh baseline (preferring the server's `current_updated_at` from
+// the conflict body, falling back to a refetch) and retry. After
+// NOTE_MERGE_RETRIES we force the write — last-resort fallback so a
+// genuinely pathological conflict loop doesn't strand the row in
+// needs-human. Unlike settings, note PATCH carries the user's intended
+// values directly (no structural merge), so "re-apply on fresh content"
+// here just means "resend the same payload with a fresher baseline".
+async function drainUpdateNote(
+  client: VaultClient,
+  targetId: string,
+  payload: UpdateNotePayload,
+  initialBaseline: string | undefined,
+): Promise<void> {
+  let baseline = initialBaseline;
+  for (let attempt = 0; attempt <= NOTE_MERGE_RETRIES; attempt++) {
+    const callPayload: UpdateNotePayload = baseline
+      ? { ...payload, if_updated_at: baseline }
+      : { ...payload };
+    try {
+      await client.updateNote(targetId, callPayload);
+      return;
+    } catch (err) {
+      if (err instanceof VaultConflictError && attempt < NOTE_MERGE_RETRIES) {
+        if (err.currentUpdatedAt) {
+          baseline = err.currentUpdatedAt;
+        } else {
+          const fresh = await client.getNote(targetId);
+          if (!fresh) {
+            // Note vanished between PATCH and GET — let the outer drain drop
+            // the row via its 404 handler instead of forcing.
+            throw new VaultNotFoundError(`Note ${targetId} disappeared during retry`);
+          }
+          baseline = fresh.updatedAt ?? fresh.createdAt;
+        }
+        continue;
+      }
+      if (err instanceof VaultConflictError) {
+        // Exhausted polite retries — force the write.
+        await client.updateNote(targetId, { ...payload, force: true });
+        return;
+      }
+      throw err;
+    }
+  }
+}
 
 // Drain handler for `update-settings`. We refetch the settings note, merge
 // the enqueued patch onto whatever the server currently shows, and PATCH

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -26,6 +26,12 @@ export interface PendingUpdateNote {
   // Either a server ID or a local ID awaiting resolution via the id-map.
   targetId: string;
   payload: UpdateNotePayload;
+  // Last-known `note.updatedAt` captured at enqueue time — supplied as
+  // `if_updated_at` on drain so an offline write doesn't silently overwrite a
+  // cross-device write that landed first. Optional for forward-compat with
+  // rows enqueued before this field existed; the drain handler treats a
+  // missing baseline like a 428 (refetch + retry).
+  baselineUpdatedAt?: string;
 }
 
 export interface PendingDeleteNote {

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -160,7 +160,11 @@ export class VaultClient {
     if (res.status === 404) {
       throw new VaultNotFoundError(`${init.method ?? "GET"} ${path} → 404`);
     }
-    if (res.status === 409) {
+    if (res.status === 409 || res.status === 428) {
+      // 409 = baseline mismatch (sent stale `if_updated_at`); 428 = baseline
+      // missing (didn't send `if_updated_at` and `force` wasn't set). Both
+      // recover the same way — refetch the note for a fresh baseline and
+      // retry — so we collapse them into one error class.
       const body = (await res.json().catch(() => ({}))) as {
         error?: string;
         target?: string;

--- a/src/lib/vault/queries.offline.test.tsx
+++ b/src/lib/vault/queries.offline.test.tsx
@@ -2,7 +2,7 @@ import { type LensDB, openLensDB } from "@/lib/sync/db";
 import { isLocalId } from "@/lib/sync/id-map";
 import { countPending, listPending } from "@/lib/sync/queue";
 import { SyncProvider, useSync } from "@/providers/SyncProvider";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -135,6 +135,43 @@ describe("mutation hooks — offline dispatch", () => {
     const sharedDb = await openLensDB();
     const rows = await listPending(sharedDb, "v1");
     expect(rows[0].mutation.kind).toBe("update-note");
+    sharedDb.close();
+  });
+
+  it("useUpdateNote captures baselineUpdatedAt from the cached note", async () => {
+    // The drain handler uses this as `if_updated_at` so an offline write
+    // doesn't silently overwrite a peer's edit (notes#84). Verify it's
+    // populated from the QueryClient cache at enqueue time.
+    function useUpdateWithSeededCache(id: string) {
+      const qc = useQueryClient();
+      const update = useUpdateNote(id);
+      const sync = useSync();
+      return { qc, update, sync };
+    }
+
+    const { result } = renderHook(() => useUpdateWithSeededCache("srv-42"), {
+      wrapper: wrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current.sync.db).not.toBeNull();
+    });
+    act(() => {
+      result.current.qc.setQueryData(["note", "v1", "srv-42"], {
+        id: "srv-42",
+        createdAt: "2026-04-20T00:00:00Z",
+        updatedAt: "2026-04-26T12:00:00Z",
+      });
+    });
+    await act(async () => {
+      await result.current.update.mutateAsync({ content: "# updated" });
+    });
+
+    const sharedDb = await openLensDB();
+    const rows = await listPending(sharedDb, "v1");
+    expect(rows[0].mutation.kind).toBe("update-note");
+    if (rows[0].mutation.kind === "update-note") {
+      expect(rows[0].mutation.baselineUpdatedAt).toBe("2026-04-26T12:00:00Z");
+    }
     sharedDb.close();
   });
 });

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -238,7 +238,21 @@ async function enqueueUpdate(
   payload: UpdateNotePayload,
   existing: Note | undefined,
 ): Promise<Note> {
-  await enqueue(db, { kind: "update-note", targetId, payload }, { vaultId });
+  // Baseline carries the last-known server `updatedAt` so the drain handler
+  // can send `if_updated_at` and avoid silently clobbering a peer's edit. A
+  // missing baseline (note never fetched in this session) is fine — the drain
+  // gets a 428 on first PATCH, refetches, and retries.
+  const baselineUpdatedAt = existing?.updatedAt;
+  await enqueue(
+    db,
+    {
+      kind: "update-note",
+      targetId,
+      payload,
+      ...(baselineUpdatedAt && { baselineUpdatedAt }),
+    },
+    { vaultId },
+  );
   const base: Note = existing ?? { id: targetId, createdAt: new Date().toISOString() };
   return {
     ...base,


### PR DESCRIPTION
Closes #84.

## Summary

Offline note mutations enqueued without a baseline drained as 428 Precondition Required and got stashed as `needs-human` — even when the right answer was just "refetch and retry." This PR makes note PATCH follow the same merge-on-409 pattern that `drainUpdateSettings` already uses.

- `PendingUpdateNote` gains `baselineUpdatedAt` (parallel to `PendingUpdateSettings.baselineUpdatedAt`); captured at enqueue time from the QueryClient cache (`existing.updatedAt`).
- New `drainUpdateNote` helper in `src/lib/sync/queue.ts` sends the baseline as `if_updated_at`, then on 428/409:
  1. Pulls a fresh baseline — preferring `current_updated_at` from the conflict body, falling back to a `getNote()` refetch.
  2. Retries the same payload with the fresh baseline.
  3. Loops up to 3 times before forcing the write (last-resort fallback so a pathological conflict loop doesn't strand the row).
- `VaultClient.request` maps `428` → `VaultConflictError` alongside `409` so both flow through one branch.

The field is optional on `PendingUpdateNote` — rows enqueued by older builds (no baseline) drain through the legacy 428 path: vault returns 428, drain refetches, retries with the fresh baseline. Forward-compat without a migration.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 593/593 pass (5 new note-update drain tests + 1 new offline-baseline enqueue test)
- [x] Lint clean on changed files (pre-existing `TranscriptionStatus.test.tsx` lint error on main is unrelated)
- [ ] Manual: edit a note offline (DevTools → Offline), come back online, confirm the row drains without the needs-human stash that #84 reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)