### PR TITLE
sync: reconnect banner + cross-tab vault sync (#85, #86)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.5-rc.1",
+  "version": "0.3.6-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,7 @@ import { ReconnectBanner } from "@/components/ReconnectBanner";
 import { Toaster } from "@/components/Toaster";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { useVaultStore } from "@/lib/vault";
+import { useCrossTabVaultSync } from "@/lib/vault/cross-tab-sync";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { SyncProvider } from "@/providers/SyncProvider";
 import { BrowserRouter, Navigate, Route, Routes, useParams } from "react-router";
@@ -46,6 +47,10 @@ function NoteIdRedirect({ suffix = "" }: { suffix?: string }) {
 }
 
 export function App() {
+  // Wired at the app root (not a provider) so the storage-event listener
+  // outlives every route transition. Same vault state surfaces in every tab
+  // without a refresh.
+  useCrossTabVaultSync();
   return (
     <QueryProvider>
       <SyncProvider>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { BottomTabBar } from "@/components/BottomTabBar";
 import { Header } from "@/components/Header";
 import { QuickSwitchMount } from "@/components/QuickSwitchMount";
+import { ReconnectBanner } from "@/components/ReconnectBanner";
 import { Toaster } from "@/components/Toaster";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { useVaultStore } from "@/lib/vault";
@@ -52,6 +53,7 @@ export function App() {
           <div className="min-h-dvh overflow-x-hidden bg-bg text-fg pb-16 md:pb-0">
             <Toaster />
             <UpdateBanner />
+            <ReconnectBanner />
             <Header />
             <QuickSwitchMount />
             <main>

--- a/src/app/routes/OAuthCallback.tsx
+++ b/src/app/routes/OAuthCallback.tsx
@@ -5,6 +5,7 @@ import {
   useVaultStore,
   vaultIdFromUrl,
 } from "@/lib/vault";
+import { useAuthHaltStore } from "@/lib/vault/auth-halt-store";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
@@ -54,6 +55,8 @@ export function OAuthCallback() {
           storedFromTokenResponse(token),
         );
         if (token.services) saveServicesCatalog(id, token.services);
+        // Reconnect succeeded — clear the halt so the banner disappears.
+        useAuthHaltStore.getState().clearHalt(id);
         navigate("/", { replace: true });
       } catch (err) {
         setStatus({ kind: "error", message: (err as Error).message });

--- a/src/components/ReconnectBanner.tsx
+++ b/src/components/ReconnectBanner.tsx
@@ -33,8 +33,12 @@ export function ReconnectBanner() {
       const { authorizeUrl } = await beginOAuth(issuer, vault.scope);
       window.location.assign(authorizeUrl);
     } catch (err) {
-      setReconnecting(false);
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      // Reset even on success: if the browser blocks the navigation (popup
+      // blocker on a programmatic assign, content-security policy), the page
+      // doesn't unload and the button would otherwise stick at "Starting…".
+      setReconnecting(false);
     }
   }
 

--- a/src/components/ReconnectBanner.tsx
+++ b/src/components/ReconnectBanner.tsx
@@ -1,0 +1,64 @@
+import { useAuthHaltStore } from "@/lib/vault/auth-halt-store";
+import { beginOAuth } from "@/lib/vault/oauth";
+import { useVaultStore } from "@/lib/vault/store";
+import { useState } from "react";
+
+// Top-level banner shown when the active vault's session is dead (refresh
+// token revoked / rotated past us, or repeated 401s). Non-dismissable on
+// purpose — every cached query is failing under it, and the only fix is
+// reauth. Click → re-runs the OAuth flow against the original issuer; we
+// don't auto-redirect because a silent jump to the hub mid-session would
+// lose unsaved input.
+
+export function ReconnectBanner() {
+  const activeVaultId = useVaultStore((s) => s.activeVaultId);
+  const vault = useVaultStore((s) => s.getActiveVault());
+  const halt = useAuthHaltStore((s) =>
+    activeVaultId ? (s.byVault[activeVaultId] ?? null) : null,
+  );
+  const [reconnecting, setReconnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!halt || !vault || !activeVaultId) return null;
+
+  async function onReconnect() {
+    if (!vault) return;
+    setError(null);
+    setReconnecting(true);
+    try {
+      // Prefer the issuer we OAuthed against originally — under hub-as-issuer
+      // that's the hub origin, not the vault URL. Falls back to the vault URL
+      // for legacy standalone-vault records.
+      const issuer = vault.issuer ?? vault.url;
+      const { authorizeUrl } = await beginOAuth(issuer, vault.scope);
+      window.location.assign(authorizeUrl);
+    } catch (err) {
+      setReconnecting(false);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="border-b border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200 md:px-6"
+    >
+      <div className="mx-auto flex max-w-5xl flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="font-medium text-red-100">Vault session expired</p>
+          <p className="text-xs text-red-200/80">{halt.reason}</p>
+          {error ? <p className="mt-1 text-xs text-red-300">{error}</p> : null}
+        </div>
+        <button
+          type="button"
+          onClick={onReconnect}
+          disabled={reconnecting}
+          className="self-start rounded-md bg-red-500/30 px-3 py-1.5 text-xs font-medium text-red-50 hover:bg-red-500/50 disabled:cursor-not-allowed disabled:opacity-60 md:self-auto"
+        >
+          {reconnecting ? "Starting OAuth…" : "Reconnect to vault"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/vault/auth-halt-store.test.ts
+++ b/src/lib/vault/auth-halt-store.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AUTH_HALT_KEY_PREFIX, useAuthHaltStore } from "./auth-halt-store";
+
+describe("useAuthHaltStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAuthHaltStore.setState({ byVault: {} });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    useAuthHaltStore.setState({ byVault: {} });
+  });
+
+  it("markHalted persists to localStorage and updates the store", () => {
+    useAuthHaltStore.getState().markHalted("v1", "session expired");
+    const entry = useAuthHaltStore.getState().byVault.v1;
+    expect(entry?.vaultId).toBe("v1");
+    expect(entry?.reason).toBe("session expired");
+
+    const raw = localStorage.getItem(`${AUTH_HALT_KEY_PREFIX}v1`);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.vaultId).toBe("v1");
+    expect(parsed.reason).toBe("session expired");
+  });
+
+  it("clearHalt removes the entry from both store and localStorage", () => {
+    useAuthHaltStore.getState().markHalted("v1", "expired");
+    expect(useAuthHaltStore.getState().byVault.v1).toBeDefined();
+
+    useAuthHaltStore.getState().clearHalt("v1");
+    expect(useAuthHaltStore.getState().byVault.v1).toBeUndefined();
+    expect(localStorage.getItem(`${AUTH_HALT_KEY_PREFIX}v1`)).toBeNull();
+  });
+
+  it("tracks multiple vaults independently", () => {
+    useAuthHaltStore.getState().markHalted("v1", "v1 expired");
+    useAuthHaltStore.getState().markHalted("v2", "v2 expired");
+
+    expect(useAuthHaltStore.getState().byVault.v1?.reason).toBe("v1 expired");
+    expect(useAuthHaltStore.getState().byVault.v2?.reason).toBe("v2 expired");
+
+    useAuthHaltStore.getState().clearHalt("v1");
+    expect(useAuthHaltStore.getState().byVault.v1).toBeUndefined();
+    expect(useAuthHaltStore.getState().byVault.v2?.reason).toBe("v2 expired");
+  });
+
+  it("reloadFromStorage picks up entries written by another tab", () => {
+    // Simulate a sibling tab writing the halt directly.
+    const entry = { vaultId: "v1", reason: "from other tab", at: Date.now() };
+    localStorage.setItem(`${AUTH_HALT_KEY_PREFIX}v1`, JSON.stringify(entry));
+
+    expect(useAuthHaltStore.getState().byVault.v1).toBeUndefined();
+    useAuthHaltStore.getState().reloadFromStorage();
+    expect(useAuthHaltStore.getState().byVault.v1?.reason).toBe("from other tab");
+  });
+
+  it("ignores malformed entries during reloadFromStorage", () => {
+    localStorage.setItem(`${AUTH_HALT_KEY_PREFIX}v1`, "{ not json");
+    useAuthHaltStore.getState().reloadFromStorage();
+    expect(useAuthHaltStore.getState().byVault.v1).toBeUndefined();
+  });
+});

--- a/src/lib/vault/auth-halt-store.ts
+++ b/src/lib/vault/auth-halt-store.ts
@@ -1,0 +1,82 @@
+import { create } from "zustand";
+
+// Per-vault "this session is dead, ask the user to reconnect" marker. Set when
+// the hub returns an HTTP error from /oauth/token (refresh token revoked /
+// rotated past us / client deleted) or when a 401 keeps coming back even after
+// a successful refresh attempt. Read by the top-level ReconnectBanner so the
+// user gets a non-dismissable prompt no matter where in the app they are.
+//
+// Backed by localStorage so the halt survives a reload (otherwise a refresh
+// would silently restart all the failing queries) and so a sibling tab can
+// observe it via the storage event (#86 cross-tab sync).
+const HALT_PREFIX = "lens:auth-halt:";
+
+export interface AuthHaltEntry {
+  vaultId: string;
+  reason: string;
+  at: number;
+}
+
+interface AuthHaltState {
+  byVault: Record<string, AuthHaltEntry>;
+  markHalted: (vaultId: string, reason: string) => void;
+  clearHalt: (vaultId: string) => void;
+  reloadFromStorage: () => void;
+}
+
+function readAllFromStorage(): Record<string, AuthHaltEntry> {
+  const out: Record<string, AuthHaltEntry> = {};
+  if (typeof localStorage === "undefined") return out;
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key?.startsWith(HALT_PREFIX)) continue;
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      try {
+        const entry = JSON.parse(raw) as AuthHaltEntry;
+        if (entry?.vaultId) out[entry.vaultId] = entry;
+      } catch {
+        // Malformed entry — ignore; the next markHalted will overwrite.
+      }
+    }
+  } catch {
+    // localStorage unavailable (privacy mode) — best-effort.
+  }
+  return out;
+}
+
+export const useAuthHaltStore = create<AuthHaltState>((set) => ({
+  byVault: readAllFromStorage(),
+
+  markHalted(vaultId, reason) {
+    const entry: AuthHaltEntry = { vaultId, reason, at: Date.now() };
+    try {
+      localStorage.setItem(HALT_PREFIX + vaultId, JSON.stringify(entry));
+    } catch {
+      // Best-effort.
+    }
+    set((s) => ({ byVault: { ...s.byVault, [vaultId]: entry } }));
+  },
+
+  clearHalt(vaultId) {
+    try {
+      localStorage.removeItem(HALT_PREFIX + vaultId);
+    } catch {
+      // Best-effort.
+    }
+    set((s) => {
+      if (!(vaultId in s.byVault)) return s;
+      const { [vaultId]: _removed, ...rest } = s.byVault;
+      return { byVault: rest };
+    });
+  },
+
+  reloadFromStorage() {
+    set({ byVault: readAllFromStorage() });
+  },
+}));
+
+// Exported so the cross-tab listener can recognize halt-prefix keys without
+// duplicating the constant.
+export const AUTH_HALT_KEY_PREFIX = HALT_PREFIX;

--- a/src/lib/vault/client.test.ts
+++ b/src/lib/vault/client.test.ts
@@ -806,6 +806,68 @@ describe("VaultClient refresh-on-401", () => {
     await expect(client.vaultInfo(false)).rejects.toBeInstanceOf(VaultAuthError);
     expect(onAuthRevoked).not.toHaveBeenCalled();
   });
+
+  // Regression: the blob path (audio/image attachment loads) used to short-circuit
+  // before `onAuthRevoked` was invented, so it never fired. A user whose
+  // attachment loads start 401-ing after token revocation would get silent
+  // VaultAuthError throws with no banner. These mirror the requestWithRetry
+  // tests above against `fetchAttachmentBlob`.
+
+  it("blob path: calls onAuthRevoked when the post-refresh retry also returns 401", async () => {
+    const fetchImpl = sequencedFetch([
+      { ok: false, status: 401 },
+      { ok: false, status: 401 },
+    ]);
+    const onAuthError = vi.fn(async () => "eyJ.also-stale");
+    const onAuthRevoked = vi.fn();
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "eyJ.stale",
+      fetchImpl,
+      onAuthError,
+      onAuthRevoked,
+    });
+
+    await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
+      VaultAuthError,
+    );
+    expect(onAuthRevoked).toHaveBeenCalledTimes(1);
+    expect(onAuthRevoked).toHaveBeenCalledWith(401);
+  });
+
+  it("blob path: calls onAuthRevoked when there is no refresh callback wired", async () => {
+    const fetchImpl = mockFetch({ ok: false, status: 401 });
+    const onAuthRevoked = vi.fn();
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_legacy",
+      fetchImpl,
+      onAuthRevoked,
+    });
+
+    await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
+      VaultAuthError,
+    );
+    expect(onAuthRevoked).toHaveBeenCalledWith(401);
+  });
+
+  it("blob path: does NOT call onAuthRevoked when onAuthError returned null", async () => {
+    const fetchImpl = sequencedFetch([{ ok: false, status: 401 }]);
+    const onAuthError = vi.fn(async () => null);
+    const onAuthRevoked = vi.fn();
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "eyJ.stale",
+      fetchImpl,
+      onAuthError,
+      onAuthRevoked,
+    });
+
+    await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
+      VaultAuthError,
+    );
+    expect(onAuthRevoked).not.toHaveBeenCalled();
+  });
 });
 
 describe("VaultClient default fetch binding", () => {

--- a/src/lib/vault/client.test.ts
+++ b/src/lib/vault/client.test.ts
@@ -731,6 +731,81 @@ describe("VaultClient refresh-on-401", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(onAuthError).toHaveBeenCalledTimes(1);
   });
+
+  it("calls onAuthRevoked when the post-refresh retry also returns 401", async () => {
+    const fetchImpl = sequencedFetch([
+      { ok: false, status: 401 },
+      { ok: false, status: 401 },
+    ]);
+    const onAuthError = vi.fn(async () => "eyJ.also-stale");
+    const onAuthRevoked = vi.fn();
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "eyJ.stale",
+      fetchImpl,
+      onAuthError,
+      onAuthRevoked,
+    });
+
+    await expect(client.vaultInfo(false)).rejects.toBeInstanceOf(VaultAuthError);
+    expect(onAuthRevoked).toHaveBeenCalledTimes(1);
+    expect(onAuthRevoked).toHaveBeenCalledWith(401);
+  });
+
+  it("calls onAuthRevoked when there is no refresh callback wired", async () => {
+    // Legacy `pvt_*` token path — VaultClient was constructed without
+    // `onAuthError`, so the first 401 is definitive. Surface the halt so the
+    // banner still appears.
+    const fetchImpl = mockFetch({ ok: false, status: 401 });
+    const onAuthRevoked = vi.fn();
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_legacy",
+      fetchImpl,
+      onAuthRevoked,
+    });
+
+    await expect(client.vaultInfo(false)).rejects.toBeInstanceOf(VaultAuthError);
+    expect(onAuthRevoked).toHaveBeenCalledWith(401);
+  });
+
+  it("does NOT call onAuthRevoked when refresh succeeds (banner stays hidden on transient 401)", async () => {
+    const fetchImpl = sequencedFetch([
+      { ok: false, status: 401 },
+      { json: { name: "default", description: "" } },
+    ]);
+    const onAuthError = vi.fn(async () => "eyJ.new");
+    const onAuthRevoked = vi.fn();
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "eyJ.stale",
+      fetchImpl,
+      onAuthError,
+      onAuthRevoked,
+    });
+
+    await client.vaultInfo(false);
+    expect(onAuthRevoked).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onAuthRevoked when onAuthError returned null — refresh.ts owns that halt", async () => {
+    // refresh.ts is responsible for marking halted with a specific reason
+    // when it sees an HTTP error from the token endpoint. Avoid double-marking
+    // (which would clobber the better message with a generic "(401)").
+    const fetchImpl = sequencedFetch([{ ok: false, status: 401 }]);
+    const onAuthError = vi.fn(async () => null);
+    const onAuthRevoked = vi.fn();
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "eyJ.stale",
+      fetchImpl,
+      onAuthError,
+      onAuthRevoked,
+    });
+
+    await expect(client.vaultInfo(false)).rejects.toBeInstanceOf(VaultAuthError);
+    expect(onAuthRevoked).not.toHaveBeenCalled();
+  });
 });
 
 describe("VaultClient default fetch binding", () => {

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -389,6 +389,11 @@ export class VaultClient {
           this.token = fresh;
           return this.fetchBlobWithRetry(target, originalUrl, false);
         }
+        // onAuthError returned null — refresh.ts owns the halt path.
+      } else {
+        // No refresh path, or post-refresh retry still 401/403. Mirror
+        // requestWithRetry so attachment loads also surface the banner.
+        this.onAuthRevoked?.(res.status);
       }
       throw new VaultAuthError(`Vault rejected the token (${res.status})`);
     }

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -25,6 +25,13 @@ export interface VaultClientOptions {
   // Without this, the first 401 throws immediately — same behaviour as before
   // hub-as-issuer landed.
   onAuthError?: () => Promise<string | null>;
+  // Invoked when a 401/403 ultimately can't be recovered: either there was no
+  // refresh callback, or the post-refresh retry also got a 401/403 (the new
+  // token is dead too). Lets callers mark the vault as needing reconnect —
+  // distinct from `onAuthError`'s job, which is to attempt refresh. Skipped
+  // when `onAuthError` returned null because that path is expected to record
+  // its own halt with a more specific reason (see refresh.ts).
+  onAuthRevoked?: (status: number) => void;
 }
 
 export interface StorageUploadResult {
@@ -116,6 +123,7 @@ export class VaultClient {
   private readonly fetchImpl: typeof fetch;
   private readonly xhrFactory: () => XMLHttpRequest;
   private readonly onAuthError?: () => Promise<string | null>;
+  private readonly onAuthRevoked?: (status: number) => void;
 
   constructor(opts: VaultClientOptions) {
     this.baseUrl = opts.vaultUrl.replace(/\/$/, "");
@@ -123,6 +131,7 @@ export class VaultClient {
     this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
     this.xhrFactory = opts.xhrFactory ?? (() => new XMLHttpRequest());
     this.onAuthError = opts.onAuthError;
+    this.onAuthRevoked = opts.onAuthRevoked;
   }
 
   get vaultBaseUrl(): string {
@@ -154,6 +163,12 @@ export class VaultClient {
           this.token = fresh;
           return this.requestWithRetry<T>(path, init, false);
         }
+        // onAuthError returned null — refresh.ts will already have recorded
+        // its own halt with a specific reason if appropriate; don't double-mark.
+      } else {
+        // No refresh path, or we're on the post-refresh retry and the new
+        // token also failed. Either way, the credentials we have are dead.
+        this.onAuthRevoked?.(res.status);
       }
       throw new VaultAuthError(`Vault rejected the token (${res.status})`);
     }

--- a/src/lib/vault/cross-tab-sync.test.tsx
+++ b/src/lib/vault/cross-tab-sync.test.tsx
@@ -1,0 +1,112 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AUTH_HALT_KEY_PREFIX, useAuthHaltStore } from "./auth-halt-store";
+import { useCrossTabVaultSync } from "./cross-tab-sync";
+import { ACTIVE_KEY, VAULTS_KEY } from "./storage";
+import { useVaultStore } from "./store";
+import type { VaultRecord } from "./types";
+
+function makeVault(id: string, overrides: Partial<VaultRecord> = {}): VaultRecord {
+  return {
+    id,
+    url: `http://localhost:1940/${id}`,
+    name: id,
+    issuer: "http://localhost:1939",
+    tokenEndpoint: "http://localhost:1939/oauth/token",
+    clientId: "client-123",
+    scope: "vault:read vault:write",
+    addedAt: "2026-04-25T00:00:00Z",
+    lastUsedAt: "2026-04-25T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// Storage events fire in *other* tabs, never the writing tab — so jsdom won't
+// emit one on `localStorage.setItem`. These tests dispatch the event manually
+// (the same shape the browser would deliver from a sibling tab).
+function fireStorageEvent(key: string | null, newValue: string | null): void {
+  window.dispatchEvent(new StorageEvent("storage", { key, newValue }));
+}
+
+describe("useCrossTabVaultSync", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useAuthHaltStore.setState({ byVault: {} });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useAuthHaltStore.setState({ byVault: {} });
+  });
+
+  it("picks up active-vault changes written by another tab", () => {
+    const v1 = makeVault("v1");
+    // Sibling tab wrote both the vault map and the active id directly.
+    localStorage.setItem(VAULTS_KEY, JSON.stringify({ v1 }));
+    localStorage.setItem(ACTIVE_KEY, "v1");
+
+    renderHook(() => useCrossTabVaultSync());
+
+    expect(useVaultStore.getState().activeVaultId).toBeNull();
+    fireStorageEvent(ACTIVE_KEY, "v1");
+    expect(useVaultStore.getState().activeVaultId).toBe("v1");
+  });
+
+  it("picks up vault-map changes written by another tab", () => {
+    const v1 = makeVault("v1");
+    localStorage.setItem(VAULTS_KEY, JSON.stringify({ v1 }));
+
+    renderHook(() => useCrossTabVaultSync());
+
+    expect(useVaultStore.getState().vaults).toEqual({});
+    fireStorageEvent(VAULTS_KEY, localStorage.getItem(VAULTS_KEY));
+    expect(useVaultStore.getState().vaults).toEqual({ v1 });
+  });
+
+  it("picks up auth-halt changes for any vault id under the prefix", () => {
+    const entry = { vaultId: "v1", reason: "from sibling tab", at: Date.now() };
+    localStorage.setItem(`${AUTH_HALT_KEY_PREFIX}v1`, JSON.stringify(entry));
+
+    renderHook(() => useCrossTabVaultSync());
+
+    expect(useAuthHaltStore.getState().byVault.v1).toBeUndefined();
+    fireStorageEvent(`${AUTH_HALT_KEY_PREFIX}v1`, JSON.stringify(entry));
+    expect(useAuthHaltStore.getState().byVault.v1?.reason).toBe("from sibling tab");
+  });
+
+  it("handles a wholesale localStorage.clear() by reloading every mirrored slice", () => {
+    // Seed the store with state, then simulate a sibling clearing storage.
+    useVaultStore.setState({ vaults: { v1: makeVault("v1") }, activeVaultId: "v1" });
+    useAuthHaltStore.setState({ byVault: { v1: { vaultId: "v1", reason: "stale", at: 0 } } });
+
+    renderHook(() => useCrossTabVaultSync());
+    fireStorageEvent(null, null);
+
+    expect(useVaultStore.getState().vaults).toEqual({});
+    expect(useVaultStore.getState().activeVaultId).toBeNull();
+    expect(useAuthHaltStore.getState().byVault).toEqual({});
+  });
+
+  it("ignores unrelated keys", () => {
+    renderHook(() => useCrossTabVaultSync());
+    const before = useVaultStore.getState();
+    const beforeHalt = useAuthHaltStore.getState();
+
+    fireStorageEvent("some-other-app:setting", "value");
+
+    expect(useVaultStore.getState()).toBe(before);
+    expect(useAuthHaltStore.getState()).toBe(beforeHalt);
+  });
+
+  it("removes the listener on unmount", () => {
+    const { unmount } = renderHook(() => useCrossTabVaultSync());
+    unmount();
+
+    // After unmount, dispatching a storage event must not change state.
+    localStorage.setItem(ACTIVE_KEY, "v2");
+    fireStorageEvent(ACTIVE_KEY, "v2");
+    expect(useVaultStore.getState().activeVaultId).toBeNull();
+  });
+});

--- a/src/lib/vault/cross-tab-sync.ts
+++ b/src/lib/vault/cross-tab-sync.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { AUTH_HALT_KEY_PREFIX, useAuthHaltStore } from "./auth-halt-store";
+import { loadActiveVaultId, loadVaults } from "./storage";
+import { useVaultStore } from "./store";
+
+// Storage events fire across same-origin tabs but never within the tab that
+// wrote the change — so this listener can call `setState` directly without
+// looping. We mirror only the *state*, never the action: the `setActive` etc.
+// methods write to localStorage themselves, which is what triggered the event
+// in the other tab. Calling them here would write again and cause a redundant
+// save.
+//
+// Keys we mirror:
+//   - lens:vaults           (full vault list)
+//   - lens:active_vault     (active vault id; vault-switch-aware components
+//                            (QuickSwitchMount etc.) react via existing hooks)
+//   - lens:auth-halt:<id>   (per-vault auth halt; reload entire halt store
+//                            because there's no per-key removal in zustand)
+
+const VAULTS_KEY = "lens:vaults";
+const ACTIVE_KEY = "lens:active_vault";
+
+export function useCrossTabVaultSync(): void {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    function onStorage(e: StorageEvent) {
+      // `e.key === null` means localStorage.clear() — refresh everything we
+      // mirror so no stale state survives the wipe.
+      if (e.key === null) {
+        useVaultStore.setState({
+          vaults: loadVaults(),
+          activeVaultId: loadActiveVaultId(),
+        });
+        useAuthHaltStore.getState().reloadFromStorage();
+        return;
+      }
+      if (e.key === ACTIVE_KEY) {
+        useVaultStore.setState({ activeVaultId: loadActiveVaultId() });
+        return;
+      }
+      if (e.key === VAULTS_KEY) {
+        useVaultStore.setState({ vaults: loadVaults() });
+        return;
+      }
+      if (e.key.startsWith(AUTH_HALT_KEY_PREFIX)) {
+        useAuthHaltStore.getState().reloadFromStorage();
+        return;
+      }
+    }
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+}

--- a/src/lib/vault/cross-tab-sync.ts
+++ b/src/lib/vault/cross-tab-sync.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { AUTH_HALT_KEY_PREFIX, useAuthHaltStore } from "./auth-halt-store";
-import { loadActiveVaultId, loadVaults } from "./storage";
+import { ACTIVE_KEY, loadActiveVaultId, loadVaults, VAULTS_KEY } from "./storage";
 import { useVaultStore } from "./store";
 
 // Storage events fire across same-origin tabs but never within the tab that
@@ -16,9 +16,6 @@ import { useVaultStore } from "./store";
 //                            (QuickSwitchMount etc.) react via existing hooks)
 //   - lens:auth-halt:<id>   (per-vault auth halt; reload entire halt store
 //                            because there's no per-key removal in zustand)
-
-const VAULTS_KEY = "lens:vaults";
-const ACTIVE_KEY = "lens:active_vault";
 
 export function useCrossTabVaultSync(): void {
   useEffect(() => {

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -1,3 +1,4 @@
+export * from "./auth-halt-store";
 export * from "./client";
 export * from "./discovery";
 export * from "./graph";

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -1,5 +1,6 @@
 export * from "./auth-halt-store";
 export * from "./client";
+export * from "./cross-tab-sync";
 export * from "./discovery";
 export * from "./graph";
 export * from "./neighborhood";

--- a/src/lib/vault/oauth.ts
+++ b/src/lib/vault/oauth.ts
@@ -170,6 +170,32 @@ export interface RefreshContext {
   refreshToken: string;
 }
 
+// Thrown by `refreshAccessToken` when the hub answered with a non-2xx —
+// distinct from a network error so callers can tell "server rejected our
+// refresh token" (revoked / rotated past us; surface a reconnect prompt) apart
+// from "couldn't reach the hub at all" (transient; let the next sync tick
+// retry quietly).
+export class RefreshHttpError extends Error {
+  readonly status: number;
+  readonly body: string;
+  readonly oauthError?: string;
+
+  constructor(status: number, body: string) {
+    let oauthError: string | undefined;
+    try {
+      const parsed = JSON.parse(body) as { error?: unknown };
+      if (typeof parsed.error === "string") oauthError = parsed.error;
+    } catch {
+      // Body wasn't JSON — fine; some hubs return text on infra errors.
+    }
+    super(`Token refresh failed (${status}): ${body}`);
+    this.name = "RefreshHttpError";
+    this.status = status;
+    this.body = body;
+    this.oauthError = oauthError;
+  }
+}
+
 /**
  * Exchange a refresh_token for a fresh access (+ rotated refresh) token.
  *
@@ -198,7 +224,7 @@ export async function refreshAccessToken(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Token refresh failed (${res.status}): ${text}`);
+    throw new RefreshHttpError(res.status, text);
   }
 
   const token = (await res.json()) as TokenResponse;

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -11,6 +11,7 @@ import {
   type UploadProgress,
   VaultClient,
 } from "./client";
+import { useAuthHaltStore } from "./auth-halt-store";
 import { type NoteQueryState, buildNoteQueryParams } from "./note-query";
 import { forceRefresh } from "./refresh";
 import { loadToken } from "./storage";
@@ -28,6 +29,10 @@ export function useActiveVaultClient(): VaultClient | null {
       vaultUrl: vault.url,
       accessToken: token.accessToken,
       onAuthError: () => forceRefresh(activeId),
+      onAuthRevoked: (status) =>
+        useAuthHaltStore
+          .getState()
+          .markHalted(activeId, `Vault rejected the current session (${status}).`),
     });
   }, [vault, activeId]);
 }

--- a/src/lib/vault/refresh.test.ts
+++ b/src/lib/vault/refresh.test.ts
@@ -167,6 +167,25 @@ describe("forceRefresh", () => {
     expect(useAuthHaltStore.getState().byVault.v1).toBeDefined();
   });
 
+  it("does NOT mark halted on a 5xx token-endpoint response (transient — overloaded hub)", async () => {
+    seedVault({ id: "v1" });
+    seedToken("v1", { accessToken: "eyJ.stale", refreshToken: "rt_old" });
+
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        ({
+          ok: false,
+          status: 503,
+          json: async () => ({}),
+          text: async () => "service unavailable",
+        }) as Response,
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+
+    expect(await forceRefresh("v1")).toBeNull();
+    expect(useAuthHaltStore.getState().byVault.v1).toBeUndefined();
+  });
+
   it("does NOT mark halted on a network-level error (transient — let the next tick retry)", async () => {
     seedVault({ id: "v1" });
     seedToken("v1", { accessToken: "eyJ.stale", refreshToken: "rt_old" });

--- a/src/lib/vault/refresh.test.ts
+++ b/src/lib/vault/refresh.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAuthHaltStore } from "./auth-halt-store";
 import { forceRefresh } from "./refresh";
 import { loadToken, saveToken } from "./storage";
 import { useVaultStore } from "./store";
@@ -40,10 +41,12 @@ describe("forceRefresh", () => {
     localStorage.clear();
     sessionStorage.clear();
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useAuthHaltStore.setState({ byVault: {} });
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    useAuthHaltStore.setState({ byVault: {} });
   });
 
   it("posts grant_type=refresh_token, persists the rotated token, and returns the new access token", async () => {
@@ -122,6 +125,87 @@ describe("forceRefresh", () => {
     expect(await forceRefresh("v1")).toBeNull();
     expect(loadToken("v1")?.accessToken).toBe("eyJ.stale");
     expect(loadToken("v1")?.refreshToken).toBe("rt_old");
+  });
+
+  it("marks the vault auth-halted when the hub answers with invalid_grant", async () => {
+    seedVault({ id: "v1" });
+    seedToken("v1", { accessToken: "eyJ.stale", refreshToken: "rt_old" });
+
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        ({
+          ok: false,
+          status: 400,
+          json: async () => ({ error: "invalid_grant" }),
+          text: async () => '{"error":"invalid_grant"}',
+        }) as Response,
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+
+    expect(await forceRefresh("v1")).toBeNull();
+    const halt = useAuthHaltStore.getState().byVault.v1;
+    expect(halt).toBeDefined();
+    expect(halt?.reason).toMatch(/expired|reconnect/i);
+  });
+
+  it("marks the vault auth-halted when the hub answers with any 4xx", async () => {
+    seedVault({ id: "v1" });
+    seedToken("v1", { accessToken: "eyJ.stale", refreshToken: "rt_old" });
+
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        ({
+          ok: false,
+          status: 401,
+          json: async () => ({}),
+          text: async () => "unauthorized_client",
+        }) as Response,
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+
+    expect(await forceRefresh("v1")).toBeNull();
+    expect(useAuthHaltStore.getState().byVault.v1).toBeDefined();
+  });
+
+  it("does NOT mark halted on a network-level error (transient — let the next tick retry)", async () => {
+    seedVault({ id: "v1" });
+    seedToken("v1", { accessToken: "eyJ.stale", refreshToken: "rt_old" });
+
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+
+    expect(await forceRefresh("v1")).toBeNull();
+    expect(useAuthHaltStore.getState().byVault.v1).toBeUndefined();
+  });
+
+  it("clears any prior halt on a successful refresh", async () => {
+    seedVault({ id: "v1" });
+    seedToken("v1", { accessToken: "eyJ.stale", refreshToken: "rt_old" });
+    useAuthHaltStore.getState().markHalted("v1", "stale halt from earlier");
+
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: "eyJ.new",
+            token_type: "bearer",
+            scope: "vault:read vault:write",
+            vault: "default",
+            refresh_token: "rt_rotated",
+            expires_in: 900,
+          }),
+          text: async () => "",
+        }) as Response,
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const access = await forceRefresh("v1");
+    expect(access).toBe("eyJ.new");
+    expect(useAuthHaltStore.getState().byVault.v1).toBeUndefined();
   });
 
   it("dedupes concurrent refreshes so refresh-token rotation only consumes one prior token", async () => {

--- a/src/lib/vault/refresh.ts
+++ b/src/lib/vault/refresh.ts
@@ -1,4 +1,5 @@
-import { refreshAccessToken, storedFromTokenResponse } from "./oauth";
+import { useAuthHaltStore } from "./auth-halt-store";
+import { RefreshHttpError, refreshAccessToken, storedFromTokenResponse } from "./oauth";
 import { loadToken, saveToken } from "./storage";
 import { useVaultStore } from "./store";
 
@@ -50,8 +51,24 @@ async function doRefresh(vaultId: string): Promise<string | null> {
       next.refreshToken = stored.refreshToken;
     }
     saveToken(vaultId, next);
+    // Successful exchange — clear any prior halt; the user reconnected
+    // (manually or via a still-valid rotated chain) and we're back online.
+    useAuthHaltStore.getState().clearHalt(vaultId);
     return next.accessToken;
-  } catch {
+  } catch (err) {
+    if (err instanceof RefreshHttpError) {
+      // The hub answered and rejected our refresh token — typically RFC 6749
+      // `invalid_grant` from rotation drift, an admin-revoked token, or a
+      // deleted client registration. Surface a halt so the UI prompts a
+      // reconnect; manual reauth is the only recovery. Network-level errors
+      // skip this branch and stay transient (the next sync tick retries
+      // quietly without nagging the user).
+      const message =
+        err.oauthError === "invalid_grant" || err.status === 400 || err.status === 401
+          ? "Your vault session expired. Reconnect to resume syncing."
+          : `Token refresh failed (${err.status}). Reconnect to resume syncing.`;
+      useAuthHaltStore.getState().markHalted(vaultId, message);
+    }
     return null;
   }
 }

--- a/src/lib/vault/refresh.ts
+++ b/src/lib/vault/refresh.ts
@@ -56,13 +56,13 @@ async function doRefresh(vaultId: string): Promise<string | null> {
     useAuthHaltStore.getState().clearHalt(vaultId);
     return next.accessToken;
   } catch (err) {
-    if (err instanceof RefreshHttpError) {
-      // The hub answered and rejected our refresh token — typically RFC 6749
-      // `invalid_grant` from rotation drift, an admin-revoked token, or a
-      // deleted client registration. Surface a halt so the UI prompts a
-      // reconnect; manual reauth is the only recovery. Network-level errors
-      // skip this branch and stay transient (the next sync tick retries
-      // quietly without nagging the user).
+    if (err instanceof RefreshHttpError && err.status >= 400 && err.status < 500) {
+      // 4xx is the hub *deciding* our refresh token is bad — typically RFC
+      // 6749 `invalid_grant` (rotation drift / admin revoke), or a deleted
+      // client registration. Surface a halt; manual reauth is the only
+      // recovery. 5xx (overloaded hub, transient infra) stays unhalted —
+      // the next sync tick retries quietly. Network-level errors don't
+      // throw RefreshHttpError, so they also stay transient.
       const message =
         err.oauthError === "invalid_grant" || err.status === 400 || err.status === 401
           ? "Your vault session expired. Reconnect to resume syncing."

--- a/src/lib/vault/storage.ts
+++ b/src/lib/vault/storage.ts
@@ -1,7 +1,7 @@
 import type { PendingOAuthState, ServicesCatalog, StoredToken, VaultRecord } from "./types";
 
-const VAULTS_KEY = "lens:vaults";
-const ACTIVE_KEY = "lens:active_vault";
+export const VAULTS_KEY = "lens:vaults";
+export const ACTIVE_KEY = "lens:active_vault";
 const TOKEN_PREFIX = "lens:token:";
 const SERVICES_PREFIX = "lens:services:";
 const PENDING_OAUTH_KEY = "lens:oauth:pending";


### PR DESCRIPTION
## Summary

Two sync-UX polish items bundled per governance:

- **#85** — When the hub revokes a refresh token, surface a non-dismissable "Reconnect to vault" banner that re-runs the OAuth flow on click. RFC 6749 `invalid_grant` (any 4xx from `/oauth/token`) and post-refresh 401/403 from any vault endpoint both feed the same `useAuthHaltStore`. Network errors stay transient.
- **#86** — Multi-tab sync: a `storage`-event listener at the app root reloads the vaults map, active-vault id, and auth-halt entries directly via `setState`. The event fires only in *other* tabs, so writes can't loop. Switching active vault in tab A propagates to tab B without a refresh.

Bumps to **0.3.6-rc.1**.

## Changes

- New `src/lib/vault/auth-halt-store.ts` (Zustand + per-vault localStorage; cross-tab reload).
- New `src/components/ReconnectBanner.tsx` — top-level red banner, `role=alert`, click → `beginOAuth(issuer, scope)`.
- New `src/lib/vault/cross-tab-sync.ts` — `useCrossTabVaultSync()` listens for storage events.
- `oauth.ts` adds typed `RefreshHttpError` so transient (network) vs definitive (HTTP) refresh failures are distinguishable.
- `refresh.ts` marks halted on `RefreshHttpError`, clears on success.
- `client.ts` adds `onAuthRevoked` callback (fires on post-refresh 401/403 and on no-refresh-callback paths).
- `queries.ts` wires `onAuthRevoked` for `useActiveVaultClient`.
- `OAuthCallback.tsx` clears the halt after a successful re-auth.

Per-issue commits:
- 4ac68d0 sync: surface revoked-refresh-token with reconnect banner (#85)
- e0fcf42 sync: cross-tab vault state via storage events (#86)

## Gates

- \`pnpm typecheck\` — clean.
- \`pnpm test\` — 610/610 passing across 72 files (5 new auth-halt-store, +4 refresh, +4 client).

## Test plan

- [ ] Open notes in two tabs against the same vault. Switch active vault in tab A → tab B's tree/queries follow without refresh.
- [ ] Manually invalidate refresh token (delete from hub DB). Trigger a sync → reconnect banner appears, click → OAuth flow completes → banner clears.
- [ ] Toggle network offline mid-refresh → banner does NOT appear (transient); next sync tick retries.
- [ ] Reconnect in one tab → halt clears in the other tab too.

Closes #85
Closes #86