### PR TITLE
feat: saved-view management UI + cluster-A closeout (0.3.7-rc.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.6-rc.1",
+  "version": "0.3.7-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/routes/Notes.savedViews.test.tsx
+++ b/src/app/routes/Notes.savedViews.test.tsx
@@ -1,0 +1,197 @@
+import { Notes } from "@/app/routes/Notes";
+import { useToastStore } from "@/lib/toast/store";
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { BrowserRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FetchState {
+  notes: unknown[];
+  tags: unknown[];
+  views: unknown[];
+}
+
+function installFetch(state: FetchState) {
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (method === "PATCH" || method === "DELETE") {
+      const id = url.match(/\/api\/notes\/([^?]+)/)?.[1] ?? "x";
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id, path: `UI/Views/${id}`, createdAt: "2026-04-26T00:00:00Z" }),
+        text: async () => "",
+      } as Response;
+    }
+    if (url.includes("/api/tags")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => state.tags,
+        text: async () => "",
+      } as Response;
+    }
+    // Saved-views are filtered by `path_prefix=UI%2FViews%2F` on the request.
+    const isViewsQuery = url.includes("path_prefix=UI%2FViews%2F");
+    const body = isViewsQuery ? state.views : state.notes;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => "",
+    } as Response;
+  });
+  vi.stubGlobal("fetch", fetchImpl);
+  return fetchImpl;
+}
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      dev: {
+        id: "dev",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "client-test",
+        scope: "full",
+        addedAt: "2026-04-25T00:00:00.000Z",
+        lastUsedAt: "2026-04-25T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "dev",
+  });
+  localStorage.setItem(
+    "lens:token:dev",
+    JSON.stringify({ accessToken: "pvt_abc", scope: "full", vault: "default" }),
+  );
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return (
+    <QueryClientProvider client={client}>
+      <BrowserRouter>{children}</BrowserRouter>
+    </QueryClientProvider>
+  );
+}
+
+const viewNote = {
+  id: "view-1",
+  path: "UI/Views/Daily",
+  createdAt: "2026-04-25T00:00:00Z",
+  updatedAt: "2026-04-25T10:00:00Z",
+  metadata: { kind: "saved-view", filters: { tags: ["journal"] } },
+};
+
+describe("SavedViewsSidebar management menu", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    useToastStore.setState({ toasts: [] });
+    seedStore();
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders saved views with a per-row management menu trigger", async () => {
+    installFetch({ notes: [], tags: [], views: [viewNote] });
+
+    render(<Notes />, { wrapper: Wrapper });
+
+    const list = await screen.findByRole("list", { name: /saved views/i });
+    const item = within(list).getByText("Daily").closest("li") as HTMLElement;
+    expect(item).not.toBeNull();
+    const trigger = within(item).getByRole("button", { name: /manage saved view daily/i });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("opens the menu and disables 'Update with current filters' when no filters are active", async () => {
+    installFetch({ notes: [], tags: [], views: [viewNote] });
+
+    render(<Notes />, { wrapper: Wrapper });
+    const trigger = await screen.findByRole("button", { name: /manage saved view daily/i });
+    fireEvent.click(trigger);
+
+    const update = await screen.findByRole("menuitem", { name: /update with current filters/i });
+    expect(update).toBeDisabled();
+  });
+
+  it("Delete sends DELETE to the view note id when confirmed", async () => {
+    const fetchImpl = installFetch({ notes: [], tags: [], views: [viewNote] });
+    vi.stubGlobal("confirm", () => true);
+
+    render(<Notes />, { wrapper: Wrapper });
+    const trigger = await screen.findByRole("button", { name: /manage saved view daily/i });
+    fireEvent.click(trigger);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: /^delete$/i }));
+    });
+
+    await waitFor(() => {
+      const del = fetchImpl.mock.calls.find(
+        ([url, init]) =>
+          (init as RequestInit | undefined)?.method === "DELETE" &&
+          String(url).includes("/api/notes/view-1"),
+      );
+      expect(del).toBeDefined();
+    });
+  });
+
+  it("Delete is a no-op when the user cancels the confirm prompt", async () => {
+    const fetchImpl = installFetch({ notes: [], tags: [], views: [viewNote] });
+    vi.stubGlobal("confirm", () => false);
+
+    render(<Notes />, { wrapper: Wrapper });
+    const trigger = await screen.findByRole("button", { name: /manage saved view daily/i });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("menuitem", { name: /^delete$/i }));
+
+    // Give react-query a microtask in case the mutation queued anyway.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const del = fetchImpl.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === "DELETE",
+    );
+    expect(del).toBeUndefined();
+  });
+
+  it("Rename opens a dialog and PATCHes the new path on save", async () => {
+    const fetchImpl = installFetch({ notes: [], tags: [], views: [viewNote] });
+
+    render(<Notes />, { wrapper: Wrapper });
+    const trigger = await screen.findByRole("button", { name: /manage saved view daily/i });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("menuitem", { name: /rename/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /rename view/i });
+    const input = within(dialog).getByLabelText(/view name/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Weekly" } });
+
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole("button", { name: /^save$/i }));
+    });
+
+    await waitFor(() => {
+      const patch = fetchImpl.mock.calls.find(
+        ([url, init]) =>
+          (init as RequestInit | undefined)?.method === "PATCH" &&
+          String(url).includes("/api/notes/view-1"),
+      );
+      expect(patch).toBeDefined();
+      const body = JSON.parse((patch?.[1] as RequestInit).body as string);
+      expect(body.path).toBe("UI/Views/Weekly");
+      expect(body.if_updated_at).toBe("2026-04-25T10:00:00Z");
+    });
+  });
+});

--- a/src/app/routes/Notes.tsx
+++ b/src/app/routes/Notes.tsx
@@ -3,7 +3,13 @@ import { TagBrowser } from "@/components/TagBrowser";
 import { normalizeTag } from "@/components/TagEditor";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { meetsAutoThreshold, usePathTreeMode } from "@/lib/path-tree";
-import { useSaveView, useSavedViews } from "@/lib/saved-views/queries";
+import {
+  useDeleteView,
+  useRenameView,
+  useSaveView,
+  useSavedViews,
+  useUpdateView,
+} from "@/lib/saved-views/queries";
 import {
   type SavedView,
   type SavedViewFilters,
@@ -138,8 +144,12 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
   const tags = useTags();
   const savedViews = useSavedViews(roles.view);
   const saveView = useSaveView(roles.view);
+  const renameView = useRenameView();
+  const updateView = useUpdateView();
+  const deleteView = useDeleteView();
   const pushToast = useToastStore((s) => s.push);
   const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [renaming, setRenaming] = useState<SavedView | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   // Path tree: independent capped fetch (separate from the filtered list) so
@@ -181,6 +191,46 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
       }
     },
     [saveView, currentFilters, pushToast],
+  );
+
+  const onRenameView = useCallback(
+    async (view: SavedView, newName: string) => {
+      try {
+        await renameView.mutateAsync({ view, newName });
+        pushToast(`Renamed to "${newName}".`, "success");
+        setRenaming(null);
+      } catch (err) {
+        pushToast(`Could not rename: ${(err as Error).message}`, "error");
+      }
+    },
+    [renameView, pushToast],
+  );
+
+  const onUpdateView = useCallback(
+    async (view: SavedView) => {
+      try {
+        await updateView.mutateAsync({ view, filters: currentFilters });
+        pushToast(`Updated "${view.name}".`, "success");
+      } catch (err) {
+        pushToast(`Could not update: ${(err as Error).message}`, "error");
+      }
+    },
+    [updateView, currentFilters, pushToast],
+  );
+
+  const onDeleteView = useCallback(
+    async (view: SavedView) => {
+      // Plain confirm is consistent with the other destructive flows in this
+      // app (Vaults.tsx removal, SyncStatusPanel discard).
+      if (!confirm(`Delete saved view "${view.name}"? This can't be undone.`)) return;
+      try {
+        await deleteView.mutateAsync(view);
+        pushToast(`Deleted "${view.name}".`, "success");
+      } catch (err) {
+        pushToast(`Could not delete: ${(err as Error).message}`, "error");
+      }
+    },
+    [deleteView, pushToast],
   );
 
   // Client-side post-process: hide archived on default list unless toggled, and
@@ -296,6 +346,10 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
                 views={savedViews.data}
                 isPending={savedViews.isPending}
                 error={savedViews.error}
+                canUpdateWithCurrent={isFiltersNonEmpty(currentFilters)}
+                onRename={(v) => setRenaming(v)}
+                onUpdate={onUpdateView}
+                onDelete={onDeleteView}
               />
               {showFoldersAccordion ? (
                 <details
@@ -440,6 +494,16 @@ export function Notes({ preset }: { preset?: NotesPreset } = {}) {
           onSave={onSaveView}
         />
       ) : null}
+
+      {renaming ? (
+        <RenameViewDialog
+          view={renaming}
+          existing={savedViews.data ?? []}
+          isSaving={renameView.isPending}
+          onCancel={() => setRenaming(null)}
+          onSave={(name) => onRenameView(renaming, name)}
+        />
+      ) : null}
     </div>
   );
 }
@@ -448,11 +512,41 @@ function SavedViewsSidebar({
   views,
   isPending,
   error,
+  canUpdateWithCurrent,
+  onRename,
+  onUpdate,
+  onDelete,
 }: {
   views: SavedView[] | undefined;
   isPending: boolean;
   error: Error | null;
+  canUpdateWithCurrent: boolean;
+  onRename: (view: SavedView) => void;
+  onUpdate: (view: SavedView) => void;
+  onDelete: (view: SavedView) => void;
 }) {
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+
+  // Close the menu when the user clicks/taps outside or presses Escape — small
+  // dropdowns rendered inline like this don't get focus-trap behavior for free.
+  useEffect(() => {
+    if (!openMenuId) return;
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.closest("[data-saved-view-menu]")) return;
+      setOpenMenuId(null);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpenMenuId(null);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [openMenuId]);
+
   return (
     <aside>
       <h2 className="mb-2 text-xs uppercase tracking-wider text-fg-dim">Saved views</h2>
@@ -467,18 +561,156 @@ function SavedViewsSidebar({
       ) : (
         <ul className="space-y-1" aria-label="Saved views">
           {views.map((v) => (
-            <li key={v.id}>
+            <li
+              key={v.id}
+              className="group flex items-center rounded-md border border-transparent hover:border-border hover:bg-card"
+            >
               <Link
                 to={`/?${filtersToSearchParams(v.filters).toString()}`}
-                className="block truncate rounded-md border border-transparent px-2 py-1 text-sm text-fg-muted hover:border-border hover:bg-card hover:text-accent"
+                className="block flex-1 truncate px-2 py-1 text-sm text-fg-muted hover:text-accent"
               >
                 {v.name}
               </Link>
+              <div className="relative" data-saved-view-menu>
+                <button
+                  type="button"
+                  onClick={() => setOpenMenuId((c) => (c === v.id ? null : v.id))}
+                  aria-label={`Manage saved view ${v.name}`}
+                  aria-haspopup="menu"
+                  aria-expanded={openMenuId === v.id}
+                  className="px-2 py-1 text-fg-dim hover:text-accent"
+                >
+                  <span aria-hidden="true" className="font-mono text-xs">
+                    ⋯
+                  </span>
+                </button>
+                {openMenuId === v.id ? (
+                  <div
+                    role="menu"
+                    className="absolute right-0 top-full z-30 mt-1 w-48 overflow-hidden rounded-md border border-border bg-card shadow-lg"
+                  >
+                    <button
+                      type="button"
+                      role="menuitem"
+                      disabled={!canUpdateWithCurrent}
+                      onClick={() => {
+                        setOpenMenuId(null);
+                        onUpdate(v);
+                      }}
+                      className="block w-full px-3 py-2 text-left text-sm text-fg-muted hover:bg-bg hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
+                      title={
+                        canUpdateWithCurrent
+                          ? undefined
+                          : "Apply some filters first to update this view."
+                      }
+                    >
+                      Update with current filters
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setOpenMenuId(null);
+                        onRename(v);
+                      }}
+                      className="block w-full px-3 py-2 text-left text-sm text-fg-muted hover:bg-bg hover:text-accent"
+                    >
+                      Rename…
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setOpenMenuId(null);
+                        onDelete(v);
+                      }}
+                      className="block w-full border-t border-border px-3 py-2 text-left text-sm text-red-400 hover:bg-bg"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                ) : null}
+              </div>
             </li>
           ))}
         </ul>
       )}
     </aside>
+  );
+}
+
+function RenameViewDialog({
+  view,
+  existing,
+  isSaving,
+  onCancel,
+  onSave,
+}: {
+  view: SavedView;
+  existing: SavedView[];
+  isSaving: boolean;
+  onCancel: () => void;
+  onSave: (name: string) => void;
+}) {
+  const [name, setName] = useState(view.name);
+  const trimmed = name.trim();
+  // Same-name (no-op) is allowed-but-disabled — it's just clutter to send a
+  // rename that doesn't change anything. Collision check skips the view itself
+  // so re-typing its current name doesn't read as a collision.
+  const collides = existing.some(
+    (v) => v.id !== view.id && v.name.toLowerCase() === trimmed.toLowerCase(),
+  );
+  const unchanged = trimmed === view.name;
+  const canSave = trimmed.length > 0 && !collides && !unchanged && !isSaving;
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
+      // biome-ignore lint/a11y/useSemanticElements: native <dialog> requires imperative showModal()/close(); we want declarative open=!!renaming
+      role="dialog"
+      aria-modal="true"
+      aria-label="Rename view"
+    >
+      <div className="w-full max-w-sm rounded-md border border-border bg-card p-5">
+        <h3 className="mb-3 font-serif text-lg text-fg">Rename view</h3>
+        <label className="block text-sm">
+          <span className="mb-1 block text-fg-muted">Name</span>
+          <input
+            type="text"
+            value={name}
+            // biome-ignore lint/a11y/noAutofocus: dialog focus
+            autoFocus
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canSave) onSave(trimmed);
+              if (e.key === "Escape") onCancel();
+            }}
+            aria-label="View name"
+            className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg focus:border-accent focus:outline-none"
+          />
+        </label>
+        {collides ? (
+          <p className="mt-2 text-xs text-red-400">A view with that name already exists.</p>
+        ) : null}
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="min-h-11 rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted hover:text-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => canSave && onSave(trimmed)}
+            disabled={!canSave}
+            className="min-h-11 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-40"
+          >
+            {isSaving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/lib/saved-views/queries.test.tsx
+++ b/src/lib/saved-views/queries.test.tsx
@@ -1,0 +1,188 @@
+import { useVaultStore } from "@/lib/vault/store";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDeleteView, useRenameView, useSavedViews, useUpdateView } from "./queries";
+import type { SavedView } from "./spec";
+
+interface FetchEntry {
+  status?: number;
+  body: unknown;
+}
+type FetchMap = Record<string, FetchEntry>;
+
+function installFetch(map: FetchMap) {
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    for (const matcher of Object.keys(map)) {
+      const [wantMethod, wantFragment] = matcher.includes(" ")
+        ? matcher.split(" ", 2)
+        : ["GET", matcher];
+      if (method !== wantMethod) continue;
+      if (!url.includes(wantFragment!)) continue;
+      const entry = map[matcher]!;
+      return {
+        ok: (entry.status ?? 200) < 400,
+        status: entry.status ?? 200,
+        json: async () => entry.body,
+        text: async () => "",
+      } as Response;
+    }
+    return { ok: false, status: 404, json: async () => null, text: async () => "" } as Response;
+  });
+  vi.stubGlobal("fetch", fetchImpl);
+  return fetchImpl;
+}
+
+function seedStore() {
+  useVaultStore.setState({
+    vaults: {
+      dev: {
+        id: "dev",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "client-test",
+        scope: "full",
+        addedAt: "2026-04-25T00:00:00.000Z",
+        lastUsedAt: "2026-04-25T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "dev",
+  });
+  localStorage.setItem(
+    "lens:token:dev",
+    JSON.stringify({ accessToken: "pvt_abc", scope: "full", vault: "default" }),
+  );
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const baseView: SavedView = {
+  id: "view-1",
+  name: "Daily",
+  filters: { tags: ["journal"] },
+  updatedAt: "2026-04-25T10:00:00.000Z",
+};
+
+describe("saved-views mutations", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    seedStore();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("useSavedViews exposes updatedAt so mutations can send if_updated_at", async () => {
+    installFetch({
+      "/api/notes?tag=view": {
+        body: [
+          {
+            id: "view-1",
+            path: "UI/Views/Daily",
+            createdAt: "2026-04-25T00:00:00Z",
+            updatedAt: "2026-04-25T10:00:00.000Z",
+            metadata: { kind: "saved-view", filters: { tags: ["journal"] } },
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useSavedViews("view"), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.[0]?.updatedAt).toBe("2026-04-25T10:00:00.000Z");
+  });
+
+  it("useRenameView PATCHes the new path with if_updated_at when a baseline is present", async () => {
+    const fetchImpl = installFetch({
+      "PATCH /api/notes/view-1": {
+        body: { id: "view-1", path: "UI/Views/Renamed", createdAt: "2026-04-25T00:00:00Z" },
+      },
+    });
+
+    const { result } = renderHook(() => useRenameView(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ view: baseView, newName: "Renamed" });
+    });
+
+    const patch = fetchImpl.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === "PATCH",
+    );
+    expect(patch).toBeDefined();
+    const body = JSON.parse((patch?.[1] as RequestInit).body as string);
+    expect(body.path).toBe("UI/Views/Renamed");
+    expect(body.if_updated_at).toBe("2026-04-25T10:00:00.000Z");
+    expect(body.force).toBeUndefined();
+  });
+
+  it("useRenameView falls back to force when the view has no updatedAt baseline", async () => {
+    const fetchImpl = installFetch({
+      "PATCH /api/notes/view-1": {
+        body: { id: "view-1", path: "UI/Views/X", createdAt: "2026-04-25T00:00:00Z" },
+      },
+    });
+    const noBaseline: SavedView = { ...baseView, updatedAt: undefined };
+
+    const { result } = renderHook(() => useRenameView(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ view: noBaseline, newName: "X" });
+    });
+
+    const patch = fetchImpl.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === "PATCH",
+    );
+    const body = JSON.parse((patch?.[1] as RequestInit).body as string);
+    expect(body.force).toBe(true);
+    expect(body.if_updated_at).toBeUndefined();
+  });
+
+  it("useUpdateView re-encodes the metadata against the current filters", async () => {
+    const fetchImpl = installFetch({
+      "PATCH /api/notes/view-1": {
+        body: { id: "view-1", path: "UI/Views/Daily", createdAt: "2026-04-25T00:00:00Z" },
+      },
+    });
+
+    const { result } = renderHook(() => useUpdateView(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({
+        view: baseView,
+        filters: { search: "draft", tags: ["a", "b"], tagMatch: "all" },
+      });
+    });
+
+    const patch = fetchImpl.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === "PATCH",
+    );
+    const body = JSON.parse((patch?.[1] as RequestInit).body as string);
+    expect(body.metadata).toEqual({
+      kind: "saved-view",
+      filters: { search: "draft", tags: ["a", "b"], tagMatch: "all" },
+    });
+    expect(body.if_updated_at).toBe("2026-04-25T10:00:00.000Z");
+  });
+
+  it("useDeleteView fires DELETE against the view note id", async () => {
+    const fetchImpl = installFetch({
+      "DELETE /api/notes/view-1": { body: { deleted: true, id: "view-1" } },
+    });
+
+    const { result } = renderHook(() => useDeleteView(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.mutateAsync(baseView);
+    });
+
+    const del = fetchImpl.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === "DELETE",
+    );
+    expect(del?.[0]).toContain("/api/notes/view-1");
+  });
+});

--- a/src/lib/saved-views/queries.ts
+++ b/src/lib/saved-views/queries.ts
@@ -11,6 +11,13 @@ import {
   pathForName,
 } from "./spec";
 
+function invalidateAll(qc: ReturnType<typeof useQueryClient>, activeId: string | null): void {
+  qc.invalidateQueries({ queryKey: ["savedViews", activeId] });
+  qc.invalidateQueries({ queryKey: ["notes", activeId] });
+  qc.invalidateQueries({ queryKey: ["tags", activeId] });
+  qc.invalidateQueries({ queryKey: ["vaultInfo", activeId] });
+}
+
 // Listing strategy: ask the vault for notes tagged with the role's view tag,
 // then filter to the conventional UI/Views/ prefix and decode metadata. The
 // path filter is the safety net — a stray "view"-tagged note outside that
@@ -61,11 +68,71 @@ export function useSaveView(viewTag: string) {
         metadata: encodeFiltersMetadata(args.filters),
       });
     },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["savedViews", activeId] });
-      qc.invalidateQueries({ queryKey: ["notes", activeId] });
-      qc.invalidateQueries({ queryKey: ["tags", activeId] });
-      qc.invalidateQueries({ queryKey: ["vaultInfo", activeId] });
+    onSuccess: () => invalidateAll(qc, activeId),
+  });
+}
+
+interface RenameArgs {
+  view: SavedView;
+  newName: string;
+}
+
+// Rename = move the note to a new `UI/Views/<name>` path. The vault's PATCH
+// endpoint accepts `path` for moves. We send `if_updated_at` when the view
+// carries a baseline so concurrent edits from another tab/device surface as
+// 428, not silent overwrite.
+export function useRenameView() {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ view, newName }: RenameArgs): Promise<Note> => {
+      if (!client) throw new Error("No active vault");
+      return client.updateNote(view.id, {
+        path: pathForName(newName),
+        ...(view.updatedAt ? { if_updated_at: view.updatedAt } : { force: true }),
+      });
     },
+    onSuccess: () => invalidateAll(qc, activeId),
+  });
+}
+
+interface UpdateArgs {
+  view: SavedView;
+  filters: SavedViewFilters;
+}
+
+// "Update with current filters" — overwrite the saved-view metadata so the
+// existing entry now points at whatever the user has filtered to right now.
+// Same baseline semantics as rename.
+export function useUpdateView() {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ view, filters }: UpdateArgs): Promise<Note> => {
+      if (!client) throw new Error("No active vault");
+      return client.updateNote(view.id, {
+        metadata: encodeFiltersMetadata(filters),
+        ...(view.updatedAt ? { if_updated_at: view.updatedAt } : { force: true }),
+      });
+    },
+    onSuccess: () => invalidateAll(qc, activeId),
+  });
+}
+
+export function useDeleteView() {
+  const client = useActiveVaultClient();
+  const activeId = useVaultStore((s) => s.activeVaultId);
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (view: SavedView): Promise<void> => {
+      if (!client) throw new Error("No active vault");
+      await client.deleteNote(view.id);
+    },
+    onSuccess: () => invalidateAll(qc, activeId),
   });
 }

--- a/src/lib/saved-views/spec.ts
+++ b/src/lib/saved-views/spec.ts
@@ -23,6 +23,10 @@ export interface SavedView {
   name: string;
   filters: SavedViewFilters;
   description?: string;
+  // Carried so rename / update mutations can send `if_updated_at` and avoid
+  // clobbering a peer's edit. Optional because a view note that's never been
+  // touched after creation may not have one.
+  updatedAt?: string;
 }
 
 // Build the canonical metadata blob the vault stores. Only emit fields
@@ -58,6 +62,7 @@ export function decodeView(note: Note): SavedView | null {
       sort: f.sort === "asc" ? "asc" : f.sort === "desc" ? "desc" : undefined,
       showArchived: f.showArchived === true,
     },
+    updatedAt: note.updatedAt,
   };
 }
 


### PR DESCRIPTION
## Summary

Cluster-A closeout. Surveying first turned up that two of the three issues had already shipped — only #29 had remaining code work.

- **#29 — Saved views management UI** (the only code change). The create flow has been live since #88; this adds the missing post-create lifecycle: rename, update with current filters, delete. Per-row kebab menu in `SavedViewsSidebar`, inline `RenameViewDialog`, three new mutations (`useRenameView` / `useUpdateView` / `useDeleteView`), and `SavedView.updatedAt` plumbed through `decodeView` so mutations send `if_updated_at` and respect optimistic concurrency.
- **#25 — Pinned + archived views with customizable tag roles**: closed by verification. The `TagRolesSection` settings panel (autocomplete via `<datalist>`, save / reset to defaults) shipped earlier in `Settings.tsx` lines 135–221; `PinArchiveButtons` and the pinned/archived list filtering already use the configured `roles.pinned` / `roles.archived` tags. P/A keyboard shortcuts wired.
- **#28 — Untagged + orphaned**: closed by vault-side verification. `parachute-vault` accepts `has_tags=false` / `has_links=false` query params (`src/routes.ts:199-200` → `core/src/notes.ts:289-307` `EXISTS` / `NOT EXISTS` SQL). `Notes.tsx` `queryState` builder forwards both flags on the `/untagged` and `/orphaned` preset routes.

0.3.6-rc.1 → 0.3.7-rc.1.

## Optimistic concurrency note

Rename and Update both send `if_updated_at` when the view carries a baseline (i.e. always, unless the cache returns a freshly created view that lacks one — then we fall back to `force: true`). A concurrent rename from a peer tab will surface as a 428 instead of a silent overwrite. Same model the offline note-edit drain uses (#88).

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx vitest run` — 630 pass / 75 files (was 620)
- [x] New: `src/lib/saved-views/queries.test.tsx` — 5 mutation tests (rename baseline, rename force-fallback, update metadata round-trip, delete fires DELETE, savedViews exposes `updatedAt`)
- [x] New: `src/app/routes/Notes.savedViews.test.tsx` — 5 sidebar UI tests (menu trigger, disabled-update-when-empty, delete confirm + cancel, rename dialog round-trip)
- [x] Existing `Notes.test.tsx` (22 tests) and `spec.test.ts` (15 tests) still green
- [ ] Manual: open a saved view, click `⋯`, exercise Update / Rename / Delete; verify a peer-tab edit doesn't silently clobber

## Closes

- Closes #29
- #25 closed by separate comment (verification)
- #28 closed by separate comment (vault-side verification, on this branch's predecessor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)