### PR TITLE
fix(a11y): visible RouteFallback with announceable status (#97)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.9-rc.1",
+  "version": "0.3.10-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -46,12 +46,18 @@ function NotesIndex() {
   return activeVault ? <Notes /> : <Home />;
 }
 
-// Bare fallback while a lazy route's chunk loads. Routes are tiny once split,
-// so the network round-trip is usually invisible — we don't want a spinner
-// flashing on every nav. An empty placeholder reserves the main column without
-// jumping the layout.
+// Fallback while a lazy route's chunk loads. Routes are tiny once split, so
+// the round-trip is usually invisible — but if the network stalls (slow PWA
+// cold-start, offline-with-stale-SW, throttled mobile) the user needs *some*
+// signal that the app is doing work. `role="status"` makes screen readers
+// announce the change politely; the visible "Loading…" matches what sighted
+// users see, so both audiences get the same affordance.
 function RouteFallback() {
-  return <div aria-busy="true" />;
+  return (
+    <output className="mx-auto block max-w-5xl px-6 py-10 text-center text-sm text-fg-dim">
+      Loading…
+    </output>
+  );
 }
 
 // Shim for pre-mount external bookmarks. When the app lived at the origin root,


### PR DESCRIPTION
Closes #97.

## Summary

The Suspense fallback shipped in PR #96 as \`<div aria-busy=\"true\" />\` — invisible to sighted users and a11y-incorrect. \`aria-busy\` on a tiny empty container tells assistive tech nothing actionable, and sighted users get no signal at all when a chunk-load stalls.

Replace with an \`<output>\` element containing visible \"Loading…\" text. \`<output>\` carries an implicit \`role=\"status\"\`, so screen readers announce the chunk-load politely as a live region; the visible text gives sighted users the same signal.

```tsx
function RouteFallback() {
  return (
    <output className=\"mx-auto block max-w-5xl px-6 py-10 text-center text-sm text-fg-dim\">
      Loading…
    </output>
  );
}
```

## Why \`<output>\` over \`<div role=\"status\">\`

Biome's \`useSemanticElements\` rule pushed me to the semantic element. \`<output>\` has implicit \`role=\"status\"\` per WAI-ARIA, so it works the same for assistive tech without the explicit role attribute.

## Test plan

- [x] \`bun x tsc -b --noEmit\` — clean
- [x] \`bun x biome check\` on touched files — clean
- [x] \`bun x vitest run\` — 630/630 passing
- [ ] Manual: throttle network in devtools, navigate to /settings — confirm \"Loading…\" text is visible (not just an invisible div)
- [ ] Manual: VoiceOver/NVDA — confirm chunk-load is announced when navigating to a lazy route

Bumps to 0.3.10-rc.1.