### PR TITLE
release: 0.3.11 — SPA discovery fix + cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .vite/
 coverage/
 .turbo/
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+## 0.3.11 (2026-05-04)
+
+First `@latest` publish since launch (`0.3.0`). Bundles every change merged
+since launch into a single tagged release plus the discovery-protocol fix
+needed for hub well-known to resolve notes correctly.
+
+### Discovery / module protocol
+
+- **fix(spa): serve `.parachute/info` as JSON before SPA catch-all (#102).**
+  Notes' Vite preview SPA fallback was matching `/.parachute/info` and
+  `/notes/.parachute/info` and returning the index.html shell, so hub's
+  well-known builder couldn't read notes' module identity. The
+  `infoEndpointPlugin` now registers Connect middleware at both the
+  basePath-prefixed path (`/notes/.parachute/info`) and the root
+  (`/.parachute/info`) — matching the canonical contract used by vault and
+  scribe (no `.json` extension). The middleware runs before sirv and the
+  SPA fallback. Build still emits `dist/.parachute/info` as a static asset
+  for static-deploy scenarios.
+
+### Accessibility
+
+- **fix(a11y): visible RouteFallback with announceable status (#98).** The
+  route-level lazy fallback now renders a visible spinner with `role="status"`
+  so screen readers announce route transitions.
+- **fix(a11y): explicit `aria-live="polite"` on RouteFallback + smoke test
+  (#101).** Hardens the fallback's announcement contract and adds a
+  regression test.
+
+### Feature work and cleanup since launch
+
+- **chore: closeout — capture race + queue nit + route-level lazy (#96).**
+- **feat: unified single-screen capture (#94).** Capture flow consolidated.
+- **feat: saved-view management UI + cluster-A closeout (#93).**
+- **sync: reconnect banner + cross-tab vault sync (#92).**
+- **Cleanup bundle: pinned hint, group test, vault-switch reset, settings
+  drain, module.json (#90).**
+- **fix: capture `if_updated_at` baseline for offline note edits (#88).**
+- **feat: OAuth via hub-as-issuer with refresh + DCR cache (#83).**
+- **release: 0.3.2 (+ ignore `.claude` in lint/test) (#82).**
+- **docs: update parachute-cli refs to parachute-hub (#81).**
+- **feat: probe local hub at :1939 when same-origin probe fails (#80).**
+- **docs(readme): status note — PWA install flow coming with public
+  exposure (#77).**
+
+### Repo hygiene
+
+- **chore: gitignore `.claude/` stray artifacts.** Local agent worktrees /
+  scheduled-task locks no longer show up as untracked files.
+
+## 0.3.0 (2026-04-23)
+
+Launch.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.11-rc.1",
+  "version": "0.3.11",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/scripts/info-endpoint-plugin.test.ts
+++ b/scripts/info-endpoint-plugin.test.ts
@@ -53,7 +53,7 @@ describe("buildServiceInfo", () => {
 });
 
 describe("infoEndpointPlugin", () => {
-  it("emits .parachute/info.json into the bundle on build", () => {
+  it("emits .parachute/info into the bundle on build (no .json — matches hub's discovery contract)", () => {
     const plugin = infoEndpointPlugin({ basePath: "/notes", ...exampleInfo });
     const emitted: Array<{ type: string; fileName?: string; source?: string | Uint8Array }> = [];
     const ctx = {
@@ -72,12 +72,12 @@ describe("infoEndpointPlugin", () => {
       true,
     );
     expect(emitted).toHaveLength(1);
-    expect(emitted[0]?.fileName).toBe(".parachute/info.json");
+    expect(emitted[0]?.fileName).toBe(".parachute/info");
     const parsed = JSON.parse(String(emitted[0]?.source));
     expect(parsed).toEqual(exampleInfo);
   });
 
-  it("serves the same JSON via dev server middleware at basePath/.parachute/info.json", () => {
+  it("registers middleware at both /notes/.parachute/info and root /.parachute/info — beats the SPA catch-all that would otherwise serve index.html", () => {
     const plugin = infoEndpointPlugin({ basePath: "/notes", ...exampleInfo });
     const uses: Array<{ path: string; handler: (req: unknown, res: MockRes) => void }> = [];
     const fakeServer = {
@@ -93,14 +93,43 @@ describe("infoEndpointPlugin", () => {
     // biome-ignore lint/suspicious/noExplicitAny: ViteDevServer surface isn't worth typing for a smoke test
     configure.call(plugin as any, fakeServer as any);
 
-    expect(uses).toHaveLength(1);
-    expect(uses[0]?.path).toBe("/notes/.parachute/info.json");
+    expect(uses.map((u) => u.path).sort()).toEqual(["/.parachute/info", "/notes/.parachute/info"]);
+
+    for (const use of uses) {
+      const res = new MockRes();
+      use.handler({}, res);
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["Content-Type"]).toMatch(/application\/json/);
+      expect(JSON.parse(res.body)).toEqual(exampleInfo);
+    }
+  });
+
+  it("response shape matches the hub discovery contract — name, displayName, tagline, version, kind", () => {
+    const plugin = infoEndpointPlugin({ basePath: "/notes", ...exampleInfo });
+    const captured: { path: string; handler: (req: unknown, res: MockRes) => void }[] = [];
+    const fakeServer = {
+      middlewares: {
+        use(path: string, handler: (req: unknown, res: MockRes) => void) {
+          captured.push({ path, handler });
+        },
+      },
+      httpServer: null,
+    };
+    const configurePreview = plugin.configurePreviewServer;
+    if (typeof configurePreview !== "function") throw new Error("configurePreviewServer missing");
+    // biome-ignore lint/suspicious/noExplicitAny: PreviewServer surface isn't worth typing for a smoke test
+    configurePreview.call(plugin as any, fakeServer as any);
+    const rooted = captured.find((u) => u.path === "/.parachute/info");
+    if (!rooted) throw new Error("expected root middleware to be registered");
 
     const res = new MockRes();
-    uses[0]?.handler({}, res);
-    expect(res.statusCode).toBe(200);
-    expect(res.headers["Content-Type"]).toMatch(/application\/json/);
-    expect(JSON.parse(res.body)).toEqual(exampleInfo);
+    rooted.handler({}, res);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.name).toBe("parachute-notes");
+    expect(parsed.displayName).toBe("Notes");
+    expect(parsed.tagline).toBeTypeOf("string");
+    expect(parsed.version).toBeTypeOf("string");
+    expect(parsed.kind).toBe("frontend");
   });
 });
 

--- a/scripts/info-endpoint-plugin.ts
+++ b/scripts/info-endpoint-plugin.ts
@@ -19,25 +19,34 @@ interface PluginOptions extends ServiceInfo {
   basePath: string;
 }
 
-const ENDPOINT = ".parachute/info.json";
+const ENDPOINT = ".parachute/info";
 
-// Synthesize the `/.parachute/info.json` endpoint that the hub page reads to
-// render service cards. We don't commit a placeholder file in `public/`
-// because `version` has to come from `package.json` at build time — keeping
-// it dynamic avoids drift between the package version and the served value.
+// Synthesize the `/.parachute/info` endpoint that the hub's well-known
+// builder reads to discover modules and render service cards. We don't commit
+// a placeholder file in `public/` because `version` has to come from
+// `package.json` at build time — keeping it dynamic avoids drift between the
+// package version and the served value.
+//
+// The middleware is registered at BOTH the basePath-prefixed path (e.g.
+// `/notes/.parachute/info`) and the root (`/.parachute/info`) — hub probes
+// some modules at root, and we'd otherwise fall through to the SPA index.html
+// catch-all and return HTML.
 export function infoEndpointPlugin(options: PluginOptions): Plugin {
   const { basePath, ...info } = options;
   const body = `${JSON.stringify(info satisfies ServiceInfo, null, 2)}\n`;
   const baseWithSlash = basePath.endsWith("/") ? basePath : `${basePath}/`;
-  const servePath = `${baseWithSlash}${ENDPOINT}`;
+  const basedPath = `${baseWithSlash}${ENDPOINT}`;
+  const rootPath = `/${ENDPOINT}`;
 
   function attach(server: ViteDevServer | PreviewServer): void {
-    server.middlewares.use(servePath, (_req, res) => {
+    const handler = (_req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => {
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
       res.setHeader("Cache-Control", "no-cache");
       res.end(body);
-    });
+    };
+    server.middlewares.use(basedPath, handler);
+    if (rootPath !== basedPath) server.middlewares.use(rootPath, handler);
   }
 
   return {


### PR DESCRIPTION
## Summary

First `@latest` publish since launch (`0.3.0`). Bundles every change merged
since launch plus the discovery-protocol fix needed for hub well-known to
resolve notes correctly. Targeting **0.3.11** for `@latest`.

### Changes in this PR

1. **fix(spa): serve `.parachute/info` as JSON before catch-all (closes #102).**
   Hub's well-known builder reads each module's `/.parachute/info` to
   discover identity. Notes' Vite preview SPA fallback was matching
   `/.parachute/info` and `/notes/.parachute/info` and returning the
   index.html shell — hub got HTML instead of JSON, breaking discovery.
   Plugin now registers Connect middleware at both the basePath-prefixed
   path and the root, ahead of sirv + the SPA fallback. Build still emits
   `dist/.parachute/info` as a static asset for static-deploy scenarios.
2. **chore: gitignore `.claude/` stray artifacts.** Local agent worktrees +
   scheduled-task locks no longer show as untracked.
3. **chore(release): 0.3.11** + CHANGELOG.md (new file) summarizing every
   merged PR since 0.3.0.

### Changes since npm `0.3.0` (already merged to main, included in this release)

- a11y: visible RouteFallback with announceable status (#98)
- a11y: explicit `aria-live="polite"` + role=status smoke test (#101)
- chore: closeout — capture race + queue nit + route-level lazy (#96)
- feat: unified single-screen capture (#94)
- feat: saved-view management UI + cluster-A closeout (#93)
- sync: reconnect banner + cross-tab vault sync (#92)
- Cleanup bundle: pinned hint, group test, vault-switch reset, settings drain, module.json (#90)
- fix: capture `if_updated_at` baseline for offline note edits (#88)
- feat: OAuth via hub-as-issuer with refresh + DCR cache (#83)
- release: 0.3.2 + ignore `.claude` in lint/test (#82)
- docs: parachute-cli → parachute-hub refs (#81)
- feat: probe local hub at :1939 when same-origin probe fails (#80)
- docs(readme): PWA install flow status (#77)

Plus the SPA discovery fix and gitignore cleanup in this PR.

### Gates (fresh on this branch)

- `bun run typecheck` — clean
- `bun run test` — **633 / 633 passing** (73 test files), including 6 in
  `scripts/info-endpoint-plugin.test.ts` (3 new for the SPA-catch-all fix)
- `bun run build` — clean; `dist/.parachute/info` emitted; 38 PWA precache entries (1.5 MiB)
- `bun run lint` — 4 pre-existing baseline errors in unrelated files
  (`src/components/ReconnectBanner.tsx`, `TranscriptionStatus.test.tsx`,
  `src/lib/vault/cross-tab-sync.ts`, `src/lib/vault/queries.ts`); no new
  errors introduced. Untouched scope.

### Manual smoke

`bun run preview` (port 1942):

- `GET http://localhost:1942/.parachute/info` → 200 `application/json` (matches body)
- `GET http://localhost:1942/notes/.parachute/info` → 200 `application/json` (matches body)
- `GET http://localhost:1942/notes/some-route` → 200 `text/html` (SPA fallback intact)

### npm publish target

`@openparachute/notes@0.3.11` → `@latest`

## Test plan

- [ ] Reviewer confirms `/.parachute/info` returns JSON in preview
- [ ] Reviewer confirms SPA routes still serve `index.html`
- [ ] Reviewer confirms hub well-known build resolves notes correctly after merge
- [ ] After merge: `npm publish` to `@latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)