### PR TITLE
fix(a11y): explicit aria-live + role=status smoke test (#99 + #100)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.10-rc.1",
+  "version": "0.3.11-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -1,7 +1,7 @@
 import { useVaultStore } from "@/lib/vault/store";
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { App } from "./App";
+import { App, RouteFallback } from "./App";
 
 function stubFetch() {
   vi.stubGlobal(
@@ -84,6 +84,52 @@ describe("App", () => {
     const shell = screen.getByRole("link", { name: /parachute notes/i }).closest("div.min-h-dvh");
     expect(shell).not.toBeNull();
     expect(shell?.className).toMatch(/\boverflow-x-hidden\b/);
+  });
+
+  it("RouteFallback exposes role=status with aria-live=polite and visible text (#100)", () => {
+    // Smoke test for the a11y contract of the Suspense fallback (#99/#100).
+    // `<output>` carries an implicit role="status"; we layer on an explicit
+    // `aria-live="polite"` because NVDA on Windows has historically
+    // inconsistent support for the implicit form. If either the role or the
+    // live-region attribute regresses, screen-reader users would lose the
+    // "the app is working on it" announcement during a slow lazy-chunk
+    // fetch — silent loading is the failure mode this guards against.
+    render(<RouteFallback />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent(/loading/i);
+  });
+
+  it("RouteFallback is mounted while a lazy route resolves (#100)", async () => {
+    // Companion check: the contract above only matters if the App actually
+    // hands rendering to RouteFallback during a lazy-route transition.
+    // /settings is route-split (lazy import in App.tsx), so the very first
+    // synchronous render at /notes/settings paints the fallback before the
+    // chunk's promise settles. Wait for the lazy chunk to land afterwards
+    // to keep the test isolated from later assertions.
+    useVaultStore.setState({
+      vaults: {
+        v1: {
+          id: "v1",
+          url: "http://localhost:1940",
+          name: "default",
+          issuer: "http://localhost:1940",
+          clientId: "c",
+          scope: "full",
+          addedAt: "2026-04-29T00:00:00.000Z",
+          lastUsedAt: "2026-04-29T00:00:00.000Z",
+        },
+      },
+      activeVaultId: "v1",
+    });
+    window.history.replaceState({}, "", "/notes/settings");
+    render(<App />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent(/loading/i);
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { level: 1, name: /settings/i })).toBeInTheDocument();
+    });
   });
 
   it("static route /settings wins over the dynamic /:id deep-link shim", () => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -49,12 +49,18 @@ function NotesIndex() {
 // Fallback while a lazy route's chunk loads. Routes are tiny once split, so
 // the round-trip is usually invisible — but if the network stalls (slow PWA
 // cold-start, offline-with-stale-SW, throttled mobile) the user needs *some*
-// signal that the app is doing work. `role="status"` makes screen readers
-// announce the change politely; the visible "Loading…" matches what sighted
-// users see, so both audiences get the same affordance.
-function RouteFallback() {
+// signal that the app is doing work. `<output>` carries an implicit
+// `role="status"`; we set `aria-live="polite"` explicitly because NVDA on
+// Windows has historically inconsistent support for the implicit form, and
+// the rest of the codebase (Toaster) already pairs status with explicit
+// aria-live. The visible "Loading…" matches what sighted users see, so both
+// audiences get the same affordance.
+export function RouteFallback() {
   return (
-    <output className="mx-auto block max-w-5xl px-6 py-10 text-center text-sm text-fg-dim">
+    <output
+      aria-live="polite"
+      className="mx-auto block max-w-5xl px-6 py-10 text-center text-sm text-fg-dim"
+    >
       Loading…
     </output>
   );


### PR DESCRIPTION
## Summary

Bundle of two a11y review follow-ups on top of #98 (the visible-RouteFallback fix). One commit per issue, rc bump per governance.

- **#99** — Add explicit `aria-live="polite"` to the `<output>` in RouteFallback.
  - `<output>` carries an implicit `role="status"` per WAI-ARIA, but NVDA on Windows has historically inconsistent support for the implicit form.
  - Matches the codebase pattern in `src/components/Toaster.tsx`, which already pairs status with explicit `aria-live`.
  - Also exports `RouteFallback` so #100 can assert the contract directly.

- **#100** — Smoke test asserting `role="status"` on RouteFallback during a lazy-route load.
  - Direct render of `RouteFallback` — locks the role + aria-live + visible-text triple.
  - Lazy-route entry at `/notes/settings` — proves App actually hands rendering to RouteFallback while the code-split chunk resolves. Catches regressions where the Suspense boundary is moved or removed.

Version bumps `0.3.10-rc.1` → `0.3.11-rc.1`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (632/632 passing — including the two new #100 assertions)
- [ ] Manual: load `/notes/` cold, watch DevTools accessibility tree show `role="status"` + `aria-live="polite"` while a route chunk is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)