### PR TITLE
feat(ui): vault popover + hub-discovery + OAuth vault-hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,37 @@
 
 ## Unreleased
 
-### Design
+### Vault popover (header)
 
-- **docs(design): Notes UI audit + vault-selector design proposal**
-  at [`design/2026-05-12-notes-ui-audit.md`](./design/2026-05-12-notes-ui-audit.md).
-  Inventories the current routes, navigation primitives, and primary
-  user flows; designs a vault popover that surfaces the hub's
-  well-known vault list to fix the multi-vault-on-one-hub gap;
-  surfaces ten broader improvement candidates with scope and leverage
-  reads; engages with the surface-direction research note
-  (parachute-patterns#54) on how Notes might evolve as a configured
-  surface instance. No code changes.
+- **feat(ui): vault popover + hub-discovery + OAuth `vault=<name>` hint
+  (0.3.15-rc.1).** Replaces the bare `<select>` switcher in the header
+  with a popover that surfaces the operator's full hub-side vault list
+  alongside the locally-connected vaults. Implements §2 of
+  [`design/2026-05-12-notes-ui-audit.md`](./design/2026-05-12-notes-ui-audit.md);
+  the first item in the §5 ship sequence.
+  - **Two sections.** "Connected" lists vaults Notes has tokens for
+    (active vault gets a filled accent dot + "current" tag; the rest
+    are one click to switch). "Available from your hub" lists vaults
+    published at `<hub>/.well-known/parachute.json` that Notes hasn't
+    connected to yet, each with an inline "Connect" button. Footer
+    links to the existing `/vaults` management page.
+  - **Hub-origin discovery.** Derived from `VaultRecord.issuer` (which
+    under hub-as-issuer is the hub origin itself, captured at OAuth
+    time in `OAuthCallback.tsx`) — no schema change to the stored
+    record, no migration. For a standalone-vault deployment the
+    well-known fetch returns no peers and the Available section is
+    omitted (graceful degradation).
+  - **OAuth `vault=<name>` hint (Path A).** `beginOAuth` now accepts an
+    `options.params` bag appended to the authorize URL last, guarded
+    so caller-supplied params can never overwrite standard OAuth/PKCE
+    params. Notes sends `vault=<name>` so future hubs that adopt the
+    hint can pre-select on the consent screen; pre-#240 hubs ignore it
+    and the picker renders as today.
+  - **Mobile.** Same component, rendered as `variant="inline"` inside
+    the existing hamburger menu — replaces the mobile `<select>` plus
+    the standalone "Manage vaults" button.
+
+### Design
 
 ## 0.3.14 (2026-05-11)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.14",
+  "version": "0.3.15-rc.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/scripts/info-endpoint-plugin.ts
+++ b/scripts/info-endpoint-plugin.ts
@@ -39,7 +39,10 @@ export function infoEndpointPlugin(options: PluginOptions): Plugin {
   const rootPath = `/${ENDPOINT}`;
 
   function attach(server: ViteDevServer | PreviewServer): void {
-    const handler = (_req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => {
+    const handler = (
+      _req: import("node:http").IncomingMessage,
+      res: import("node:http").ServerResponse,
+    ) => {
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
       res.setHeader("Cache-Control", "no-cache");

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -3,7 +3,7 @@ import { useVaultStore } from "@/lib/vault/store";
 import type { VaultRecord } from "@/lib/vault/types";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 function makeVault(partial: Partial<VaultRecord> & Pick<VaultRecord, "id" | "url">): VaultRecord {
   return {
@@ -28,10 +28,21 @@ function renderHeader() {
 describe("Header vault label fallback", () => {
   beforeEach(() => {
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    // Stub fetch so the popover's well-known fetcher doesn't escape into a
+    // real network call during component render.
+    global.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({ vaults: [], services: [] }),
+        }) as Response,
+    ) as unknown as typeof fetch;
   });
 
   afterEach(() => {
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    vi.restoreAllMocks();
   });
 
   it("renders the vault name when present", () => {
@@ -40,7 +51,7 @@ describe("Header vault label fallback", () => {
       activeVaultId: "a",
     });
     renderHeader();
-    expect(screen.getByRole("combobox", { name: /active vault/i })).toHaveTextContent("default");
+    expect(screen.getByRole("button", { name: /active vault: default/i })).toBeInTheDocument();
   });
 
   it("falls back to the URL host when name is empty", () => {
@@ -49,9 +60,9 @@ describe("Header vault label fallback", () => {
       activeVaultId: "a",
     });
     renderHeader();
-    expect(screen.getByRole("combobox", { name: /active vault/i })).toHaveTextContent(
-      "vault.example.com:8443",
-    );
+    expect(
+      screen.getByRole("button", { name: /active vault: vault\.example\.com:8443/i }),
+    ).toBeInTheDocument();
   });
 
   it("falls back to the raw URL when both name and URL are unparseable", () => {
@@ -60,6 +71,6 @@ describe("Header vault label fallback", () => {
       activeVaultId: "a",
     });
     renderHeader();
-    expect(screen.getByRole("combobox", { name: /active vault/i })).toHaveTextContent("not a url");
+    expect(screen.getByRole("button", { name: /active vault: not a url/i })).toBeInTheDocument();
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,16 +1,14 @@
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { SyncStatusIndicator } from "@/components/SyncStatusIndicator";
 import { ThemeToggle } from "@/components/ThemeToggle";
-import { type VaultRecord, useVaultStore } from "@/lib/vault";
+import { VaultPopover } from "@/components/VaultPopover";
+import { useVaultStore } from "@/lib/vault";
 import { useEffect, useState } from "react";
-import { Link, useLocation, useNavigate } from "react-router";
+import { Link, useLocation } from "react-router";
 
 export function Header() {
-  const navigate = useNavigate();
   const location = useLocation();
-  const vaults = useVaultStore((s) => s.vaults);
-  const activeVaultId = useVaultStore((s) => s.activeVaultId);
-  const setActiveVault = useVaultStore((s) => s.setActiveVault);
+  const hasVaults = useVaultStore((s) => Object.keys(s.vaults).length > 0);
   const [menuOpen, setMenuOpen] = useState(false);
 
   // Close the mobile menu whenever the route changes — otherwise a tap on a
@@ -19,19 +17,6 @@ export function Header() {
   useEffect(() => {
     setMenuOpen(false);
   }, [location.pathname]);
-
-  const vaultLabel = (v: VaultRecord): string => {
-    if (v.name) return v.name;
-    try {
-      return new URL(v.url).host;
-    } catch {
-      return v.url;
-    }
-  };
-  const vaultList = Object.values(vaults).sort((a, b) =>
-    vaultLabel(a).localeCompare(vaultLabel(b)),
-  );
-  const hasVaults = vaultList.length > 0;
 
   return (
     <header
@@ -65,28 +50,7 @@ export function Header() {
               <Link to="/capture" className="text-sm text-fg-muted hover:text-accent">
                 + Capture
               </Link>
-              <label htmlFor="vault-switcher" className="sr-only">
-                Active vault
-              </label>
-              <select
-                id="vault-switcher"
-                value={activeVaultId ?? ""}
-                onChange={(e) => setActiveVault(e.target.value || null)}
-                className="rounded-md border border-border bg-card px-2.5 py-1.5 text-sm text-fg"
-              >
-                {vaultList.map((v) => (
-                  <option key={v.id} value={v.id}>
-                    {vaultLabel(v)}
-                  </option>
-                ))}
-              </select>
-              <button
-                type="button"
-                onClick={() => navigate("/vaults")}
-                className="text-sm text-fg-muted hover:text-accent"
-              >
-                Manage
-              </button>
+              <VaultPopover />
               <Link to="/settings" className="text-sm text-fg-muted hover:text-accent">
                 Settings
               </Link>
@@ -131,27 +95,12 @@ export function Header() {
               <Link to="/activity" className="py-1 text-sm text-fg hover:text-accent">
                 Activity
               </Link>
-              <button
-                type="button"
-                onClick={() => navigate("/vaults")}
-                className="py-1 text-left text-sm text-fg hover:text-accent"
-              >
-                Manage vaults
-              </button>
-              <label className="mt-1 block text-xs text-fg-dim">
-                <span className="mb-1 block uppercase tracking-wider">Active vault</span>
-                <select
-                  value={activeVaultId ?? ""}
-                  onChange={(e) => setActiveVault(e.target.value || null)}
-                  className="w-full rounded-md border border-border bg-card px-2.5 py-2 text-sm text-fg"
-                >
-                  {vaultList.map((v) => (
-                    <option key={v.id} value={v.id}>
-                      {vaultLabel(v)}
-                    </option>
-                  ))}
-                </select>
-              </label>
+              <div className="mt-1">
+                <span className="mb-1 block text-xs uppercase tracking-wider text-fg-dim">
+                  Active vault
+                </span>
+                <VaultPopover variant="inline" />
+              </div>
               <div className="mt-1 flex items-center gap-3">
                 <InstallPrompt />
                 <ThemeToggle />

--- a/src/components/ReconnectBanner.tsx
+++ b/src/components/ReconnectBanner.tsx
@@ -13,9 +13,7 @@ import { useState } from "react";
 export function ReconnectBanner() {
   const activeVaultId = useVaultStore((s) => s.activeVaultId);
   const vault = useVaultStore((s) => s.getActiveVault());
-  const halt = useAuthHaltStore((s) =>
-    activeVaultId ? (s.byVault[activeVaultId] ?? null) : null,
-  );
+  const halt = useAuthHaltStore((s) => (activeVaultId ? (s.byVault[activeVaultId] ?? null) : null));
   const [reconnecting, setReconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/components/TranscriptionStatus.test.tsx
+++ b/src/components/TranscriptionStatus.test.tsx
@@ -9,25 +9,19 @@ describe("TranscriptionStatus", () => {
   });
 
   it("shows 'Transcribing…' when the note still carries the pending marker", () => {
-    render(
-      <TranscriptionStatus content="# 🎙️ Voice memo\n\n_Transcript pending._\n" />,
-    );
+    render(<TranscriptionStatus content="# 🎙️ Voice memo\n\n_Transcript pending._\n" />);
     expect(screen.getByText(/transcribing/i)).toBeInTheDocument();
   });
 
   it("shows the unavailable chip when the note carries the unavailable marker", () => {
     render(
-      <TranscriptionStatus
-        content="Some preamble.\n\n_Transcription unavailable._\n\nrest"
-      />,
+      <TranscriptionStatus content="Some preamble.\n\n_Transcription unavailable._\n\nrest" />,
     );
     expect(screen.getByText(/transcription unavailable/i)).toBeInTheDocument();
   });
 
   it("prefers the pending chip when both markers coexist", () => {
-    render(
-      <TranscriptionStatus content="_Transcript pending._\n_Transcription unavailable._" />,
-    );
+    render(<TranscriptionStatus content="_Transcript pending._\n_Transcription unavailable._" />);
     expect(screen.getByText(/transcribing/i)).toBeInTheDocument();
     expect(screen.queryByText(/transcription unavailable/i)).not.toBeInTheDocument();
   });

--- a/src/components/VaultPopover.test.tsx
+++ b/src/components/VaultPopover.test.tsx
@@ -1,0 +1,277 @@
+import { VaultPopover, buildVaultPopoverRows } from "@/components/VaultPopover";
+import type { HubVaultEntry } from "@/lib/vault/hub-discovery";
+import * as oauthModule from "@/lib/vault/oauth";
+import { useVaultStore } from "@/lib/vault/store";
+import type { VaultRecord } from "@/lib/vault/types";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function makeVault(partial: Partial<VaultRecord> & Pick<VaultRecord, "id" | "url">): VaultRecord {
+  return {
+    name: "",
+    issuer: "http://localhost:1939",
+    clientId: "client-test",
+    scope: "vault:read",
+    addedAt: "2026-05-12T00:00:00.000Z",
+    lastUsedAt: "2026-05-12T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+function makeHubVault(name: string, url: string): HubVaultEntry {
+  return { name, url, version: "0.1.0" };
+}
+
+describe("buildVaultPopoverRows", () => {
+  it("returns just the connected vaults when the hub list is empty", () => {
+    const v = makeVault({
+      id: "v",
+      url: "http://localhost:1939/vault/default",
+      name: "default",
+    });
+    const rows = buildVaultPopoverRows([v], "v", [], "http://localhost:1939");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ kind: "connected", id: "v", isActive: true, hubKnown: false });
+  });
+
+  it("marks a connected vault as hubKnown when the hub publishes a matching URL", () => {
+    const v = makeVault({
+      id: "v",
+      url: "http://localhost:1939/vault/default",
+      name: "default",
+    });
+    const rows = buildVaultPopoverRows(
+      [v],
+      "v",
+      [makeHubVault("default", "http://localhost:1939/vault/default")],
+      "http://localhost:1939",
+    );
+    expect(rows.filter((r) => r.kind === "connected")).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ kind: "connected", hubKnown: true });
+    expect(rows.filter((r) => r.kind === "available")).toHaveLength(0);
+  });
+
+  it("splits hub-only vaults into the Available section", () => {
+    const v = makeVault({
+      id: "v",
+      url: "http://localhost:1939/vault/default",
+      name: "default",
+    });
+    const rows = buildVaultPopoverRows(
+      [v],
+      "v",
+      [
+        makeHubVault("default", "http://localhost:1939/vault/default"),
+        makeHubVault("techne", "http://localhost:1939/vault/techne"),
+        makeHubVault("boulder", "http://localhost:1939/vault/boulder"),
+      ],
+      "http://localhost:1939",
+    );
+    const connected = rows.filter((r) => r.kind === "connected");
+    const available = rows.filter((r) => r.kind === "available");
+    expect(connected).toHaveLength(1);
+    expect(available).toHaveLength(2);
+    expect(available.map((r) => r.kind === "available" && r.name)).toEqual(["boulder", "techne"]);
+  });
+
+  it("returns no Available rows when hub origin is null (standalone-vault case)", () => {
+    const v = makeVault({
+      id: "v",
+      url: "https://vault.example.com",
+      name: "default",
+      issuer: "https://vault.example.com",
+    });
+    const rows = buildVaultPopoverRows(
+      [v],
+      "v",
+      [makeHubVault("other", "https://vault.example.com/vault/other")],
+      null,
+    );
+    expect(rows.every((r) => r.kind === "connected")).toBe(true);
+  });
+
+  it("sorts Connected rows by display label", () => {
+    const a = makeVault({
+      id: "a",
+      url: "http://localhost:1939/vault/charlie",
+      name: "charlie",
+    });
+    const b = makeVault({
+      id: "b",
+      url: "http://localhost:1939/vault/alpha",
+      name: "alpha",
+    });
+    const rows = buildVaultPopoverRows([a, b], "a", [], "http://localhost:1939");
+    expect(rows.map((r) => r.kind === "connected" && r.label)).toEqual(["alpha", "charlie"]);
+  });
+
+  it("matches connected vs hub URLs after trailing-slash normalization", () => {
+    const v = makeVault({
+      id: "v",
+      url: "http://localhost:1939/vault/default",
+      name: "default",
+    });
+    const rows = buildVaultPopoverRows(
+      [v],
+      "v",
+      [makeHubVault("default", "http://localhost:1939/vault/default/")],
+      "http://localhost:1939",
+    );
+    expect(rows.filter((r) => r.kind === "available")).toHaveLength(0);
+  });
+});
+
+describe("VaultPopover (component)", () => {
+  beforeEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    vi.restoreAllMocks();
+    // Default: hub returns nothing
+    global.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({ vaults: [], services: [] }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    vi.restoreAllMocks();
+  });
+
+  function renderPopover() {
+    return render(
+      <MemoryRouter>
+        <VaultPopover />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders the active vault's label on the trigger", () => {
+    useVaultStore.setState({
+      vaults: {
+        v: makeVault({ id: "v", url: "http://localhost:1939/vault/default", name: "default" }),
+      },
+      activeVaultId: "v",
+    });
+    renderPopover();
+    expect(screen.getByRole("button", { name: /active vault: default/i })).toBeInTheDocument();
+  });
+
+  it("opens and closes on trigger click + closes on outside click", async () => {
+    useVaultStore.setState({
+      vaults: {
+        v: makeVault({ id: "v", url: "http://localhost:1939/vault/default", name: "default" }),
+      },
+      activeVaultId: "v",
+    });
+    renderPopover();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /active vault/i }));
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("switches the active vault when a Connected row is clicked, then closes", async () => {
+    useVaultStore.setState({
+      vaults: {
+        a: makeVault({ id: "a", url: "http://localhost:1939/vault/default", name: "default" }),
+        b: makeVault({ id: "b", url: "http://localhost:1939/vault/techne", name: "techne" }),
+      },
+      activeVaultId: "a",
+    });
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: /active vault/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "techne" }));
+    expect(useVaultStore.getState().activeVaultId).toBe("b");
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("renders Available rows when the hub publishes additional vaults", async () => {
+    useVaultStore.setState({
+      vaults: {
+        v: makeVault({ id: "v", url: "http://localhost:1939/vault/default", name: "default" }),
+      },
+      activeVaultId: "v",
+    });
+    global.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            vaults: [
+              { name: "default", url: "http://localhost:1939/vault/default", version: "0.1.0" },
+              { name: "techne", url: "http://localhost:1939/vault/techne", version: "0.1.0" },
+            ],
+            services: [],
+          }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: /active vault/i }));
+    await waitFor(() => expect(screen.getByText("Available from your hub")).toBeInTheDocument());
+    expect(screen.getByText("techne")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Connect$/ })).toBeInTheDocument();
+  });
+
+  it("kicks beginOAuth with the vault hint when Connect is clicked", async () => {
+    useVaultStore.setState({
+      vaults: {
+        v: makeVault({ id: "v", url: "http://localhost:1939/vault/default", name: "default" }),
+      },
+      activeVaultId: "v",
+    });
+    global.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            vaults: [
+              { name: "default", url: "http://localhost:1939/vault/default", version: "0.1.0" },
+              { name: "techne", url: "http://localhost:1939/vault/techne", version: "0.1.0" },
+            ],
+            services: [],
+          }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+    const beginSpy = vi.spyOn(oauthModule, "beginOAuth").mockResolvedValue({
+      authorizeUrl: "http://localhost:1939/oauth/authorize?test",
+      pending: {
+        issuerUrl: "http://localhost:1939",
+        issuer: "http://localhost:1939",
+        tokenEndpoint: "http://localhost:1939/oauth/token",
+        clientId: "x",
+        codeVerifier: "v",
+        state: "s",
+        redirectUri: "r",
+        scope: "vault:read",
+        startedAt: "now",
+      },
+    });
+    const assignSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign: assignSpy },
+    });
+
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: /active vault/i }));
+    await waitFor(() => expect(screen.getByText("techne")).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Connect$/ }));
+    });
+
+    await waitFor(() => expect(beginSpy).toHaveBeenCalled());
+    expect(beginSpy.mock.calls[0]?.[0]).toBe("http://localhost:1939");
+    expect(beginSpy.mock.calls[0]?.[3]).toEqual({ params: { vault: "techne" } });
+    await waitFor(() =>
+      expect(assignSpy).toHaveBeenCalledWith("http://localhost:1939/oauth/authorize?test"),
+    );
+  });
+});

--- a/src/components/VaultPopover.tsx
+++ b/src/components/VaultPopover.tsx
@@ -1,0 +1,317 @@
+import {
+  type HubVaultEntry,
+  type VaultRecord,
+  beginOAuth,
+  fetchHubVaults,
+  hubOriginForVault,
+  normalizeVaultUrl,
+  useVaultStore,
+} from "@/lib/vault";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+
+// One row per vault — connected (clickable to switch) or available (Connect
+// button). Diffing rule: a hub entry whose URL matches a connected vault's URL
+// belongs in Connected; the rest go to Available.
+interface ConnectedRow {
+  kind: "connected";
+  id: string;
+  label: string;
+  isActive: boolean;
+  hubKnown: boolean;
+  vault: VaultRecord;
+}
+
+interface AvailableRow {
+  kind: "available";
+  name: string;
+  url: string;
+  hubOrigin: string;
+}
+
+export type VaultPopoverRow = ConnectedRow | AvailableRow;
+
+function vaultDisplayLabel(v: VaultRecord): string {
+  if (v.name) return v.name;
+  try {
+    return new URL(v.url).host;
+  } catch {
+    return v.url;
+  }
+}
+
+function normalizedUrlForMatch(raw: string): string {
+  try {
+    return normalizeVaultUrl(raw);
+  } catch {
+    return raw.replace(/\/$/, "");
+  }
+}
+
+/**
+ * Compute the rows the popover should render given the locally-connected
+ * vaults and the hub's published list. Pure function for easy testing.
+ *
+ * Matching is URL-based (normalized) — a hub entry with the same vault URL
+ * as a connected record collapses into the Connected row (marked
+ * `hubKnown: true`). Connected vaults whose URL isn't in the hub list still
+ * render under Connected (with `hubKnown: false` so the UI can hint
+ * "Hub doesn't know about this one" later if we want).
+ */
+export function buildVaultPopoverRows(
+  connected: VaultRecord[],
+  activeId: string | null,
+  hubVaults: HubVaultEntry[],
+  hubOriginForAvailable: string | null,
+): VaultPopoverRow[] {
+  const hubUrlSet = new Set(hubVaults.map((v) => normalizedUrlForMatch(v.url)));
+  const connectedUrlSet = new Set(connected.map((v) => normalizedUrlForMatch(v.url)));
+
+  const connectedRows: ConnectedRow[] = [...connected]
+    .sort((a, b) => vaultDisplayLabel(a).localeCompare(vaultDisplayLabel(b)))
+    .map((v) => ({
+      kind: "connected" as const,
+      id: v.id,
+      label: vaultDisplayLabel(v),
+      isActive: v.id === activeId,
+      hubKnown: hubUrlSet.has(normalizedUrlForMatch(v.url)),
+      vault: v,
+    }));
+
+  const availableRows: AvailableRow[] =
+    hubOriginForAvailable === null
+      ? []
+      : hubVaults
+          .filter((hv) => !connectedUrlSet.has(normalizedUrlForMatch(hv.url)))
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((hv) => ({
+            kind: "available" as const,
+            name: hv.name,
+            url: hv.url,
+            hubOrigin: hubOriginForAvailable,
+          }));
+
+  return [...connectedRows, ...availableRows];
+}
+
+interface VaultPopoverProps {
+  /**
+   * Render variant. `header` is the desktop dropdown anchored to the trigger;
+   * `inline` is the mobile menu where the popover sits in flow (no float, no
+   * absolute positioning).
+   */
+  variant?: "header" | "inline";
+}
+
+export function VaultPopover({ variant = "header" }: VaultPopoverProps) {
+  const navigate = useNavigate();
+  const vaults = useVaultStore((s) => s.vaults);
+  const activeVaultId = useVaultStore((s) => s.activeVaultId);
+  const setActiveVault = useVaultStore((s) => s.setActiveVault);
+  const activeVault = activeVaultId ? (vaults[activeVaultId] ?? null) : null;
+  const [open, setOpen] = useState(false);
+  const [hubVaults, setHubVaults] = useState<HubVaultEntry[] | null>(null);
+  const [connecting, setConnecting] = useState<string | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  const hubOrigin = useMemo(
+    () => (activeVault ? hubOriginForVault(activeVault) : null),
+    [activeVault],
+  );
+
+  // Outside-click and Escape close the popover. Same shape as
+  // SyncStatusIndicator — mousedown so a click that selects something inside
+  // doesn't fire before the click handler.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!rootRef.current) return;
+      if (rootRef.current.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Fetch the hub's vault list when the popover opens. Refetched per-open so
+  // newly-added vaults show up without a page reload; cheap (one same-origin
+  // GET to a static-ish JSON).
+  useEffect(() => {
+    if (!open || !hubOrigin) {
+      return;
+    }
+    const ctrl = new AbortController();
+    fetchHubVaults(hubOrigin, fetch.bind(globalThis), ctrl.signal).then((result) => {
+      if (ctrl.signal.aborted) return;
+      setHubVaults(result);
+    });
+    return () => ctrl.abort();
+  }, [open, hubOrigin]);
+
+  const rows = useMemo(
+    () => buildVaultPopoverRows(Object.values(vaults), activeVaultId, hubVaults ?? [], hubOrigin),
+    [vaults, activeVaultId, hubVaults, hubOrigin],
+  );
+  const connectedRows = rows.filter((r): r is ConnectedRow => r.kind === "connected");
+  const availableRows = rows.filter((r): r is AvailableRow => r.kind === "available");
+
+  const triggerLabel = activeVault ? vaultDisplayLabel(activeVault) : "Choose vault";
+
+  const onSwitch = useCallback(
+    (id: string) => {
+      setActiveVault(id);
+      setOpen(false);
+    },
+    [setActiveVault],
+  );
+
+  const onConnect = useCallback(async (row: AvailableRow) => {
+    setConnecting(row.name);
+    setConnectError(null);
+    try {
+      // Path A (design doc §2): pass `vault=<name>` as a hint. Pre-#240 hubs
+      // ignore it and the consent screen renders the picker as today; future
+      // hubs can pre-select on the consent screen with no Notes change.
+      const { authorizeUrl } = await beginOAuth(row.hubOrigin, undefined, undefined, {
+        params: { vault: row.name },
+      });
+      window.location.assign(authorizeUrl);
+    } catch (err) {
+      setConnecting(null);
+      setConnectError((err as Error).message);
+    }
+  }, []);
+
+  const onManage = useCallback(() => {
+    setOpen(false);
+    navigate("/vaults");
+  }, [navigate]);
+
+  const panel = (
+    // biome-ignore lint/a11y/useSemanticElements: a native <dialog> requires imperative show()/showModal() calls; this is a popover, not a modal.
+    <div
+      role="dialog"
+      aria-label="Vaults"
+      className={
+        variant === "header"
+          ? "absolute right-0 z-30 mt-2 w-72 rounded-md border border-border bg-card text-sm shadow-lg"
+          : "mt-2 w-full rounded-md border border-border bg-card text-sm"
+      }
+    >
+      {connectedRows.length > 0 ? (
+        <div className="border-b border-border">
+          <div className="px-3 pt-3 pb-1.5 text-[10px] font-medium uppercase tracking-wider text-fg-dim">
+            Connected
+          </div>
+          <ul className="pb-2">
+            {connectedRows.map((row) => (
+              <li key={row.id}>
+                <button
+                  type="button"
+                  onClick={() => onSwitch(row.id)}
+                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-accent/5"
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span
+                      aria-hidden
+                      className={`inline-block h-2 w-2 shrink-0 rounded-full ${
+                        row.isActive ? "bg-accent" : "border border-border bg-transparent"
+                      }`}
+                    />
+                    <span className="truncate text-fg">{row.label}</span>
+                  </span>
+                  {row.isActive ? (
+                    <span className="shrink-0 text-[10px] uppercase tracking-wider text-accent">
+                      current
+                    </span>
+                  ) : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {availableRows.length > 0 ? (
+        <div className="border-b border-border">
+          <div className="px-3 pt-3 pb-1.5 text-[10px] font-medium uppercase tracking-wider text-fg-dim">
+            Available from your hub
+          </div>
+          <ul className="pb-2">
+            {availableRows.map((row) => (
+              <li key={row.url}>
+                <div className="flex w-full items-center justify-between gap-3 px-3 py-2">
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span
+                      aria-hidden
+                      className="inline-block h-2 w-2 shrink-0 rounded-full border border-border"
+                    />
+                    <span className="truncate text-fg-muted">{row.name}</span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onConnect(row)}
+                    disabled={connecting === row.name}
+                    className="shrink-0 rounded border border-accent/40 px-2 py-1 text-xs font-medium text-accent hover:bg-accent/10 disabled:opacity-60"
+                  >
+                    {connecting === row.name ? "Connecting…" : "Connect"}
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {connectError ? (
+        <div className="border-b border-border px-3 py-2 text-xs text-red-400">{connectError}</div>
+      ) : null}
+
+      <div className="flex items-center justify-between px-3 py-2">
+        <button
+          type="button"
+          onClick={onManage}
+          className="text-xs text-fg-muted hover:text-accent"
+        >
+          Manage vaults →
+        </button>
+        {hubOrigin && hubVaults === null && open ? (
+          <span className="text-[10px] text-fg-dim">Loading hub vaults…</span>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  return (
+    <div ref={rootRef} className={variant === "header" ? "relative" : ""}>
+      <button
+        type="button"
+        aria-label={`Active vault: ${triggerLabel}`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen((v) => !v)}
+        className={
+          variant === "header"
+            ? "flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1.5 text-sm text-fg hover:border-accent/50"
+            : "flex w-full items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm text-fg"
+        }
+      >
+        <span aria-hidden className="inline-block h-2 w-2 shrink-0 rounded-full bg-accent" />
+        <span className="truncate">{triggerLabel}</span>
+        <span aria-hidden className="ml-1 text-xs text-fg-dim">
+          ▾
+        </span>
+      </button>
+
+      {open ? panel : null}
+    </div>
+  );
+}

--- a/src/lib/vault/cross-tab-sync.ts
+++ b/src/lib/vault/cross-tab-sync.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { AUTH_HALT_KEY_PREFIX, useAuthHaltStore } from "./auth-halt-store";
-import { ACTIVE_KEY, loadActiveVaultId, loadVaults, VAULTS_KEY } from "./storage";
+import { ACTIVE_KEY, VAULTS_KEY, loadActiveVaultId, loadVaults } from "./storage";
 import { useVaultStore } from "./store";
 
 // Storage events fire across same-origin tabs but never within the tab that

--- a/src/lib/vault/hub-discovery.test.ts
+++ b/src/lib/vault/hub-discovery.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchHubVaults, hubOriginForVault } from "./hub-discovery";
+import type { VaultRecord } from "./types";
+
+function makeVault(partial: Partial<VaultRecord> & Pick<VaultRecord, "issuer">): VaultRecord {
+  return {
+    id: "v",
+    url: "http://localhost:1939/vault/default",
+    name: "default",
+    clientId: "client",
+    scope: "vault:read",
+    addedAt: "2026-05-12T00:00:00.000Z",
+    lastUsedAt: "2026-05-12T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+function mockFetch(response: { ok?: boolean; status?: number; json?: unknown; text?: string }) {
+  return vi.fn<typeof fetch>(async () => {
+    return {
+      ok: response.ok ?? true,
+      status: response.status ?? 200,
+      json: async () => response.json,
+      text: async () => response.text ?? "",
+    } as Response;
+  });
+}
+
+function mockFetchThrows(err: Error) {
+  return vi.fn<typeof fetch>(async () => {
+    throw err;
+  });
+}
+
+describe("hubOriginForVault", () => {
+  it("returns the origin of the issuer URL", () => {
+    expect(hubOriginForVault(makeVault({ issuer: "http://localhost:1939" }))).toBe(
+      "http://localhost:1939",
+    );
+  });
+
+  it("strips path + query from a path-bearing issuer (standalone vault case)", () => {
+    expect(hubOriginForVault(makeVault({ issuer: "https://hub.example.com/some/path?q=1" }))).toBe(
+      "https://hub.example.com",
+    );
+  });
+
+  it("returns null for an unparseable issuer", () => {
+    expect(hubOriginForVault(makeVault({ issuer: "not a url" }))).toBe(null);
+  });
+});
+
+describe("fetchHubVaults", () => {
+  it("returns parsed vaults on a 200", async () => {
+    const fetchImpl = mockFetch({
+      json: {
+        vaults: [
+          { name: "default", url: "http://localhost:1939/vault/default", version: "0.1.0" },
+          { name: "techne", url: "http://localhost:1939/vault/techne", version: "0.1.0" },
+        ],
+        services: [],
+      },
+    });
+    const result = await fetchHubVaults("http://localhost:1939", fetchImpl);
+    expect(result).toEqual([
+      { name: "default", url: "http://localhost:1939/vault/default", version: "0.1.0" },
+      { name: "techne", url: "http://localhost:1939/vault/techne", version: "0.1.0" },
+    ]);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1939/.well-known/parachute.json");
+  });
+
+  it("passes through optional managementUrl", async () => {
+    const fetchImpl = mockFetch({
+      json: {
+        vaults: [
+          {
+            name: "default",
+            url: "http://localhost:1939/vault/default",
+            version: "0.1.0",
+            managementUrl: "/vault/default/admin",
+          },
+        ],
+      },
+    });
+    const result = await fetchHubVaults("http://localhost:1939", fetchImpl);
+    expect(result?.[0]?.managementUrl).toBe("/vault/default/admin");
+  });
+
+  it("returns an empty array when the hub publishes no vaults", async () => {
+    const fetchImpl = mockFetch({ json: { vaults: [], services: [] } });
+    const result = await fetchHubVaults("http://localhost:1939", fetchImpl);
+    expect(result).toEqual([]);
+  });
+
+  it("returns null on a non-2xx response", async () => {
+    const fetchImpl = mockFetch({ ok: false, status: 404 });
+    const result = await fetchHubVaults("http://localhost:1939", fetchImpl);
+    expect(result).toBe(null);
+  });
+
+  it("returns null when fetch throws (network error)", async () => {
+    const fetchImpl = mockFetchThrows(new Error("network down"));
+    const result = await fetchHubVaults("http://localhost:1939", fetchImpl);
+    expect(result).toBe(null);
+  });
+
+  it("returns null on malformed JSON", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error("not JSON");
+        },
+      } as unknown as Response;
+    });
+    const result = await fetchHubVaults("http://localhost:1939", fetchImpl);
+    expect(result).toBe(null);
+  });
+
+  it("returns null when the response body isn't an object", async () => {
+    const fetchImpl = mockFetch({ json: "not an object" });
+    const result = await fetchHubVaults("http://localhost:1939", fetchImpl);
+    expect(result).toBe(null);
+  });
+
+  it("returns null when `vaults` is missing or not an array", async () => {
+    const fetchImpl = mockFetch({ json: { services: [] } });
+    const result = await fetchHubVaults("http://localhost:1939", fetchImpl);
+    expect(result).toBe(null);
+  });
+
+  it("filters out malformed vault entries (missing name/url/version)", async () => {
+    const fetchImpl = mockFetch({
+      json: {
+        vaults: [
+          { name: "good", url: "http://localhost:1939/vault/good", version: "0.1.0" },
+          { name: "missing-url", version: "0.1.0" },
+          { url: "http://localhost:1939/vault/no-name", version: "0.1.0" },
+          null,
+          "string",
+        ],
+      },
+    });
+    const result = await fetchHubVaults("http://localhost:1939", fetchImpl);
+    expect(result).toEqual([
+      { name: "good", url: "http://localhost:1939/vault/good", version: "0.1.0" },
+    ]);
+  });
+
+  it("strips trailing slash on the hub origin before composing the URL", async () => {
+    const fetchImpl = mockFetch({ json: { vaults: [] } });
+    await fetchHubVaults("http://localhost:1939/", fetchImpl);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1939/.well-known/parachute.json");
+  });
+});

--- a/src/lib/vault/hub-discovery.ts
+++ b/src/lib/vault/hub-discovery.ts
@@ -1,0 +1,75 @@
+import type { VaultRecord } from "./types";
+
+/**
+ * Vault entries the hub publishes at `/.well-known/parachute.json`. Mirrors
+ * the `WellKnownVaultEntry` shape in `parachute-hub/src/well-known.ts`
+ * (intentionally re-declared here so Notes doesn't pick up a transitive hub
+ * dependency).
+ */
+export interface HubVaultEntry {
+  name: string;
+  url: string;
+  version: string;
+  managementUrl?: string;
+}
+
+/**
+ * Derive the OAuth/discovery origin Notes should query for a stored vault.
+ * Under hub-as-issuer (the standard install) `VaultRecord.issuer` is the
+ * hub origin itself — captured at OAuth time in OAuthCallback.tsx. Under a
+ * standalone vault `issuer` equals the vault URL; the well-known fetch will
+ * fail or return no peer vaults, which is the right answer in that case.
+ *
+ * Returning the origin (not the full issuer URL) lets a hub fronted at a
+ * sub-path still answer `<origin>/.well-known/parachute.json` cleanly —
+ * matches the path the hub's own admin SPA uses.
+ */
+export function hubOriginForVault(vault: Pick<VaultRecord, "issuer">): string | null {
+  try {
+    return new URL(vault.issuer).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isHubVaultEntry(value: unknown): value is HubVaultEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.name === "string" && typeof v.url === "string" && typeof v.version === "string";
+}
+
+/**
+ * Fetch the hub's vault list. Same-origin in standard installs, CORS-open
+ * cross-origin. Returns the vault array on success, `null` on any failure
+ * (network, non-2xx, malformed JSON) — callers treat "no list" as
+ * "popover doesn't render the Available section".
+ *
+ * `hubOrigin` is the bare origin (`https://hub.example`); the well-known
+ * path is appended here so callers don't have to know the URL shape.
+ */
+export async function fetchHubVaults(
+  hubOrigin: string,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
+  signal?: AbortSignal,
+): Promise<HubVaultEntry[] | null> {
+  const url = `${hubOrigin.replace(/\/$/, "")}/.well-known/parachute.json`;
+  let res: Response;
+  try {
+    res = await fetchImpl(url, { headers: { Accept: "application/json" }, signal });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = await res.json();
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const vaults = (parsed as Record<string, unknown>).vaults;
+  if (!Array.isArray(vaults)) return null;
+
+  return vaults.filter(isHubVaultEntry);
+}

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -3,6 +3,7 @@ export * from "./client";
 export * from "./cross-tab-sync";
 export * from "./discovery";
 export * from "./graph";
+export * from "./hub-discovery";
 export * from "./neighborhood";
 export * from "./note-query";
 export * from "./oauth";

--- a/src/lib/vault/oauth.test.ts
+++ b/src/lib/vault/oauth.test.ts
@@ -99,6 +99,29 @@ describe("beginOAuth", () => {
     expect(pending.clientId).toBe("client-123");
   });
 
+  it("appends caller-supplied `params` to the authorize URL", async () => {
+    const fetchImpl = mockFetch([{ json: validMetadata }, { json: clientReg }]);
+    const { authorizeUrl } = await beginOAuth("http://localhost:1940", "vault:read", fetchImpl, {
+      params: { vault: "techne" },
+    });
+    const url = new URL(authorizeUrl);
+    expect(url.searchParams.get("vault")).toBe("techne");
+    // Standard OAuth/PKCE params still present and unmodified.
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("never lets `params` overwrite a standard OAuth/PKCE param", async () => {
+    const fetchImpl = mockFetch([{ json: validMetadata }, { json: clientReg }]);
+    const { authorizeUrl } = await beginOAuth("http://localhost:1940", "vault:read", fetchImpl, {
+      params: { response_type: "token", scope: "evil:scope", vault: "techne" },
+    });
+    const url = new URL(authorizeUrl);
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe("vault:read");
+    expect(url.searchParams.get("vault")).toBe("techne");
+  });
+
   it("re-registers when the redirect URI no longer matches the cache", async () => {
     const first = mockFetch([{ json: validMetadata }, { json: clientReg }]);
     await beginOAuth("http://localhost:1940", "vault:read", first);

--- a/src/lib/vault/oauth.ts
+++ b/src/lib/vault/oauth.ts
@@ -31,6 +31,18 @@ export function redirectUriForOrigin(origin: string = window.location.origin): s
   return `${origin.replace(/\/$/, "")}${basePathPrefix()}${REDIRECT_PATH}`;
 }
 
+export interface BeginOAuthOptions {
+  /**
+   * Extra query params appended to the authorize URL after the standard
+   * OAuth + PKCE params. Used for hints the hub may consume (e.g. a
+   * `vault=<name>` pre-selection hint from the Notes vault popover —
+   * design doc 2026-05-12-notes-ui-audit §2). Unknown params are
+   * harmless: a hub that doesn't recognize them ignores them and the
+   * consent screen renders as today.
+   */
+  params?: Record<string, string>;
+}
+
 /**
  * Begin the OAuth 2.1 + PKCE flow against an issuer URL.
  *
@@ -44,6 +56,7 @@ export async function beginOAuth(
   issuerInput: string,
   scope: TokenScope = DEFAULT_SCOPE,
   fetchImpl: typeof fetch = fetch.bind(globalThis),
+  options: BeginOAuthOptions = {},
 ): Promise<{ authorizeUrl: string; pending: PendingOAuthState }> {
   const issuerUrl = normalizeVaultUrl(issuerInput);
   const redirectUri = redirectUriForOrigin();
@@ -88,6 +101,16 @@ export async function beginOAuth(
   authorizeUrl.searchParams.set("code_challenge_method", "S256");
   authorizeUrl.searchParams.set("state", state);
   authorizeUrl.searchParams.set("scope", scope);
+  // Appended last so caller-supplied params never overwrite the OAuth/PKCE
+  // params above. A caller that passes `code_challenge` will see it ignored
+  // — by design.
+  if (options.params) {
+    for (const [key, value] of Object.entries(options.params)) {
+      if (!authorizeUrl.searchParams.has(key)) {
+        authorizeUrl.searchParams.set(key, value);
+      }
+    }
+  }
 
   return { authorizeUrl: authorizeUrl.toString(), pending };
 }

--- a/src/lib/vault/queries.ts
+++ b/src/lib/vault/queries.ts
@@ -4,6 +4,7 @@ import { enqueue } from "@/lib/sync/queue";
 import { useSync } from "@/providers/SyncProvider";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { useAuthHaltStore } from "./auth-halt-store";
 import {
   type CreateNotePayload,
   type StorageUploadResult,
@@ -11,7 +12,6 @@ import {
   type UploadProgress,
   VaultClient,
 } from "./client";
-import { useAuthHaltStore } from "./auth-halt-store";
 import { type NoteQueryState, buildNoteQueryParams } from "./note-query";
 import { forceRefresh } from "./refresh";
 import { loadToken } from "./storage";


### PR DESCRIPTION
## Summary

Implements Phase 2 of the merged Notes UI audit — §2 of [`design/2026-05-12-notes-ui-audit.md`](./design/2026-05-12-notes-ui-audit.md), §5 ship-sequence item #1.

Replaces the header `<select>` switcher with a popover that surfaces the operator's **full** hub-side vault list alongside the locally-connected ones. The named gap (Aaron runs four vaults — `boulder`/`default`/`gitcoin`/`techne` — but Notes only shows the ones already connected, so each new vault means another trip to `/add`) closes here.

### What's in this PR

- **`VaultPopover` component** (`src/components/VaultPopover.tsx`) — two sections (Connected / Available from your hub) plus a "Manage vaults →" footer; outside-click + Escape to close; two variants (`header` floating, `inline` for the mobile menu).
- **`buildVaultPopoverRows()`** pure diffing function (URL match via `normalizeVaultUrl`) so the Connected-vs-Available split is testable without React.
- **`fetchHubVaults()` + `hubOriginForVault()`** in `src/lib/vault/hub-discovery.ts`. Returns the parsed `WellKnownVaultEntry[]` or `null` on any failure (network, non-2xx, malformed JSON).
- **`beginOAuth(..., options)`** — new fourth arg with `params: Record<string,string>`. Appended last and guarded so caller params can never overwrite standard OAuth/PKCE params.
- **Header.tsx desktop + mobile** wired to the new component; standalone "Manage" button removed (the popover footer owns it now).

### Design calls made

1. **Hub-origin discovery (the §2 open question).** Derived from `VaultRecord.issuer` rather than storing a new field. Rationale:
   - `issuer` is already captured at OAuth time (`OAuthCallback.tsx:54`) and under hub-as-issuer semantically equals the hub origin (per the comment at `probe.ts:10-13`).
   - Standalone-vault case: `issuer === vault URL` → well-known fetch returns `null` or empty vaults → Available section omitted. Graceful degradation, no caller code to special-case.
   - No `VaultRecord` schema change, no migration, no field that could drift out of sync with `issuer`.
2. **OAuth `vault=<name>` hint plumbing.** Last-step URL decoration on `authorizeUrl.searchParams` via a new `options.params` bag, exactly as suggested in the design doc. Guarded against standard-param collisions for defense-in-depth.
3. **Path A on hub coordination.** Notes sends `vault=<name>` blind. Pre-#240 hubs ignore it; the consent screen renders the picker as today. Future hubs can adopt the hint to pre-select on consent — no Notes change required when they do. Hub steward coordination tracked as a follow-up, not a blocker here.

### What's out of scope (per design doc §5)

- Vault-in-URL (`/vault/<name>/...`) deep-link routing — later PR.
- Unified create flow (item #12) — Phase 3.
- View-level text-size control (item #11) — Phase 3 polish.
- Per-tab vault state (item #4), surface-aware theming (item #10), empty-state / network-error UX (items #6, #7) — later.

### Version + changelog

- `package.json` 0.3.14 → 0.3.15-rc.1 (rc.N convention per `parachute-patterns/patterns/governance.md` rule 2).
- CHANGELOG entry under `## Unreleased`.

## Test plan

- [x] Type-check clean (`bun run typecheck`)
- [x] Lint clean (`bun run lint`)
- [x] All tests pass (`bun run test` → 667/667, 24 new)
- [ ] Manual smoke: open popover on a multi-vault hub, verify Connected list, Available list (other hub-known vaults), click switch, click Connect → OAuth flow with `vault=<name>` in the URL
- [ ] Mobile: hamburger menu → inline variant of the popover
- [ ] Standalone-vault deploy (Available section should be hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)