### PR TITLE
docs(module): declare uiUrl per patterns/module-ui-declaration.md

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -6,5 +6,6 @@
   "kind": "frontend",
   "port": 1942,
   "paths": ["/notes"],
+  "uiUrl": "/notes",
   "health": "/notes/health"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.13-rc.1 (2026-05-10)
+
+### Module manifest
+
+- **docs(module): declare `uiUrl: "/notes"` per
+  [`patterns/module-ui-declaration.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md).**
+  Lets hub render the Notes discovery tile dynamically from the
+  well-known doc instead of from its hardcoded `SERVICE_LABELS` map.
+  No runtime change in Notes itself; the field is opaque to the PWA.
+
 ## 0.3.12 (2026-05-09)
 
 ### OAuth / DCR

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.12",
+  "version": "0.3.13-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",


### PR DESCRIPTION
## Summary

- Add `uiUrl: "/notes"` to `.parachute/module.json` per the just-merged convention at [`parachute-patterns/patterns/module-ui-declaration.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md).
- Bump `0.3.12` → `0.3.13-rc.1` per RC convention (notes was at stable patch).
- CHANGELOG entry, no other changes.

## Why

Hub's discovery page today hardcodes which services have UIs (`SERVICE_LABELS` in `parachute-hub/src/hub.ts`). The pattern flips that: services declare their own UI URL in `module.json`, and hub renders one tile per declaring service from the well-known doc. This PR is step 2 of the parallel-cross-repo rollout for Notes (Agent has its own PR; hub-side consumer change is step 3).

No runtime change in Notes itself — `uiUrl` is opaque to the PWA. The field ships in the npm artifact via the existing `files: [".parachute/module.json"]` entry in `package.json`.

## Test plan

- [x] `module.json` parses as JSON
- [x] `package.json` parses as JSON, version reads as `0.3.13-rc.1`
- [ ] Reviewer dispatch
- [ ] Merge → hub will pick `uiUrl` up via well-known once hub-side step 3 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)