### PR TITLE
chore(release): 0.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.14-rc.1 (2026-05-11)
+## 0.3.14 (2026-05-11)
 
 ### OAuth pending-approval UX
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.14-rc.1",
+  "version": "0.3.14",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",


### PR DESCRIPTION
## Summary

Promote `0.3.14-rc.1` → `0.3.14` stable for `npm publish --tag latest`.

Same code as the rc.1 tip (`41dc1a3`), no behavior changes. Validation period closed; Aaron called ready-for-release.

### Included from the rc chain

- **#111** — `feat(oauth): consume hub's approve_url from pending-approval response`. When `/oauth/token` returns a hub#240 pending-approval response, Notes now renders a friendly "Waiting for hub approval" screen with a one-click **Open approval page** link (and the `parachute auth approve-client …` CLI as a secondary path) instead of splatting the raw 401 JSON as a "Token exchange failed" error. Defense-in-depth: only `http(s)` `approve_url` schemes make it to the rendered `href`; anything else is dropped at parse time. Back-compat with pre-#240 hubs (`cli_alternative`-only) and with bare `invalid_client` errors (fall through to generic UI).

## Diff

- `package.json`: `0.3.14-rc.1` → `0.3.14`.
- `CHANGELOG.md`: rename the rc.1 heading to `## 0.3.14 (2026-05-11)`. Body unchanged.

## Test plan

- [x] `bun run test` — 641 pass / 0 fail.
- [x] `bun run typecheck` — clean.
- [ ] `npm publish --tag latest` — Aaron's call post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)