### PR TITLE
Closeout: capture race + queue nit + route-level lazy (#95, #91, #5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.8-rc.1",
+  "version": "0.3.9-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -64,8 +64,12 @@ describe("App", () => {
     // The `*` route navigates to internal `/`. With basename=/notes this is
     // external /notes (with or without trailing slash — both resolve the root
     // list). The bug Aaron hit (/notes/notes) would surface here if basename
-    // and route paths disagreed.
-    expect(window.location.pathname).toMatch(/^\/notes\/?$/);
+    // and route paths disagreed. Routes are lazy now, so the redirect chain
+    // (`/:id` → NoteView → "/") settles across a Suspense boundary instead of
+    // synchronously — wait for the URL to land.
+    return waitFor(() => {
+      expect(window.location.pathname).toMatch(/^\/notes\/?$/);
+    });
   });
 
   it("clamps horizontal overflow at the shell so a stray wide descendant can't scroll the viewport", () => {
@@ -104,7 +108,9 @@ describe("App", () => {
     // routing must hold `/settings` (and every other named static route)
     // above the `/:id` pre-#49 bookmark shim. If this ever fails, the shim
     // would start swallowing real internal pages.
-    expect(screen.getByRole("heading", { level: 1, name: /settings/i })).toBeInTheDocument();
-    expect(window.location.pathname).toBe("/notes/settings");
+    return waitFor(() => {
+      expect(screen.getByRole("heading", { level: 1, name: /settings/i })).toBeInTheDocument();
+      expect(window.location.pathname).toBe("/notes/settings");
+    });
   });
 });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,22 +8,34 @@ import { useVaultStore } from "@/lib/vault";
 import { useCrossTabVaultSync } from "@/lib/vault/cross-tab-sync";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { SyncProvider } from "@/providers/SyncProvider";
+import { Suspense, lazy } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useParams } from "react-router";
-import { Activity } from "./routes/Activity";
-import { AddVault } from "./routes/AddVault";
-import { Calendar } from "./routes/Calendar";
-import { Capture } from "./routes/Capture";
 import { Home } from "./routes/Home";
-import { NoteEditor } from "./routes/NoteEditor";
-import { NoteNew } from "./routes/NoteNew";
-import { NoteView } from "./routes/NoteView";
 import { Notes } from "./routes/Notes";
-import { OAuthCallback } from "./routes/OAuthCallback";
-import { Settings } from "./routes/Settings";
-import { Tags } from "./routes/Tags";
-import { Today } from "./routes/Today";
-import { VaultGraph } from "./routes/VaultGraph";
-import { Vaults } from "./routes/Vaults";
+
+// Home + Notes stay eager because the index dispatcher renders one of them on
+// first paint — splitting them would block FCP on a network round-trip. Every
+// other route gets its own chunk so the editor's CodeMirror, the graph's
+// force-graph layer, settings, etc. don't pile into the initial download.
+const Activity = lazy(() => import("./routes/Activity").then((m) => ({ default: m.Activity })));
+const AddVault = lazy(() => import("./routes/AddVault").then((m) => ({ default: m.AddVault })));
+const Calendar = lazy(() => import("./routes/Calendar").then((m) => ({ default: m.Calendar })));
+const Capture = lazy(() => import("./routes/Capture").then((m) => ({ default: m.Capture })));
+const NoteEditor = lazy(() =>
+  import("./routes/NoteEditor").then((m) => ({ default: m.NoteEditor })),
+);
+const NoteNew = lazy(() => import("./routes/NoteNew").then((m) => ({ default: m.NoteNew })));
+const NoteView = lazy(() => import("./routes/NoteView").then((m) => ({ default: m.NoteView })));
+const OAuthCallback = lazy(() =>
+  import("./routes/OAuthCallback").then((m) => ({ default: m.OAuthCallback })),
+);
+const Settings = lazy(() => import("./routes/Settings").then((m) => ({ default: m.Settings })));
+const Tags = lazy(() => import("./routes/Tags").then((m) => ({ default: m.Tags })));
+const Today = lazy(() => import("./routes/Today").then((m) => ({ default: m.Today })));
+const VaultGraph = lazy(() =>
+  import("./routes/VaultGraph").then((m) => ({ default: m.VaultGraph })),
+);
+const Vaults = lazy(() => import("./routes/Vaults").then((m) => ({ default: m.Vaults })));
 
 // Index dispatcher: render the notes list when a vault is connected, else the
 // landing page. Both live at internal `/`, which maps to external `/notes/`
@@ -32,6 +44,14 @@ import { Vaults } from "./routes/Vaults";
 function NotesIndex() {
   const activeVault = useVaultStore((s) => s.getActiveVault());
   return activeVault ? <Notes /> : <Home />;
+}
+
+// Bare fallback while a lazy route's chunk loads. Routes are tiny once split,
+// so the network round-trip is usually invisible — we don't want a spinner
+// flashing on every nav. An empty placeholder reserves the main column without
+// jumping the layout.
+function RouteFallback() {
+  return <div aria-busy="true" />;
 }
 
 // Shim for pre-mount external bookmarks. When the app lived at the origin root,
@@ -62,29 +82,31 @@ export function App() {
             <Header />
             <QuickSwitchMount />
             <main>
-              <Routes>
-                <Route path="/" element={<NotesIndex />} />
-                <Route path="/pinned" element={<Notes preset="pinned" />} />
-                <Route path="/archived" element={<Notes preset="archived" />} />
-                <Route path="/untagged" element={<Notes preset="untagged" />} />
-                <Route path="/orphaned" element={<Notes preset="orphaned" />} />
-                <Route path="/tags" element={<Tags />} />
-                <Route path="/new" element={<NoteNew />} />
-                <Route path="/capture" element={<Capture />} />
-                <Route path="/graph" element={<VaultGraph />} />
-                <Route path="/today" element={<Today />} />
-                <Route path="/calendar" element={<Calendar />} />
-                <Route path="/activity" element={<Activity />} />
-                <Route path="/n/:id" element={<NoteView />} />
-                <Route path="/n/:id/edit" element={<NoteEditor />} />
-                <Route path="/:id" element={<NoteIdRedirect />} />
-                <Route path="/:id/edit" element={<NoteIdRedirect suffix="/edit" />} />
-                <Route path="/add" element={<AddVault />} />
-                <Route path="/oauth/callback" element={<OAuthCallback />} />
-                <Route path="/vaults" element={<Vaults />} />
-                <Route path="/settings" element={<Settings />} />
-                <Route path="*" element={<Navigate to="/" replace />} />
-              </Routes>
+              <Suspense fallback={<RouteFallback />}>
+                <Routes>
+                  <Route path="/" element={<NotesIndex />} />
+                  <Route path="/pinned" element={<Notes preset="pinned" />} />
+                  <Route path="/archived" element={<Notes preset="archived" />} />
+                  <Route path="/untagged" element={<Notes preset="untagged" />} />
+                  <Route path="/orphaned" element={<Notes preset="orphaned" />} />
+                  <Route path="/tags" element={<Tags />} />
+                  <Route path="/new" element={<NoteNew />} />
+                  <Route path="/capture" element={<Capture />} />
+                  <Route path="/graph" element={<VaultGraph />} />
+                  <Route path="/today" element={<Today />} />
+                  <Route path="/calendar" element={<Calendar />} />
+                  <Route path="/activity" element={<Activity />} />
+                  <Route path="/n/:id" element={<NoteView />} />
+                  <Route path="/n/:id/edit" element={<NoteEditor />} />
+                  <Route path="/:id" element={<NoteIdRedirect />} />
+                  <Route path="/:id/edit" element={<NoteIdRedirect suffix="/edit" />} />
+                  <Route path="/add" element={<AddVault />} />
+                  <Route path="/oauth/callback" element={<OAuthCallback />} />
+                  <Route path="/vaults" element={<Vaults />} />
+                  <Route path="/settings" element={<Settings />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Routes>
+              </Suspense>
             </main>
             <BottomTabBar />
             <footer className="mx-auto max-w-5xl px-6 py-10 text-center text-sm text-fg-dim">

--- a/src/app/routes/Capture.test.tsx
+++ b/src/app/routes/Capture.test.tsx
@@ -26,6 +26,24 @@ const fakeState = {
   pickResult: "audio/webm;codecs=opus" as string | null,
 };
 
+// Toggle to make the next `enqueue` call throw — used by the catch-path
+// regression test to simulate a failed save and verify the savingRef leak fix.
+const enqueueState = vi.hoisted(() => ({ failNext: false }));
+
+vi.mock("@/lib/sync", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sync")>("@/lib/sync");
+  return {
+    ...actual,
+    enqueue: async (...args: Parameters<typeof actual.enqueue>) => {
+      if (enqueueState.failNext) {
+        enqueueState.failNext = false;
+        throw new Error("simulated enqueue failure");
+      }
+      return actual.enqueue(...args);
+    },
+  };
+});
+
 vi.mock("@/lib/capture/recorder", async () => {
   const actual =
     await vi.importActual<typeof import("@/lib/capture/recorder")>("@/lib/capture/recorder");
@@ -436,6 +454,78 @@ describe("Capture (unified)", () => {
     const db = await openLensDB();
     const rows = await listPending(db, "dev");
     expect(rows.length).toBe(1);
+    db.close();
+  });
+
+  it("failed save releases savingRef so a later unmount-flush still flushes the draft (#96 follow-up)", async () => {
+    // Regression for the savingRef leak on the catch path: if save() failed
+    // (network/quota/whatever) and the user kept editing then navigated away,
+    // the unmount-flush would bail unconditionally and silently drop the
+    // draft. After the fix, savingRef resets in the catch block so the
+    // unmount-flush still enqueues the latest content.
+    function Toggler() {
+      const [mounted, setMounted] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setMounted(false)}>
+            unmount
+          </button>
+          {mounted ? <Capture /> : <div>unmounted</div>}
+        </>
+      );
+    }
+    render(
+      <MemoryRouter>
+        <Toggler />
+      </MemoryRouter>,
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText(/capture content/i)).toBeInTheDocument();
+    });
+    const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
+
+    enqueueState.failNext = true;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "first attempt" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    });
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.some((t) => t.tone === "error")).toBe(true);
+    });
+
+    // Save failed — the queue should still be empty.
+    {
+      const db = await openLensDB();
+      const rows = await listPending(db, "dev");
+      expect(rows.length).toBe(0);
+      db.close();
+    }
+
+    // Type more after the failure, then navigate away. The unmount-flush
+    // should fire because savingRef was released in the catch block.
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "kept typing after failure" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "unmount" }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("unmounted")).toBeInTheDocument();
+    });
+    await waitFor(async () => {
+      const db = await openLensDB();
+      const rows = await listPending(db, "dev");
+      db.close();
+      expect(rows.length).toBe(1);
+    });
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    if (rows[0]?.mutation.kind === "create-note") {
+      expect(rows[0].mutation.payload.content).toBe("kept typing after failure");
+    }
     db.close();
   });
 

--- a/src/app/routes/Capture.test.tsx
+++ b/src/app/routes/Capture.test.tsx
@@ -395,6 +395,50 @@ describe("Capture (unified)", () => {
     db.close();
   });
 
+  it("unmount fired during save() does not double-enqueue (#95)", async () => {
+    // Race: user types, hits Capture, then immediately navigates away while
+    // the enqueue is still in flight. save() already started the create-note
+    // enqueue; the unmount-flush must not fire a second one.
+    function Toggler() {
+      const [mounted, setMounted] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setMounted(false)}>
+            unmount
+          </button>
+          {mounted ? <Capture /> : <div>unmounted</div>}
+        </>
+      );
+    }
+    render(
+      <MemoryRouter>
+        <Toggler />
+      </MemoryRouter>,
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText(/capture content/i)).toBeInTheDocument();
+    });
+    const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "racing the unmount" } });
+    });
+    // Click Capture and unmount in the same act() — both effects flush before
+    // the test reads the queue, so we observe whatever both code paths
+    // enqueue. With the bug, that's two rows.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+      fireEvent.click(screen.getByRole("button", { name: "unmount" }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("unmounted")).toBeInTheDocument();
+    });
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    expect(rows.length).toBe(1);
+    db.close();
+  });
+
   it("unmount with empty content does NOT enqueue", async () => {
     function Toggler() {
       const [mounted, setMounted] = useState(true);

--- a/src/app/routes/Capture.tsx
+++ b/src/app/routes/Capture.tsx
@@ -77,6 +77,11 @@ export function Capture() {
   const recorderRef = useRef<RecorderController | null>(null);
   const previewUrlRef = useRef<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  // Set synchronously by save() before any await so an unmount that fires in
+  // the same tick (user hits Capture and immediately navigates) can detect
+  // an in-flight enqueue and skip the unmount-flush. A render-tracked phase
+  // ref isn't enough — React may not re-render before the unmount.
+  const savingRef = useRef(false);
 
   // Tick the elapsed display while recording.
   useEffect(() => {
@@ -198,6 +203,7 @@ export function Capture() {
       return;
     }
     const audio = phase.kind === "have-audio" ? phase : null;
+    savingRef.current = true;
     setPhase({ kind: "saving" });
 
     const explicitTags = tags.filter((t) => t.length > 0);
@@ -326,10 +332,14 @@ export function Capture() {
   // so a tab switch never lost work. Preserve that for the unified surface.
   // Audio in `have-audio` is intentionally *not* flushed — it's bigger, and
   // saving an attachment without the user clicking Capture feels wrong.
+  // savingRef is checked here so a teardown that fires in the same tick as a
+  // Capture click (user hits Capture and immediately navigates) sees that
+  // save() is already in flight and bails — otherwise we'd enqueue twice.
   const latest = useRef({ db, activeVaultId: activeVault?.id ?? null, content, tags, roles });
   latest.current = { db, activeVaultId: activeVault?.id ?? null, content, tags, roles };
   useEffect(() => {
     return () => {
+      if (savingRef.current) return;
       const { db, activeVaultId, content, tags, roles } = latest.current;
       const text = content.trim();
       if (!text || !db || !activeVaultId) return;

--- a/src/app/routes/Capture.tsx
+++ b/src/app/routes/Capture.tsx
@@ -287,6 +287,11 @@ export function Capture() {
       reset();
     } catch (e) {
       pushToast(e instanceof Error ? `Capture failed: ${e.message}` : "Capture failed.", "error");
+      // Save failed — release the in-flight flag so the unmount-flush will
+      // still flush a draft if the user edits more text and navigates away.
+      // Without this, a single failed save would silently swallow every
+      // subsequent draft on the same mount.
+      savingRef.current = false;
       // Restore the audio buffer so the user can retry without re-recording.
       if (audio) {
         setPhase({

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/vault/client";
 import {
   DEFAULT_LENS_SETTINGS,
+  LEGACY_SETTINGS_NOTE_PATH,
   SETTINGS_NOTE_PATH,
   applySettingsPatch,
   extractLensSettings,
@@ -196,12 +197,12 @@ async function runMutation(ctx: DrainContext, row: PendingRow): Promise<void> {
       return;
     }
     case "update-settings": {
-      // A queued op enqueued under a prior settings-note path (e.g. the brief
-      // Lens-rebrand window's `.parachute/lens/settings`) would otherwise drain
-      // to the legacy note instead of the current one. Settings ops are
-      // idempotent — drop the row with a warning; the user re-saves and the
-      // next write goes to the current path.
-      if (m.notePath !== SETTINGS_NOTE_PATH) {
+      // A queued op enqueued under the brief Lens-rebrand window's path
+      // (`.parachute/lens/settings`) would otherwise drain to the legacy note
+      // instead of the current one. Settings ops are idempotent — drop the row
+      // with a warning; the user re-saves and the next write goes to the
+      // current path.
+      if (m.notePath === LEGACY_SETTINGS_NOTE_PATH) {
         console.warn(
           `[settings-queue] dropping queued op for migrated path "${m.notePath}" (current "${SETTINGS_NOTE_PATH}"). Re-save in Settings to apply.`,
         );


### PR DESCRIPTION
Final cleanup PR bundling the three remaining backlog items.

## Summary

- **#95 — capture: nav-away mid-save can double-enqueue**
  Reviewer concern from PR #94. \`Capture.tsx\` unmount cleanup re-read \`latest.current\` and enqueued a second create-note when the user hit Capture and navigated in the same tick. Fix: a \`savingRef\` set synchronously inside \`save()\` before any await, checked by the unmount-flush. Refs update without a render cycle, which a render-tracked phase ref couldn't guarantee.

  **Revise commit:** the catch path didn't reset \`savingRef\`, so a failed save left the ref stuck at \`true\` and the next nav-away silently dropped the user's draft. Reset alongside the phase restoration; new test simulates enqueue failure and asserts the unmount-flush still flushes.

- **#91 — queue: use LEGACY_SETTINGS_NOTE_PATH constant in drop guard**
  Reviewer NIT. Replaces \`m.notePath !== SETTINGS_NOTE_PATH\` with \`m.notePath === LEGACY_SETTINGS_NOTE_PATH\` for self-documenting intent. Same behavior, clearer guard.

- **#5 — perf: route-level React.lazy()**
  All routes except Home and Notes are now lazy. Home + Notes stay eager because the index dispatcher renders one of them on first paint. The editor (CodeMirror), graph (force-graph-2d), Settings, Capture, etc. now ship as their own chunks.

  **Note on highlight.js:** the original plan included swapping to \`highlight.js/lib/common\`. We don't import \`highlight.js\` directly — it's pulled transitively via \`rehype-highlight\`, which already defaults to lowlight's \`common\` set. Passing a runtime \`languages\` option to \`rehype-highlight\` doesn't drop the bundled languages because the static \`import { common } from 'lowlight'\` at module-load already pins them. The full bundle reduction below comes from route splitting alone.

## Bundle size (production build)

| Chunk | Before | After |
|---|---|---|
| main bundle | 1,330.25 kB / 422.41 kB gz | **393.86 kB / 121.01 kB gz** |
| reduction | — | **-71% gzipped** |

Heavy modules now lazy:
- \`MarkdownView\`: 337.29 kB / 102.30 kB gz
- \`useAttachmentUploader\`: 510.52 kB / 176.41 kB gz
- \`react-force-graph-2d\`: 188.75 kB / 61.65 kB gz (already split)
- per-route chunks: 1.5 - 14 kB each

Initial paint pulls only what the index dispatcher needs; everything else loads on first nav.

## Test plan

- [x] \`bun x tsc -b --noEmit\` — clean
- [x] \`bun x biome check\` on touched files — clean
- [x] \`bun x vitest run\` — 630/630 passing
- [x] New test (#95 catch-path): verified bug reproduces by reverting the fix locally — fails as expected (rows=0); passes with fix (rows=1)
- [x] \`bun run build\` — bundle measured before/after
- [ ] Manual: navigate to /settings, /n/<id>, /graph — confirm lazy chunks load and routes render
- [ ] Manual: hit Capture, type, click Capture button + immediately nav away — confirm exactly one row in pending
- [ ] Manual: simulate offline + hit Capture (toast: "Capture failed.") + type more + nav away — confirm draft persists in pending

Closes #95, #91, #5. Bumps to 0.3.9-rc.1.