### PR TITLE
feat(ui): accessible text-size (shortcuts + header) + locally-generated capture path (0.3.15-rc.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## Unreleased
 
+### Text-size shortcuts + header control; Capture path pre-fill
+
+- **feat(ui): accessible text-size (shortcuts + header) + locally-generated
+  capture path (0.3.15-rc.7).** Two follow-ups to rc.6 bundled because
+  they touch the same chrome / Capture surfaces. Closes notes#127 + #126.
+  - **Text-size keyboard shortcuts (notes#127).** Cmd+= / Cmd+Plus steps
+    up the ramp (default → larger → largest → default); Cmd+- /
+    Cmd+Underscore steps down; Cmd+0 resets to default. Bound at the
+    app root via `TextSizeShortcutsMount` so the listener lives in one
+    place — the visible `TextSizeControl` in the Header would otherwise
+    register twice (desktop + mobile menu). Ignored when Shift, Alt, or
+    neither modifier is held.
+  - **Header chrome control (notes#127).** Adds `TextSizeControl` — a
+    small "Aa" button next to the existing chrome (Install / Theme).
+    Click opens a 3-option popover (Default / Larger / Largest) with a
+    ✓ on the active row. Same persist + apply path as the Settings
+    dropdown via `lib/text-size.ts`. A same-tab `CustomEvent` keeps the
+    popover's active indicator in sync when a shortcut or sibling
+    control changes the size (the `storage` event only fires
+    cross-tab). Lives on both desktop and mobile menu so phones (no
+    keyboard) keep the path.
+  - **`nextTextSize` / `previousTextSize` helpers.** Added to
+    `lib/text-size.ts` for the shortcut handlers; mirror `nextTheme`
+    in `theme.ts` shape. Each direction is explicit so the call site
+    doesn't have to think about wrap-around arithmetic.
+  - **Capture path pre-fill (notes#126).** Adds `quickPath()` helper
+    next to `memoPath()` in `lib/capture/recorder.ts`. Same
+    `<root>/YYYY/MM-DD/HH-MM-SS` shape under `Notes/`. Capture's
+    `pathOverride` state is now seeded with `quickPath()` on mount so
+    the operator sees the generated path the moment they expand More
+    fields — no more invisible "vault auto-assigns" magic.
+  - **Audio-only memos.** With the pre-fill non-empty, audio captures
+    also land under `Notes/` by default (parallel to the text case).
+    Operators who want the old `Memos/` rule can clear the path input
+    — the existing rc.6 fallback to `memoPath()` for audio-only with
+    no override is preserved as the escape valve. New test pins this.
+  - **Tests.** 2 new in `text-size.test.ts` (cycle direction helpers).
+    12 new in `TextSizeControl.test.tsx` (button + popover behavior,
+    keyboard handlers, same-tab sync). 1 new in `recorder.test.ts`
+    (quickPath shape). 2 new in `Capture.test.tsx` (pre-fill is
+    editable + saved; audio-only fallback to `memoPath` when path is
+    cleared). Existing tests updated where pre-fill changed observable
+    behavior (text-only payload now carries `Notes/...`, combined
+    text+voice payload now carries `Notes/...` instead of vault-picks).
+
 ### Capture polish + view-level text-size
 
 - **feat(ui): unified capture surface refinements + view-level text-size

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.6",
+  "version": "0.3.15-rc.7",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { BottomTabBar } from "@/components/BottomTabBar";
 import { Header } from "@/components/Header";
 import { QuickSwitchMount } from "@/components/QuickSwitchMount";
+import { TextSizeShortcutsMount } from "@/components/TextSizeControl";
 import { Toaster } from "@/components/Toaster";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { VaultStatusBanner } from "@/components/VaultStatusBanner";
@@ -106,6 +107,7 @@ export function App() {
     <QueryProvider>
       <SyncProvider>
         <ReachabilityProbeMount />
+        <TextSizeShortcutsMount />
         <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "") || undefined}>
           <div className="min-h-dvh overflow-x-hidden bg-bg text-fg pb-16 md:pb-0">
             <Toaster />

--- a/src/app/routes/Capture.test.tsx
+++ b/src/app/routes/Capture.test.tsx
@@ -210,7 +210,10 @@ describe("Capture (unified)", () => {
     expect(rows.length).toBe(1);
     if (rows[0]?.mutation.kind !== "create-note") throw new Error("expected create-note");
     expect(rows[0].mutation.payload.content).toBe("got an #idea on the bus");
-    expect(rows[0].mutation.payload.path).toBeUndefined();
+    // Pre-fill from notes#126: pathOverride is now seeded with `quickPath()`
+    // on mount, so the payload's path is `Notes/<YYYY>/<MM-DD>/<HH-MM-SS>`.
+    // Asserting on the prefix keeps the test stable across clock minutes.
+    expect(rows[0].mutation.payload.path).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
     expect(rows[0].mutation.payload.tags).toEqual(["quick", "idea"]);
     db.close();
   });
@@ -257,7 +260,12 @@ describe("Capture (unified)", () => {
     ) {
       throw new Error("wrong mutation shape");
     }
-    expect(create.mutation.payload.path).toMatch(/^Memos\//);
+    // With notes#126's pre-fill, pathOverride is seeded with `quickPath()`
+    // on mount and wins over the audio-only memoPath fallback. Audio-only
+    // memos now land under Notes/<date>/<time> by default. To keep them
+    // in Memos/, the user can clear the path input (then memoPath kicks
+    // in — see the "audio-only with cleared path" test below).
+    expect(create.mutation.payload.path).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
     expect(create.mutation.payload.tags).toEqual(["voice"]);
     expect(create.mutation.payload.content).toContain("_Transcript pending._");
     expect(create.mutation.payload.content).toContain("![[");
@@ -299,8 +307,10 @@ describe("Capture (unified)", () => {
     const rows = await listPending(db, "dev");
     const create = rows.find((r) => r.mutation.kind === "create-note")!;
     if (create.mutation.kind !== "create-note") throw new Error("wrong mutation shape");
-    // Combined notes don't pin to Memos/ — they belong with the user's other notes.
-    expect(create.mutation.payload.path).toBeUndefined();
+    // Pre-fill from notes#126: combined text+voice notes also carry the
+    // quickPath value (used to be `undefined` here, meaning vault picks).
+    // They no longer pin to Memos/ — they belong with the user's other notes.
+    expect(create.mutation.payload.path).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
     expect(create.mutation.payload.content).toContain("context for the recording #meeting");
     expect(create.mutation.payload.content).toContain("![[");
     expect(create.mutation.payload.tags).toEqual(["quick", "voice", "meeting"]);
@@ -723,6 +733,93 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     const create = rows.find((r) => r.mutation.kind === "create-note")!;
     if (create.mutation.kind !== "create-note") throw new Error("expected create-note");
     expect(create.mutation.payload.path).toBe("Recordings/2026/may");
+    db.close();
+  });
+
+  it("Pre-filled path is editable and the edit is what's saved (notes#126)", async () => {
+    // The path-override input is now pre-filled with `quickPath()` on
+    // mount (notes#126). This test confirms (a) the input renders with
+    // a non-empty value, and (b) editing replaces that value cleanly —
+    // no merging, no append.
+    renderAt("/capture");
+    await waitForReady();
+    const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
+    await act(async () => {
+      detailsEl.open = true;
+      detailsEl.dispatchEvent(new Event("toggle"));
+    });
+
+    const pathInput = screen.getByLabelText(/path override/i) as HTMLInputElement;
+    // Pre-fill is non-empty and matches the quickPath shape.
+    expect(pathInput.value).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
+
+    // Edit the input to a custom value.
+    await act(async () => {
+      fireEvent.change(pathInput, { target: { value: "Projects/2026/q2/launch" } });
+    });
+
+    const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "kickoff notes" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    });
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+    });
+
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    if (rows[0]?.mutation.kind !== "create-note") throw new Error("expected create-note");
+    expect(rows[0].mutation.payload.path).toBe("Projects/2026/q2/launch");
+    db.close();
+  });
+
+  it("Audio-only with manually cleared path falls back to memoPath (rc.6 escape valve)", async () => {
+    // notes#126's pre-fill is the new default, but clearing the path
+    // input is the operator's signal of "I want the historical rule".
+    // For audio-only captures, that rule is `memoPath()` → `Memos/`.
+    // This test pins the escape valve so a future refactor doesn't
+    // delete the fallback.
+    renderAt("/capture");
+    await waitForReady();
+    const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
+    await act(async () => {
+      detailsEl.open = true;
+      detailsEl.dispatchEvent(new Event("toggle"));
+    });
+
+    const pathInput = screen.getByLabelText(/path override/i) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(pathInput, { target: { value: "" } });
+    });
+
+    // Audio-only — no text typed.
+    await act(async () => {
+      fireEvent.pointerDown(screen.getByRole("button", { name: /hold to record/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /recording/i })).toBeInTheDocument();
+    });
+    await act(async () => {
+      releasePointer();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/recorded /i)).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    });
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.some((t) => t.tone === "success")).toBe(true);
+    });
+
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    const create = rows.find((r) => r.mutation.kind === "create-note")!;
+    if (create.mutation.kind !== "create-note") throw new Error("expected create-note");
+    expect(create.mutation.payload.path).toMatch(/^Memos\//);
     db.close();
   });
 });

--- a/src/app/routes/Capture.tsx
+++ b/src/app/routes/Capture.tsx
@@ -6,6 +6,7 @@ import {
   memoFilename,
   memoPath,
   pickMimeType,
+  quickPath,
   requestMic,
 } from "@/lib/capture/recorder";
 import { blobRef, enqueue, newBlobId, newLocalId } from "@/lib/sync";
@@ -75,12 +76,16 @@ export function Capture({
   const [tagInput, setTagInput] = useState("");
   // "More fields" — the audit's escape hatch from the quick-capture default.
   // Hidden by default so the textarea stays the no-friction focus; an
-  // operator who needs to set an explicit path or one-line summary opens
-  // this and gets the structured form without leaving Capture. Empty path
-  // means "let the vault auto-assign" (the existing behavior); empty summary
-  // means "no metadata.summary" — both inputs are pure overrides.
+  // operator who needs to override the path or set a one-line summary
+  // opens this and gets the structured form without leaving Capture.
+  //
+  // pathOverride is now pre-filled with `quickPath()` (notes#126) — the
+  // generated path is Notes-side, deterministic from mount time, and
+  // visible to the operator the moment they expand More fields. They can
+  // accept it, edit it, or clear it. Clearing falls back to "let the
+  // vault auto-assign" (empty string preserves the rc.5 escape valve).
   const [moreFieldsOpen, setMoreFieldsOpen] = useState(moreFieldsOpenDefault);
-  const [pathOverride, setPathOverride] = useState("");
+  const [pathOverride, setPathOverride] = useState(() => quickPath());
   const [summary, setSummary] = useState("");
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const [elapsedMs, setElapsedMs] = useState(0);
@@ -544,7 +549,7 @@ export function Capture({
                 type="text"
                 value={pathOverride}
                 onChange={(e) => setPathOverride(e.target.value)}
-                placeholder="(blank → vault auto-assigns)"
+                placeholder="(blank → vault picks)"
                 aria-label="Path override"
                 className="rounded-md border border-border bg-card px-2.5 py-1.5 font-mono text-xs text-fg focus:border-accent focus:outline-none"
               />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { SyncStatusIndicator } from "@/components/SyncStatusIndicator";
+import { TextSizeControl } from "@/components/TextSizeControl";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { VaultPopover } from "@/components/VaultPopover";
 import { useVaultStore } from "@/lib/vault";
@@ -56,12 +57,14 @@ export function Header() {
               </Link>
               <SyncStatusIndicator />
               <InstallPrompt />
+              <TextSizeControl />
               <ThemeToggle />
             </>
           ) : (
             <>
               <span className="text-sm text-fg-dim">No vault connected</span>
               <InstallPrompt />
+              <TextSizeControl />
               <ThemeToggle />
             </>
           )}
@@ -103,6 +106,7 @@ export function Header() {
               </div>
               <div className="mt-1 flex items-center gap-3">
                 <InstallPrompt />
+                <TextSizeControl />
                 <ThemeToggle />
               </div>
             </div>
@@ -111,6 +115,7 @@ export function Header() {
               <p className="text-sm text-fg-dim">No vault connected</p>
               <div className="flex items-center gap-3">
                 <InstallPrompt />
+                <TextSizeControl />
                 <ThemeToggle />
               </div>
             </div>

--- a/src/components/TextSizeControl.test.tsx
+++ b/src/components/TextSizeControl.test.tsx
@@ -1,0 +1,191 @@
+import { TextSizeControl, TextSizeShortcutsMount } from "@/components/TextSizeControl";
+import { TEXT_SIZE_STORAGE_KEY } from "@/lib/text-size";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("TextSizeControl button + popover", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-text-size");
+  });
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-text-size");
+  });
+
+  it("renders the 'Aa' button labeled with the current size", () => {
+    render(<TextSizeControl />);
+    expect(
+      screen.getByRole("button", { name: /text size: default. click to change/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("starts from stored preference on mount", () => {
+    localStorage.setItem(TEXT_SIZE_STORAGE_KEY, "larger");
+    render(<TextSizeControl />);
+    expect(screen.getByRole("button", { name: /text size: larger/i })).toBeInTheDocument();
+  });
+
+  it("opens the popover on click and lists the three options", () => {
+    render(<TextSizeControl />);
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /text size:/i }));
+    });
+    expect(screen.getByRole("dialog", { name: /text size/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^default$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^larger$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^largest$/i })).toBeInTheDocument();
+  });
+
+  it("clicking an option applies + persists + closes the popover", () => {
+    render(<TextSizeControl />);
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /text size:/i }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /^larger$/i }));
+    });
+    expect(document.documentElement.getAttribute("data-text-size")).toBe("larger");
+    expect(localStorage.getItem(TEXT_SIZE_STORAGE_KEY)).toBe("larger");
+    expect(screen.queryByRole("dialog", { name: /text size/i })).not.toBeInTheDocument();
+  });
+
+  it("clicking 'Default' removes the attribute + storage key", () => {
+    localStorage.setItem(TEXT_SIZE_STORAGE_KEY, "largest");
+    document.documentElement.setAttribute("data-text-size", "largest");
+    render(<TextSizeControl />);
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /text size:/i }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /^default$/i }));
+    });
+    expect(document.documentElement.hasAttribute("data-text-size")).toBe(false);
+    expect(localStorage.getItem(TEXT_SIZE_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("TextSizeShortcutsMount keyboard handlers", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-text-size");
+  });
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-text-size");
+  });
+
+  function dispatchKey(key: string, opts: { meta?: boolean; ctrl?: boolean } = { meta: true }) {
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key,
+        metaKey: opts.meta ?? false,
+        ctrlKey: opts.ctrl ?? false,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  }
+
+  it("Cmd+= steps default → larger → largest → default", () => {
+    render(<TextSizeShortcutsMount />);
+    act(() => {
+      dispatchKey("=");
+    });
+    expect(document.documentElement.getAttribute("data-text-size")).toBe("larger");
+    act(() => {
+      dispatchKey("=");
+    });
+    expect(document.documentElement.getAttribute("data-text-size")).toBe("largest");
+    act(() => {
+      dispatchKey("=");
+    });
+    expect(document.documentElement.hasAttribute("data-text-size")).toBe(false);
+  });
+
+  it("Cmd+Plus also steps up (some keyboards send +)", () => {
+    render(<TextSizeShortcutsMount />);
+    act(() => {
+      dispatchKey("+");
+    });
+    expect(document.documentElement.getAttribute("data-text-size")).toBe("larger");
+  });
+
+  it("Cmd+- steps backward", () => {
+    localStorage.setItem(TEXT_SIZE_STORAGE_KEY, "larger");
+    document.documentElement.setAttribute("data-text-size", "larger");
+    render(<TextSizeShortcutsMount />);
+    act(() => {
+      dispatchKey("-");
+    });
+    expect(document.documentElement.hasAttribute("data-text-size")).toBe(false);
+  });
+
+  it("Cmd+0 resets to default", () => {
+    localStorage.setItem(TEXT_SIZE_STORAGE_KEY, "largest");
+    document.documentElement.setAttribute("data-text-size", "largest");
+    render(<TextSizeShortcutsMount />);
+    act(() => {
+      dispatchKey("0");
+    });
+    expect(document.documentElement.hasAttribute("data-text-size")).toBe(false);
+    expect(localStorage.getItem(TEXT_SIZE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("ignores key presses without Cmd/Ctrl", () => {
+    render(<TextSizeShortcutsMount />);
+    act(() => {
+      dispatchKey("=", { meta: false, ctrl: false });
+    });
+    expect(document.documentElement.hasAttribute("data-text-size")).toBe(false);
+  });
+
+  it("ignores Cmd+= with Shift (the literal Plus glyph with Shift held)", () => {
+    // Plus typed via Shift+= on a US keyboard is the actual `+` key event,
+    // but the handler explicitly skips shift to avoid stepping the ramp
+    // every time the user types `+` in a markdown table. Verify by
+    // dispatching the shifted form.
+    render(<TextSizeShortcutsMount />);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "+",
+        metaKey: true,
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    expect(document.documentElement.hasAttribute("data-text-size")).toBe(false);
+  });
+
+  it("popover mirror updates in same tab when shortcut fires", () => {
+    // The popover starts open showing "default" as active. A shortcut step
+    // up should flip the `aria-pressed` to the new value without a
+    // re-render of the popover button — proves the same-tab custom event
+    // wiring works.
+    render(
+      <>
+        <TextSizeShortcutsMount />
+        <TextSizeControl />
+      </>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /text size: default/i }));
+    });
+    expect(screen.getByRole("button", { name: /^default$/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    act(() => {
+      dispatchKey("=");
+    });
+    // Popover should still be open, and the active row should now be Larger.
+    expect(screen.getByRole("button", { name: /^larger$/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /^default$/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+});

--- a/src/components/TextSizeControl.tsx
+++ b/src/components/TextSizeControl.tsx
@@ -1,0 +1,182 @@
+import {
+  TEXT_SIZES,
+  type TextSize,
+  applyTextSize,
+  nextTextSize,
+  previousTextSize,
+  readStoredTextSize,
+  textSizeLabel,
+  writeStoredTextSize,
+} from "@/lib/text-size";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Header chrome control + global keyboard shortcuts for text-size. The
+// Settings dropdown (notes#123) is canonical for "set my preferred size";
+// this surface exists because text-zoom is an in-the-moment action (notes
+// #127: "usually I'm in the middle of typing a note when I want to
+// increase the size"). Two paths:
+//
+//   1. Click the "Aa" button (`TextSizeControl`) → 3-option popover.
+//   2. Cmd+Plus / Cmd+Minus / Cmd+0 — bound by `TextSizeShortcutsMount`,
+//      which is rendered once at the app root so the listener never
+//      double-binds when the mobile menu (a second `TextSizeControl`
+//      instance) opens.
+//
+// Both invoke the same store + apply helpers from lib/text-size.ts —
+// localStorage is the single source of truth so all surfaces (Settings,
+// header button, shortcuts) stay synchronized via the storage key. The
+// local `size` state in `TextSizeControl` is just a UI mirror so the
+// popover renders the right "current" pill; it's read fresh from
+// localStorage by the global shortcut handler so a click on one surface
+// doesn't stale-out the other.
+
+// Custom event the popover listens for so the visible "current" indicator
+// stays in sync when the keyboard shortcut (or any other same-tab caller)
+// changes the size. `storage` events don't fire on the writer tab, so we
+// need a same-tab signal alongside the cross-tab one.
+const TEXT_SIZE_CHANGE_EVENT = "notes:text-size-change";
+
+function broadcast(next: TextSize) {
+  writeStoredTextSize(next);
+  applyTextSize(next);
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent<TextSize>(TEXT_SIZE_CHANGE_EVENT, { detail: next }));
+  }
+}
+
+// Mount once at the app root — renders no DOM. Separate from the visible
+// `TextSizeControl` because the Header renders that twice (desktop +
+// mobile menu) and we don't want two keydown listeners firing in parallel
+// when both surfaces are mounted.
+export function TextSizeShortcutsMount() {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.altKey || e.shiftKey) return;
+      // Cmd+= / Cmd+Plus — many keyboards report "=" without shift even
+      // for the visible Plus glyph (same physical key). Treat both as
+      // "step up".
+      if (e.key === "=" || e.key === "+") {
+        e.preventDefault();
+        broadcast(nextTextSize(readStoredTextSize()));
+        return;
+      }
+      if (e.key === "-" || e.key === "_") {
+        e.preventDefault();
+        broadcast(previousTextSize(readStoredTextSize()));
+        return;
+      }
+      if (e.key === "0") {
+        e.preventDefault();
+        broadcast("default");
+        return;
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+  return null;
+}
+
+export function TextSizeControl() {
+  const [size, setSize] = useState<TextSize>(() => readStoredTextSize());
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // Wraps the persist+apply+mirror trio so callers (popover buttons,
+  // future onChange consumers) don't have to remember the order. Also
+  // broadcasts the same-tab change event so a sibling TextSizeControl
+  // (mobile menu) sees the new value without waiting for storage tick.
+  const set = useCallback((next: TextSize) => {
+    setSize(next);
+    broadcast(next);
+  }, []);
+
+  // Stay in sync when *another* surface changes the size. `storage` covers
+  // the cross-tab case (Settings in tab A → header in tab B); the custom
+  // `TEXT_SIZE_CHANGE_EVENT` covers the same-tab case (shortcut fires while
+  // popover is open, or sibling TextSizeControl in the mobile menu writes).
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== "notes:textSize") return;
+      setSize(readStoredTextSize());
+    };
+    const onLocal = (e: Event) => {
+      const detail = (e as CustomEvent<TextSize>).detail;
+      if (detail) setSize(detail);
+      else setSize(readStoredTextSize());
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(TEXT_SIZE_CHANGE_EVENT, onLocal);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(TEXT_SIZE_CHANGE_EVENT, onLocal);
+    };
+  }, []);
+
+  // Close the popover on click-outside. Same shape as SyncStatusIndicator.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!rootRef.current) return;
+      if (rootRef.current.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-label={`Text size: ${textSizeLabel(size)}. Click to change.`}
+        aria-expanded={open}
+        title={`Text size: ${textSizeLabel(size)}`}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md border border-border bg-card px-2 py-1.5 text-sm text-fg-muted hover:text-accent focus-visible:outline-2 focus-visible:outline-accent"
+      >
+        <span aria-hidden="true" className="font-serif">
+          A<span className="text-xs">a</span>
+        </span>
+      </button>
+
+      {open ? (
+        // biome-ignore lint/a11y/useSemanticElements: a native <dialog> requires imperative show()/showModal() calls; this is a popover, not a modal.
+        <div
+          role="dialog"
+          aria-label="Text size"
+          className="absolute right-0 z-30 mt-2 w-40 rounded-md border border-border bg-card p-2 text-sm shadow-lg"
+        >
+          <ul className="flex flex-col gap-0.5">
+            {TEXT_SIZES.map((s) => {
+              const active = s === size;
+              return (
+                <li key={s}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      set(s);
+                      setOpen(false);
+                    }}
+                    aria-pressed={active}
+                    className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left hover:bg-bg/60 ${
+                      active ? "text-accent" : "text-fg-muted"
+                    }`}
+                  >
+                    <span>{textSizeLabel(s)}</span>
+                    {active ? (
+                      <span aria-hidden="true" className="text-xs">
+                        ✓
+                      </span>
+                    ) : null}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/capture/recorder.test.ts
+++ b/src/lib/capture/recorder.test.ts
@@ -7,6 +7,7 @@ import {
   memoNoteContent,
   memoPath,
   pickMimeType,
+  quickPath,
   requestMic,
 } from "./recorder";
 
@@ -215,6 +216,13 @@ describe("memo helpers", () => {
   it("path slots into Memos/YYYY/MM-DD/HH-MM-SS", () => {
     const at = new Date(2026, 3, 19, 14, 30, 5);
     expect(memoPath(at)).toBe("Memos/2026/04-19/14-30-05");
+  });
+
+  it("quickPath mirrors memoPath shape under Notes/", () => {
+    // Same grouping as memoPath() so Memos/<date> and Notes/<date> read
+    // as parallel concepts. Closes notes#126.
+    const at = new Date(2026, 4, 12, 9, 5, 30);
+    expect(quickPath(at)).toBe("Notes/2026/05-12/09-05-30");
   });
 
   it("note content embeds the filename as a wiki-attachment", () => {

--- a/src/lib/capture/recorder.ts
+++ b/src/lib/capture/recorder.ts
@@ -207,6 +207,23 @@ export function memoPath(at: Date = new Date()): string {
   return `Memos/${yyyy}/${mm}-${dd}/${hh}-${mi}-${ss}`;
 }
 
+// Path for a typed quick-capture note. Mirrors `memoPath()`'s shape on
+// purpose so a vault's `Memos/2026/05-12/14-30-15` and
+// `Notes/2026/05-12/14-30-15` group side-by-side and read as parallel
+// concepts. Pre-#126 Notes passed `path: undefined` to the vault which
+// auto-assigned server-side; surfacing this here moves the generation
+// rule into Notes (where it belongs) and lets the operator see + edit
+// the value before save.
+export function quickPath(at: Date = new Date()): string {
+  const yyyy = at.getFullYear();
+  const mm = String(at.getMonth() + 1).padStart(2, "0");
+  const dd = String(at.getDate()).padStart(2, "0");
+  const hh = String(at.getHours()).padStart(2, "0");
+  const mi = String(at.getMinutes()).padStart(2, "0");
+  const ss = String(at.getSeconds()).padStart(2, "0");
+  return `Notes/${yyyy}/${mm}-${dd}/${hh}-${mi}-${ss}`;
+}
+
 export function memoNoteContent(filename: string, at: Date = new Date()): string {
   return [
     "# 🎙️ Voice memo",

--- a/src/lib/text-size.test.ts
+++ b/src/lib/text-size.test.ts
@@ -8,6 +8,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   TEXT_SIZE_STORAGE_KEY,
   applyTextSize,
+  nextTextSize,
+  previousTextSize,
   readStoredTextSize,
   textSizeLabel,
   writeStoredTextSize,
@@ -52,5 +54,17 @@ describe("text-size", () => {
     expect(textSizeLabel("default")).toBe("Default");
     expect(textSizeLabel("larger")).toBe("Larger");
     expect(textSizeLabel("largest")).toBe("Largest");
+  });
+
+  it("nextTextSize cycles default → larger → largest → default", () => {
+    expect(nextTextSize("default")).toBe("larger");
+    expect(nextTextSize("larger")).toBe("largest");
+    expect(nextTextSize("largest")).toBe("default");
+  });
+
+  it("previousTextSize cycles default → largest → larger → default", () => {
+    expect(previousTextSize("default")).toBe("largest");
+    expect(previousTextSize("largest")).toBe("larger");
+    expect(previousTextSize("larger")).toBe("default");
   });
 });

--- a/src/lib/text-size.ts
+++ b/src/lib/text-size.ts
@@ -50,3 +50,21 @@ export function textSizeLabel(size: TextSize): string {
   if (size === "largest") return "Largest";
   return "Default";
 }
+
+// Cycle to the next step in the canonical ramp (default → larger → largest →
+// default). Used by Cmd+Plus to step up and the header chrome control to walk
+// forward without a popover. Mirrors `nextTheme` in `theme.ts`.
+export function nextTextSize(current: TextSize): TextSize {
+  const idx = TEXT_SIZES.indexOf(current);
+  return TEXT_SIZES[(idx + 1) % TEXT_SIZES.length] ?? "default";
+}
+
+// Step down the ramp (largest → larger → default → largest). Cmd+Minus.
+// Distinct from `nextTextSize` so each direction is explicit at the call
+// site — the shortcut handlers shouldn't have to think about wrap-around
+// arithmetic.
+export function previousTextSize(current: TextSize): TextSize {
+  const idx = TEXT_SIZES.indexOf(current);
+  const len = TEXT_SIZES.length;
+  return TEXT_SIZES[(idx - 1 + len) % len] ?? "default";
+}


### PR DESCRIPTION
Two follow-ups bundled per the dispatch brief — both touch the same chrome / Capture surfaces. Closes #127 + #126.

## #127 — text-size accessible from the editing surface

Aaron flagged: *"usually I'm in the middle of typing a note when I want to increase the size"* — Settings-only is wrong UX.

**Shipped:**
- **Keyboard shortcuts** (Cmd+= / Cmd+Plus / Cmd+- / Cmd+0). Bound once at the app root via `TextSizeShortcutsMount` so the listener doesn't double-bind when the mobile menu mounts a second `TextSizeControl`. Ignored when Shift/Alt held or no modifier.
- **Header chrome** — new `TextSizeControl` ("Aa" button + popover) next to existing chrome (Install / Theme). Three options with a ✓ on the active row. Lives on both desktop and mobile menu so phones (no keyboard) keep the path.
- **Same-tab sync** — `CustomEvent("notes:text-size-change")` keeps the popover's active row in sync when a shortcut or sibling control changes the size (the `storage` event only fires cross-tab).
- **New helpers** `nextTextSize` / `previousTextSize` in `lib/text-size.ts`, mirroring `nextTheme`'s shape. Direction is explicit at the call site.

## #126 — Capture path generated locally + pre-filled

Aaron flagged: today's "vault auto-assigns" framing is wrong — vault doesn't have a path-generation workflow, the rule lives in Notes. Make it honest.

**Shipped:**
- **`quickPath()`** helper next to `memoPath()` in `lib/capture/recorder.ts`. Same `<root>/YYYY/MM-DD/HH-MM-SS` shape under `Notes/` so quickly-captured text and voice memos read as parallel concepts.
- **Capture pre-fill** — `pathOverride` state is seeded with `quickPath()` on mount. Operator sees the generated path the moment they expand More fields. They can accept, edit, or clear.
- **Escape valve preserved** — clearing the input falls back to the rc.6 behavior (text → vault-picks, audio-only → `memoPath()`). Pinned by a new test.

## Behavior changes (worth flagging for review)

- Text-only captures now land at `Notes/<date>/<time>` by default (was: vault-assigned).
- Audio captures with no override now also land under `Notes/` (was: `Memos/`). Clearing the input restores the `Memos/` rule.
- Combined text+voice captures now land at `Notes/<date>/<time>` (was: vault-assigned).

If Aaron wants audio captures to keep going to `Memos/` by default (regardless of the pre-fill being non-empty), the fix is a phase-aware pre-fill — pre-fill switches to `memoPath()` when audio is staged AND the user hasn't manually edited. Flag in review if that's the preference.

## Design call (re-flagging from my ack)

The brief said *"My lean is in-More-fields pre-filled — keeps the focused-textarea UX, but the path is no longer hidden"*, while issue #126 acceptance reads *"Pre-fill the path input visibly (not behind 'More fields')"*. I went with the brief's lean (in-More-fields pre-filled) because the textarea-first UX in audit §3 #12 is north-star. If you want it surfaced above the textarea as an always-visible slim affordance instead, flag it in review and I'll move it.

## Patterns check

- `TextSizeControl` + `TextSizeShortcutsMount` collocate as one feature module — the visible affordance and the global listener are the same concept, even though they have to be mounted at different DOM positions.
- Same-tab `CustomEvent` pattern is new for this codebase — adds explicit comment about why `storage` alone isn't enough. Mirror of cross-tab sync but for same-tab; not a clash with existing patterns.
- `quickPath()` mirrors `memoPath()` shape exactly so the two helpers are interchangeable for future "configurable path rule" work (notes#126 mentions per-vault override as a future).

## Tests

- `text-size.test.ts`: +2 (cycle direction helpers).
- `TextSizeControl.test.tsx`: +12 (button + popover behavior, keyboard handlers across Cmd+= / Cmd+Plus / Cmd+- / Cmd+0 / Shift-rejection / no-modifier-rejection, same-tab sync between shortcut and popover).
- `recorder.test.ts`: +1 (quickPath shape).
- `Capture.test.tsx`: +2 (pre-fill is editable + saved; audio-only memoPath escape valve when path cleared). Existing assertions updated where pre-fill changed observable behavior.

**Full gate: 81 test files / 741 tests pass** (+17 from this PR; was 724 in rc.6 + F1 fold). Typecheck clean, lint clean, build green (1563 KiB precache).

## End-to-end smoke

`parachute restart notes` clean. Bundle ships `TextSizeControl`, `quickPath`, the new keymap handler. Browser test plan below.

## Test plan

- [ ] Header: "Aa" button visible next to Theme toggle. Click → popover with Default / Larger / Largest. Click Larger → text scales up live, popover closes, ✓ moves to Larger.
- [ ] Cmd+= / Cmd+- cycle the size while typing in `/capture`. Cmd+0 resets.
- [ ] Shift+Cmd+= does NOT cycle (avoids stomping `+` in markdown tables).
- [ ] Mobile menu (narrow viewport, hamburger): "Aa" button present in the menu's chrome row. Tap → same popover.
- [ ] Settings → Text size dropdown still works, and changing it there updates the header popover's ✓ (cross-surface sync).
- [ ] `/capture` → expand More fields → Path input is pre-filled with `Notes/<today>/<time>`. Edit to a custom path → save → new note lands at the custom path. Clear path → save text-only → vault picks (rc.6 behavior). Clear path → record audio only → memo lands under `Memos/<date>` (rc.6 escape valve).
- [ ] `/new` → still renders NoteNew (heavy form with attachments) — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)