### PR TITLE
fix(ui): RFC 1918 detection in isLoopbackOrLocal (0.3.15-rc.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### LAN-IP vaults get the operator hint
+
+- **fix(ui): RFC 1918 detection in `isLoopbackOrLocal` (0.3.15-rc.3).**
+  The banner from rc.2 only showed the `Try `parachute start vault``
+  operator hint for `localhost` / `127.0.0.1` / `.local` URLs, so a
+  self-hosted vault on a home LAN at e.g. `192.168.1.10:1940` got no
+  hint even though the recovery is identical. Adds RFC 1918 private
+  IPv4 range matching (10/8, 172.16-31/12, 192.168/16). Tailnet and
+  cloud vaults remain correctly unaffected. Tests cover all three
+  ranges, the 172.15/172.32 boundary excludes, and public-IP
+  negatives that share a prefix digit. Closes notes#117.
+
 ### Graceful vault-unreachable UX
 
 - **feat(ui): banner + status dot + retry backoff when vault is unreachable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.2",
+  "version": "0.3.15-rc.3",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/components/VaultStatusBanner.test.tsx
+++ b/src/components/VaultStatusBanner.test.tsx
@@ -155,6 +155,29 @@ describe("isLoopbackOrLocal", () => {
   it("matches .local mDNS hostnames", () => {
     expect(isLoopbackOrLocal("http://my-mac.local:1940")).toBe(true);
   });
+  it("matches RFC 1918 10/8 range", () => {
+    expect(isLoopbackOrLocal("http://10.0.0.1:1940")).toBe(true);
+    expect(isLoopbackOrLocal("http://10.255.255.254:1940")).toBe(true);
+  });
+  it("matches RFC 1918 192.168/16 range", () => {
+    expect(isLoopbackOrLocal("http://192.168.1.10:1940")).toBe(true);
+    expect(isLoopbackOrLocal("http://192.168.255.1:1940")).toBe(true);
+  });
+  it("matches RFC 1918 172.16-31/12 range (boundaries)", () => {
+    expect(isLoopbackOrLocal("http://172.16.0.1:1940")).toBe(true);
+    expect(isLoopbackOrLocal("http://172.20.1.1:1940")).toBe(true);
+    expect(isLoopbackOrLocal("http://172.31.255.254:1940")).toBe(true);
+  });
+  it("excludes 172.15/12 and 172.32/12 — outside the private range", () => {
+    expect(isLoopbackOrLocal("http://172.15.0.1:1940")).toBe(false);
+    expect(isLoopbackOrLocal("http://172.32.0.1:1940")).toBe(false);
+  });
+  it("does not match public IPs that share a prefix digit (1.x, 19.x, 17.x)", () => {
+    expect(isLoopbackOrLocal("http://1.1.1.1:1940")).toBe(false);
+    expect(isLoopbackOrLocal("http://19.0.0.1:1940")).toBe(false);
+    expect(isLoopbackOrLocal("http://17.0.0.1:1940")).toBe(false);
+    expect(isLoopbackOrLocal("http://192.169.0.1:1940")).toBe(false);
+  });
   it("does not match Tailscale-style hostnames", () => {
     expect(isLoopbackOrLocal("https://aaron-vault.tail-scale.ts.net")).toBe(false);
   });

--- a/src/components/VaultStatusBanner.tsx
+++ b/src/components/VaultStatusBanner.tsx
@@ -164,6 +164,13 @@ function UnreachableBanner({ vaultUrl, vaultId }: { vaultUrl: string; vaultId: s
   );
 }
 
+// RFC 1918 private IPv4 ranges. A vault running on a home LAN at e.g.
+// `192.168.1.10:1940` is just as "local" as one on `127.0.0.1` from the
+// operator's perspective — same recovery (start the daemon on their box) —
+// so the banner hint applies. Loopback `127.0.0.0/8` is matched by the
+// explicit `127.0.0.1` check above to keep the regex narrow.
+const RFC_1918_IPV4 = /^(10|192\.168|172\.(1[6-9]|2\d|3[0-1]))\./;
+
 export function isLoopbackOrLocal(urlStr: string): boolean {
   try {
     const u = new URL(urlStr);
@@ -174,6 +181,7 @@ export function isLoopbackOrLocal(urlStr: string): boolean {
     if (host === "127.0.0.1") return true;
     if (host === "::1") return true;
     if (host.endsWith(".local")) return true;
+    if (RFC_1918_IPV4.test(host)) return true;
     return false;
   } catch {
     return false;


### PR DESCRIPTION
Closes #117. Reviewer follow-up from #116.

## Summary

- Extends `isLoopbackOrLocal` in `src/components/VaultStatusBanner.tsx` to match RFC 1918 private IPv4 ranges (10/8, 172.16-31/12, 192.168/16) so the `Try `parachute start vault`` operator hint shows on the unreachable banner for LAN-IP self-hosted vaults.
- Tailnet / cloud / public-IP URLs remain correctly unaffected.

## Why

The hint is appropriate when the vault is on the operator's own machine — same recovery action. The rc.2 implementation gated on `localhost` / `127.0.0.1` / `.local` only, which misses a real shape: vault running on a home LAN at e.g. `192.168.1.10:1940`. The recovery (`parachute start vault` on their box) is identical.

## Patterns check

- Pure helper in the same file it serves. No new abstraction, no shared util crate needed — single call-site, lives where the consumer reads it.
- Regex narrow on purpose: loopback `127.0.0.0/8` is matched by the explicit `127.0.0.1` check above it, not folded into the regex. Comment explains.

## Tests

Five new cases in the existing `isLoopbackOrLocal` block in `VaultStatusBanner.test.tsx`:

- 10.0.0.1, 10.255.255.254 → true
- 192.168.1.10, 192.168.255.1 → true
- 172.16.0.1, 172.20.1.1, 172.31.255.254 → true (boundaries)
- 172.15.0.1, 172.32.0.1 → false (just outside)
- 1.1.1.1, 19.0.0.1, 17.0.0.1, 192.169.0.1 → false (public IPs sharing a prefix digit)

Full gate: **78 test files / 704 tests pass** (was 699 in #116 — +5 from this PR). Lint clean, typecheck clean, build green.

## Test plan

- [ ] Manually point a vault at a LAN IP (or temporarily set the `vaults` store entry to use one), stop the vault, confirm the banner appears with the `Try `parachute start vault`` line.
- [ ] Repeat with a Tailscale URL — confirm the hint is absent.
- [ ] (Optional) Repeat with `192.168.x.x` and `10.x.x.x` to cover both home-router ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)