### PR TITLE
feat(oauth): include credentials on DCR registration so hub session cookie reaches /oauth/register (closes #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@
 - **feat(oauth): include credentials on DCR registration so hub session
   cookie reaches /oauth/register (#106).** Adds `credentials: 'include'`
   to the `POST /oauth/register` fetch in `src/lib/vault/discovery.ts` so
-  the browser sends the `parachute_hub_session` cookie even when notes is
-  loaded from a different origin than the hub (e.g. notes on a cloudflare
-  URL registering at a tailnet hub). Companion to hub#199 (hub-side
-  auto-approve) and agent#140 (sibling fix on agent's SPA). No-op until
-  hub#199 ships; completes the loop the moment it does.
+  the browser sends the `parachute_hub_session` cookie when registering.
+  Companion to hub#199 (hub-side auto-approve) and agent#140 (sibling
+  fix on agent's SPA).
+
+  **Scope:** Same-origin auto-approve (notes loaded at `<hub>/notes/` →
+  DCR at `<hub>/oauth/register`) activates as soon as hub#199/200 lands.
+  Cross-origin auto-approve (e.g. notes on a cloudflare URL → hub on
+  tailnet) does NOT work yet — it requires hub-side CORS with
+  `Access-Control-Allow-Credentials`, a first-party origin allowlist, and
+  a `SameSite` relaxation or alternative credential, tracked at
+  parachute-hub#201. Until that lands, cross-origin DCR continues to
+  register as `pending` and requires manual `parachute auth approve-client`.
 
 ## 0.3.11 (2026-05-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.12-rc.1 (2026-05-08)
+
+### OAuth / DCR
+
+- **feat(oauth): include credentials on DCR registration so hub session
+  cookie reaches /oauth/register (#106).** Adds `credentials: 'include'`
+  to the `POST /oauth/register` fetch in `src/lib/vault/discovery.ts` so
+  the browser sends the `parachute_hub_session` cookie even when notes is
+  loaded from a different origin than the hub (e.g. notes on a cloudflare
+  URL registering at a tailnet hub). Companion to hub#199 (hub-side
+  auto-approve) and agent#140 (sibling fix on agent's SPA). No-op until
+  hub#199 ships; completes the loop the moment it does.
+
 ## 0.3.11 (2026-05-05)
 
 First `@latest` publish since launch (`0.3.0`). Bundles every change merged

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.11",
+  "version": "0.3.12-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/lib/vault/discovery.test.ts
+++ b/src/lib/vault/discovery.test.ts
@@ -84,6 +84,9 @@ describe("registerClient", () => {
     expect(call?.[0]).toBe("http://localhost:1940/oauth/register");
     const init = call?.[1] as RequestInit;
     expect(init.method).toBe("POST");
+    // Hub session cookie must reach /oauth/register so hub#199's auto-approve
+    // can skip the consent round-trip when the user is already signed in.
+    expect(init.credentials).toBe("include");
     const body = JSON.parse(init.body as string);
     expect(body.redirect_uris).toEqual(["http://localhost/oauth/callback"]);
     expect(body.client_name).toBe("Parachute Notes");

--- a/src/lib/vault/discovery.ts
+++ b/src/lib/vault/discovery.ts
@@ -54,14 +54,21 @@ export async function registerClient(
   const res = await fetchImpl(registrationEndpoint, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
-    // Send the hub session cookie (`parachute_hub_session`) on DCR even when
-    // notes is loaded from a different origin than the hub (e.g. notes on a
-    // cloudflare URL registering at a tailnet hub). Same-origin defaults
-    // already send the cookie via `credentials: 'same-origin'`; setting
-    // `'include'` is defensive — covers cross-origin too. Hub-side auto-
-    // approve (parachute-hub#199) reads this cookie to skip the consent
-    // round-trip when the user is already signed in. CSRF protection lives
-    // on the hub side via Origin/Referer match.
+    // Send the hub session cookie (`parachute_hub_session`) on DCR so
+    // hub-side auto-approve (parachute-hub#199) can skip the consent
+    // round-trip when the user is already signed in. This works today for
+    // the same-origin case (notes loaded at <hub>/notes/ → DCR at
+    // <hub>/oauth/register; the cookie would actually be sent by default,
+    // but setting `'include'` is harmless and explicit).
+    //
+    // Cross-origin auto-approve (notes via cloudflare URL → hub via
+    // tailnet, etc.) does NOT work yet: it needs hub-side CORS with
+    // `Access-Control-Allow-Credentials`, a first-party origin allowlist,
+    // and either a `SameSite` relaxation or an alternative credential —
+    // tracked at parachute-hub#201. Including credentials here is
+    // forward-compat: it's a no-op until that hub work lands and activates
+    // the moment it does. CSRF protection lives on the hub side via
+    // Origin/Referer match.
     credentials: "include",
     body: JSON.stringify({
       client_name: "Parachute Notes",

--- a/src/lib/vault/discovery.ts
+++ b/src/lib/vault/discovery.ts
@@ -54,6 +54,15 @@ export async function registerClient(
   const res = await fetchImpl(registrationEndpoint, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
+    // Send the hub session cookie (`parachute_hub_session`) on DCR even when
+    // notes is loaded from a different origin than the hub (e.g. notes on a
+    // cloudflare URL registering at a tailnet hub). Same-origin defaults
+    // already send the cookie via `credentials: 'same-origin'`; setting
+    // `'include'` is defensive — covers cross-origin too. Hub-side auto-
+    // approve (parachute-hub#199) reads this cookie to skip the consent
+    // round-trip when the user is already signed in. CSRF protection lives
+    // on the hub side via Origin/Referer match.
+    credentials: "include",
     body: JSON.stringify({
       client_name: "Parachute Notes",
       redirect_uris: [redirectUri],


### PR DESCRIPTION
## Summary

- Adds `credentials: 'include'` to the `POST /oauth/register` fetch in `src/lib/vault/discovery.ts` (`registerClient`), so the browser sends the `parachute_hub_session` cookie when registering.
- Bumps version `0.3.11 → 0.3.12-rc.1` and adds a CHANGELOG entry.

## Scope

**Same-origin auto-approve** (notes loaded at `<hub>/notes/` → DCR at `<hub>/oauth/register`) activates as soon as hub#199/200 lands. In the same-origin case the browser would actually send the cookie by default (`credentials: 'same-origin'`); setting `'include'` is harmless and explicit there.

**Cross-origin auto-approve** (e.g. notes on a cloudflare URL → hub on tailnet) does NOT work yet. It requires:

- Hub-side CORS with `Access-Control-Allow-Credentials: true`
- A first-party origin allowlist for hub-issued cookies
- A `SameSite` relaxation or alternative credential (the current `SameSite=Lax` cookie won't be sent on a cross-site `POST` from JS even with `credentials: 'include'`)

That hub work is tracked at **parachute-hub#201**. Until it lands, cross-origin DCR continues to register as `pending` and requires a manual `parachute auth approve-client`. Including `credentials: 'include'` here is forward-compat: a no-op for the cross-origin path until #201 ships, and immediately useful for it the moment it does.

## Companions

- **parachute-hub#199** — hub-side auto-approve via session cookie (the consumer of this cookie). This PR is a no-op for that path until hub#199 ships; completes the same-origin loop the moment it does.
- **parachute-hub#200** — hub OAuth surface alignment.
- **parachute-hub#201** — hub-side CORS + first-party origin allowlist work needed to actually unlock cross-origin auto-approve.
- **parachute-agent#140** — sibling fix on agent's SPA (same shape).

## Threat model

- The `parachute_hub_session` cookie is only set by hub via `/admin/login`.
- Browsers only send it same-origin or when an explicit `credentials: 'include'` opts in (and even then, only when SameSite policy + CORS allow it — see Scope above).
- CSRF protection for the auto-approve path lives on the hub side via Origin/Referer match (see hub#199).
- This change does not weaken any existing posture: `registerClient` is only called for DCR against a hub the user is currently configuring, never for arbitrary cross-origin third parties.

## Tests

- `src/lib/vault/discovery.test.ts` `registerClient` "POSTs redirect_uris and returns client_id" gains a positive assertion that `init.credentials === 'include'` on the fetch call.
- All 633 tests pass; existing assertions unaffected.
- `bun run typecheck` clean.
- `bun run build` clean.
- `bun run lint` shows 5 pre-existing errors on unrelated files (also reproduce on `main`); no errors introduced by this PR.

## Test plan

- [ ] Reviewer confirms `credentials: 'include'` is the only fetch-call change in `registerClient`.
- [ ] Reviewer confirms there is no second `oauth/register` POST elsewhere in `src/` (`grep -rn 'oauth/register' src/` returns the same call sites enumerated in commit body).
- [ ] After hub#199/200 land: smoke same-origin DCR (notes mounted at `<hub>/notes/`) completes without consent round-trip when the user is signed in.
- [ ] After hub#201 lands: smoke cross-origin DCR (cloudflare ↔ tailnet hub) completes without consent round-trip when the user is signed in.

Closes #106.