### PR TITLE
chore: correct CHANGELOG date to 2026-05-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.11 (2026-05-04)
+## 0.3.11 (2026-05-05)
 
 First `@latest` publish since launch (`0.3.0`). Bundles every change merged
 since launch into a single tagged release plus the discovery-protocol fix


### PR DESCRIPTION
## Summary

One-line fix: 0.3.11 publishes today (2026-05-05), not yesterday.

No version bump — notes stays at `0.3.11`.

## Gates

- `bun run typecheck` — clean
- `bun run test` — 633 / 633 passing (73 files)

## Test plan

- [ ] Reviewer confirms CHANGELOG header reads `## 0.3.11 (2026-05-05)`
- [ ] After merge: `npm publish` to `@latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)