### PR TITLE
feat(oauth): prefer services["vault:<name>"].url in OAuthCallback (0.3.15-rc.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Multi-vault hubs — consume per-vault services keys
+
+- **feat(oauth): prefer `services["vault:<name>"].url` in OAuthCallback
+  (0.3.15-rc.5).** Companion consumer for the hub-side change in
+  hub#247/#248. Hub now emits per-vault entries in the OAuth services
+  catalog alongside the legacy collapsed `vault` key; OAuthCallback
+  picks the entry matching the token's `vault` claim. Before this PR,
+  every vault on a multi-vault hub (boulder, gitcoin, techne) would
+  resolve to the collapsed-first-vault URL, so VaultRecords collided
+  on URL and only one entry survived in Manage Vaults. Fallback chain
+  is per-vault key → collapsed `vault` → `pending.issuerUrl`, so
+  pre-#247 hubs and standalone vaults keep working unchanged. Tests
+  cover all three fallback rungs. Closes notes#121.
+
 ### Retry-now integration test
 
 - **test(ui): integration coverage for Retry-now → real client → store flush

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.4",
+  "version": "0.3.15-rc.5",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/routes/OAuthCallback.test.tsx
+++ b/src/app/routes/OAuthCallback.test.tsx
@@ -1,5 +1,6 @@
 import { OAuthCallback } from "@/app/routes/OAuthCallback";
 import { savePendingOAuth } from "@/lib/vault/storage";
+import { useVaultStore } from "@/lib/vault/store";
 import type { PendingOAuthState } from "@/lib/vault/types";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
@@ -114,5 +115,111 @@ describe("OAuthCallback pending-approval rendering", () => {
       expect(screen.getByText(/connection failed/i)).toBeInTheDocument();
     });
     expect(screen.queryByText(/waiting for hub approval/i)).not.toBeInTheDocument();
+  });
+});
+
+// Mints a successful /oauth/token response with the given catalog + vault
+// claim. Distinct from `mockTokenResponse` above (which always returns a
+// non-ok body) so the success-path tests below get a real exchange.
+function mockSuccessfulTokenResponse(body: {
+  vault: string;
+  services?: Record<string, { url: string; version?: string } | undefined>;
+}) {
+  const payload = {
+    access_token: "tok_test",
+    token_type: "bearer",
+    scope: "vault:read vault:write",
+    vault: body.vault,
+    expires_in: 3600,
+    services: body.services,
+  };
+  const impl = vi.fn<typeof fetch>(async () => {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => payload,
+      text: async () => JSON.stringify(payload),
+    } as Response;
+  });
+  vi.stubGlobal("fetch", impl);
+  return impl;
+}
+
+describe("OAuthCallback vault URL resolution (notes#121)", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+  });
+
+  it("uses services['vault:<name>'].url when the per-vault key matches the token's vault claim", async () => {
+    savePendingOAuth(pending);
+    // Hub fronting three vaults — boulder, gitcoin, techne. The token names
+    // boulder; the catalog has per-vault entries for all three plus the
+    // legacy collapsed `vault` pointing at the first. The new resolution
+    // logic should pick boulder, not the collapsed default.
+    mockSuccessfulTokenResponse({
+      vault: "boulder",
+      services: {
+        vault: { url: "http://hub.example/vault/gitcoin" },
+        "vault:boulder": { url: "http://hub.example/vault/boulder" },
+        "vault:gitcoin": { url: "http://hub.example/vault/gitcoin" },
+        "vault:techne": { url: "http://hub.example/vault/techne" },
+      },
+    });
+
+    renderCallback();
+
+    await waitFor(() => {
+      const vaults = Object.values(useVaultStore.getState().vaults);
+      expect(vaults).toHaveLength(1);
+      expect(vaults[0]?.url).toBe("http://hub.example/vault/boulder");
+    });
+  });
+
+  it("falls back to services.vault.url when the per-vault key is missing (single-vault hub)", async () => {
+    savePendingOAuth(pending);
+    // Pre-#247 hub shape (or a single-vault hub on the post-#247 build that
+    // doesn't bother emitting per-vault keys): only the collapsed `vault`
+    // entry exists. The vault claim names "default" but there's no
+    // `vault:default` key — fall through to the collapsed entry.
+    mockSuccessfulTokenResponse({
+      vault: "default",
+      services: {
+        vault: { url: "http://hub.example/vault/default" },
+      },
+    });
+
+    renderCallback();
+
+    await waitFor(() => {
+      const vaults = Object.values(useVaultStore.getState().vaults);
+      expect(vaults).toHaveLength(1);
+      expect(vaults[0]?.url).toBe("http://hub.example/vault/default");
+    });
+  });
+
+  it("falls back to pending.issuerUrl when the token has no services catalog (standalone vault)", async () => {
+    savePendingOAuth(pending);
+    // A standalone vault (no hub fronting it) issues tokens without a
+    // services catalog. URL resolution must fall through both lookups and
+    // land on the issuer URL the user OAuthed against.
+    mockSuccessfulTokenResponse({
+      vault: "default",
+      // services intentionally omitted.
+    });
+
+    renderCallback();
+
+    await waitFor(() => {
+      const vaults = Object.values(useVaultStore.getState().vaults);
+      expect(vaults).toHaveLength(1);
+      expect(vaults[0]?.url).toBe(pending.issuerUrl);
+    });
   });
 });

--- a/src/app/routes/OAuthCallback.tsx
+++ b/src/app/routes/OAuthCallback.tsx
@@ -46,7 +46,19 @@ export function OAuthCallback() {
         // hub's vault URL over whatever the user pasted, so a hub login works
         // even if the user typed the hub origin. Standalone-vault tokens have
         // no catalog, in which case the issuer URL itself is the vault URL.
-        const vaultUrl = token.services?.vault?.url ?? pending.issuerUrl;
+        //
+        // Multi-vault hubs (post hub#247/#248) also emit a per-vault key
+        // `vault:<name>` alongside the legacy collapsed `vault` entry. Prefer
+        // the per-vault key when the token's `vault` claim names which one we
+        // OAuthed for — otherwise on a hub fronting boulder + gitcoin + techne
+        // every connect would resolve to the same first-vault URL and the
+        // stored VaultRecords would collide. Pre-#247 hubs (no per-vault keys)
+        // fall through to the collapsed entry.
+        const perVaultKey = token.vault ? `vault:${token.vault}` : undefined;
+        const vaultUrl =
+          (perVaultKey ? token.services?.[perVaultKey]?.url : undefined) ??
+          token.services?.vault?.url ??
+          pending.issuerUrl;
         const id = addVault(
           {
             url: vaultUrl,


### PR DESCRIPTION
Closes #121. Companion consumer for hub#247 / hub#248 (`dedb6bd`).

## Summary

- `src/app/routes/OAuthCallback.tsx`: URL resolution now prefers `token.services["vault:<name>"].url` when the token's `vault` claim names a specific vault, falling back through the collapsed `services.vault.url` and finally `pending.issuerUrl`.
- Three new tests in `OAuthCallback.test.tsx` covering each fallback rung.

## Why

The hub emits per-vault entries in its OAuth services catalog (`services["vault:<name>"] = { url, version }`) alongside the legacy collapsed `vault` key. Before this PR, every connect against a multi-vault hub (boulder, gitcoin, techne) resolved to the collapsed-first-vault URL — so VaultRecords collided on URL and Manage Vaults only showed one entry no matter how many vaults the user actually OAuthed against. This change is what makes Aaron's multi-vault Notes work end-to-end.

## Fallback chain

```ts
const perVaultKey = token.vault ? `vault:${token.vault}` : undefined;
const vaultUrl =
  (perVaultKey ? token.services?.[perVaultKey]?.url : undefined) ??
  token.services?.vault?.url ??
  pending.issuerUrl;
```

- **Multi-vault hub (post-#247)** → per-vault key wins.
- **Single-vault hub (post-#247) or pre-#247 hub** → collapsed `vault` key.
- **Standalone vault, no services catalog** → issuer URL.

## Patterns check

- `ServicesCatalog` already had `[key: string]: ServiceCatalogEntry | undefined` indexer (`types.ts:68`), so `token.services?.["vault:boulder"]?.url` is fully type-safe — no schema change needed.
- Single resolution chain in one file, no new abstraction.

## Tests

- **Per-vault hit**: token with `vault: "boulder"` + `services["vault:boulder"] = { url: "http://hub.example/vault/boulder" }` plus boulder/gitcoin/techne entries + collapsed `vault` pointing at gitcoin. Asserts stored VaultRecord URL is the boulder one.
- **Fallback to collapsed**: token with `vault: "default"` + only the collapsed `vault` key in the catalog (no per-vault entries). Asserts the collapsed URL is stored.
- **Fallback to issuerUrl**: token without `services` catalog (standalone vault). Asserts `pending.issuerUrl` is stored.

Gates: **79 test files / 710 tests pass** (+3 from this PR). Typecheck clean, lint clean, build green (1.67s, 38 precache entries).

## Test plan

- [ ] With hub running on Aaron's box hosting two vaults, connect to vault A → confirm Manage Vaults shows it at the correct URL.
- [ ] Connect to vault B from the same hub → confirm Manage Vaults now shows **both** entries with distinct URLs (this is the bug this PR fixes — previously B's record would collide with A's).
- [ ] Standalone vault (no hub) connect still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)