### PR TITLE
fix(capture): empty path reverts to generated, never vault-picks (0.3.15-rc.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Capture path empty-input reverts to generated (option d)
+
+- **fix(capture): empty path input reverts to the generated value, never
+  vault-picks (0.3.15-rc.8).** Reviewer follow-up on notes#126 after PR
+  #130 merged. Aaron's whole framing was that "vault auto-assigns" hides
+  what's happening; rc.7 kept that escape valve when the operator
+  cleared the path input. This PR removes it: clearing the input now
+  reverts to the same mount-time `quickPath()` value the operator
+  originally saw. One canonical Notes-side rule, no phase-dependent
+  forks. The `memoPath()` fallback for audio-only with no override
+  becomes unreachable under this rule and is dropped — audio captures
+  with a cleared path land at the same generated `Notes/<date>/<time>`
+  as text captures. The save-path resolution becomes a one-liner:
+  `pathOverride.trim() || generatedPathRef.current`. Two existing tests
+  flipped to assert the new semantics ("empty path reverts to
+  generated", "audio-only cleared-path reverts to generated"); no new
+  tests needed — the option-(a) shape is no longer reachable.
+
 ### Text-size shortcuts + header control; Capture path pre-fill
 
 - **feat(ui): accessible text-size (shortcuts + header) + locally-generated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.7",
+  "version": "0.3.15-rc.8",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/routes/Capture.test.tsx
+++ b/src/app/routes/Capture.test.tsx
@@ -260,11 +260,11 @@ describe("Capture (unified)", () => {
     ) {
       throw new Error("wrong mutation shape");
     }
-    // With notes#126's pre-fill, pathOverride is seeded with `quickPath()`
-    // on mount and wins over the audio-only memoPath fallback. Audio-only
-    // memos now land under Notes/<date>/<time> by default. To keep them
-    // in Memos/, the user can clear the path input (then memoPath kicks
-    // in — see the "audio-only with cleared path" test below).
+    // With notes#126's pre-fill + option (d), audio-only captures also
+    // land under Notes/<date>/<time> by default. The `memoPath()`
+    // fallback was dropped — one canonical Notes-side rule, no phase-
+    // dependent forks. Clearing the path reverts to the same generated
+    // value (see the "audio-only with cleared path" test below).
     expect(create.mutation.payload.path).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
     expect(create.mutation.payload.tags).toEqual(["voice"]);
     expect(create.mutation.payload.content).toContain("_Transcript pending._");
@@ -660,7 +660,13 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     db.close();
   });
 
-  it("Empty path override → payload omits `path` (vault auto-assigns)", async () => {
+  it("Empty path override reverts to the mount-time generated path (notes#126 option d)", async () => {
+    // Option (d) per team-lead — clearing the path input never falls back
+    // to vault-auto-assign. The generated `quickPath()` value captured on
+    // mount is the truth-default; the operator can edit it, but emptying
+    // the input reverts to that same value at save time. Aaron's whole
+    // framing: "vault auto-assigns" hides what's happening, so an empty
+    // input must not surface that magic again.
     renderAt("/capture");
     await waitForReady();
     const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
@@ -671,6 +677,10 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
 
     const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
     const pathInput = screen.getByLabelText(/path override/i) as HTMLInputElement;
+    // Capture the mount-time generated path BEFORE clearing the input.
+    const generated = pathInput.value;
+    expect(generated).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
+
     await act(async () => {
       fireEvent.change(textarea, { target: { value: "no path here" } });
       // Whitespace-only is treated as empty per the trim().
@@ -688,12 +698,13 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     const db = await openLensDB();
     const rows = await listPending(db, "dev");
     if (rows[0]?.mutation.kind !== "create-note") throw new Error("expected create-note");
-    expect(rows[0].mutation.payload.path).toBeUndefined();
+    // The saved path is the mount-time generated value, not undefined.
+    expect(rows[0].mutation.payload.path).toBe(generated);
     expect(rows[0].mutation.payload.metadata).toBeUndefined();
     db.close();
   });
 
-  it("Path override wins over the audio-only memo path", async () => {
+  it("Path override wins over the generated default (audio-only)", async () => {
     renderAt("/capture");
     await waitForReady();
     const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
@@ -776,12 +787,12 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     db.close();
   });
 
-  it("Audio-only with manually cleared path falls back to memoPath (rc.6 escape valve)", async () => {
-    // notes#126's pre-fill is the new default, but clearing the path
-    // input is the operator's signal of "I want the historical rule".
-    // For audio-only captures, that rule is `memoPath()` → `Memos/`.
-    // This test pins the escape valve so a future refactor doesn't
-    // delete the fallback.
+  it("Audio-only with manually cleared path reverts to the generated path (option d)", async () => {
+    // notes#126 option (d) — clearing the path is NOT an escape hatch
+    // back to historical rules (`memoPath()` / vault-picks). It reverts
+    // to the mount-time `quickPath()` value. One canonical Notes-side
+    // rule, no phase-dependent forks. Audio captures via this path land
+    // under `Notes/<date>/<time>` just like text captures do.
     renderAt("/capture");
     await waitForReady();
     const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
@@ -791,6 +802,9 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     });
 
     const pathInput = screen.getByLabelText(/path override/i) as HTMLInputElement;
+    const generated = pathInput.value;
+    expect(generated).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
+
     await act(async () => {
       fireEvent.change(pathInput, { target: { value: "" } });
     });
@@ -819,7 +833,7 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     const rows = await listPending(db, "dev");
     const create = rows.find((r) => r.mutation.kind === "create-note")!;
     if (create.mutation.kind !== "create-note") throw new Error("expected create-note");
-    expect(create.mutation.payload.path).toMatch(/^Memos\//);
+    expect(create.mutation.payload.path).toBe(generated);
     db.close();
   });
 });

--- a/src/app/routes/Capture.tsx
+++ b/src/app/routes/Capture.tsx
@@ -4,7 +4,6 @@ import {
   type RecorderController,
   createRecorder,
   memoFilename,
-  memoPath,
   pickMimeType,
   quickPath,
   requestMic,
@@ -79,13 +78,18 @@ export function Capture({
   // operator who needs to override the path or set a one-line summary
   // opens this and gets the structured form without leaving Capture.
   //
-  // pathOverride is now pre-filled with `quickPath()` (notes#126) — the
+  // pathOverride is pre-filled with `quickPath()` (notes#126) — the
   // generated path is Notes-side, deterministic from mount time, and
-  // visible to the operator the moment they expand More fields. They can
-  // accept it, edit it, or clear it. Clearing falls back to "let the
-  // vault auto-assign" (empty string preserves the rc.5 escape valve).
+  // visible to the operator the moment they expand More fields. Clearing
+  // the input reverts to the same generated value at save time (option
+  // (d) — Aaron's whole feedback was that "vault auto-assigns" hides
+  // what's happening, so empty-input must never surface that magic
+  // again). The generated path is captured in a ref so subsequent saves
+  // on the same mount land at the same place — the user typed against
+  // it knowing where it would land.
   const [moreFieldsOpen, setMoreFieldsOpen] = useState(moreFieldsOpenDefault);
-  const [pathOverride, setPathOverride] = useState(() => quickPath());
+  const generatedPathRef = useRef(quickPath());
+  const [pathOverride, setPathOverride] = useState(() => generatedPathRef.current);
   const [summary, setSummary] = useState("");
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const [elapsedMs, setElapsedMs] = useState(0);
@@ -238,9 +242,11 @@ export function Capture({
     const localId = newLocalId();
 
     // "More fields" overrides: trim once here so empty-after-trim values
-    // don't end up as `path: ""` (vault would reject) or
-    // `metadata.summary: ""` (worthless metadata noise).
-    const pathOverrideValue = pathOverride.trim();
+    // Empty path reverts to the mount-time generated value (notes#126
+    // option d) — clearing the input never hands path-generation back
+    // to the vault. Trim summary so empty input doesn't write
+    // `metadata.summary: ""` noise.
+    const pathToSave = pathOverride.trim() || generatedPathRef.current;
     const summaryValue = summary.trim();
     const metadata = summaryValue ? { summary: summaryValue } : undefined;
 
@@ -256,11 +262,10 @@ export function Capture({
         const body = hasText
           ? `${content.trim()}\n\n_Transcript pending._\n\n![[${filename}]]\n`
           : `_Transcript pending._\n\n![[${filename}]]\n`;
-        // Path precedence: explicit override > audio-only memo path > let
-        // the vault auto-assign. Override wins on every shape so the user
-        // can place an audio note anywhere they want, including the typed
-        // case (where today we'd let the vault pick).
-        const path = pathOverrideValue || (hasText ? undefined : memoPath(recordedAt));
+        // One canonical Notes-side path rule now (option d). Path-generation
+        // never falls back to vault-side magic — what the operator saw in
+        // the More-fields panel is what gets written.
+        const path = pathToSave;
 
         if (!blobStore) throw new Error("blob store missing");
         await blobStore.put(blobId, audio.data, audio.mimeType, activeVault.id);
@@ -271,7 +276,7 @@ export function Capture({
             localId,
             payload: {
               content: body,
-              ...(path ? { path } : {}),
+              path,
               ...(finalTags.length ? { tags: finalTags } : {}),
               ...(metadata ? { metadata } : {}),
             },
@@ -308,7 +313,7 @@ export function Capture({
             localId,
             payload: {
               content,
-              ...(pathOverrideValue ? { path: pathOverrideValue } : {}),
+              path: pathToSave,
               ...(finalTags.length ? { tags: finalTags } : {}),
               ...(metadata ? { metadata } : {}),
             },
@@ -411,7 +416,10 @@ export function Capture({
       const all = Array.from(
         new Set([roles.captureText, ...explicit, ...extracted].filter((t) => t.length > 0)),
       );
-      const pathValue = pathOverride.trim();
+      // Same path-resolution rule as save() (notes#126 option d): trimmed
+      // override OR the mount-time generated path. Never write
+      // `path: undefined` to the queue — the path is always Notes-side.
+      const pathValue = pathOverride.trim() || generatedPathRef.current;
       const summaryValue = summary.trim();
       // Swallow rejections here — we're in the unmount path, so there's no
       // user-visible surface to report a failure (the toaster has already
@@ -426,7 +434,7 @@ export function Capture({
           localId: newLocalId(),
           payload: {
             content,
-            ...(pathValue ? { path: pathValue } : {}),
+            path: pathValue,
             ...(all.length ? { tags: all } : {}),
             ...(summaryValue ? { metadata: { summary: summaryValue } } : {}),
           },
@@ -549,7 +557,7 @@ export function Capture({
                 type="text"
                 value={pathOverride}
                 onChange={(e) => setPathOverride(e.target.value)}
-                placeholder="(blank → vault picks)"
+                placeholder="(blank → uses generated path)"
                 aria-label="Path override"
                 className="rounded-md border border-border bg-card px-2.5 py-1.5 font-mono text-xs text-fg focus:border-accent focus:outline-none"
               />


### PR DESCRIPTION
Reviewer / team-lead call on the design question I flagged in #130: option (d), not (a).

Aaron's framing on #126 was that "vault auto-assigns" hides what's happening. rc.7 (#130) still re-introduced that magic via the "cleared input" path — empty `pathOverride` fell back to either `memoPath()` (audio-only) or `undefined` (text → vault-picks). Option (d) removes that escape valve.

## Summary

Save-path resolution becomes a one-liner:

```ts
const pathToSave = pathOverride.trim() || generatedPathRef.current;
```

Where `generatedPathRef` is captured once on mount (`useRef(quickPath())`) so subsequent saves on the same Capture mount land at the same place — the user typed against it knowing where it would go.

Side effect: the rc.6 `memoPath()` fallback for audio-only with no override is unreachable under option (d) (empty path now goes to `quickPath()`), so it's dropped. **One canonical Notes-side rule, no phase-dependent forks.** Audio captures with a cleared path land at the same `Notes/<date>/<time>` as text captures.

## Patterns check

- Single resolution chain in one file (Capture.tsx). No new abstraction.
- `useRef(quickPath())` captures generation once; subsequent renders' `quickPath()` calls are discarded (React only stores the initial). Wasteful but harmless; the alternative — lazy-init via `useRef<T | null>(null)` + check on first access — is more LOC for the same outcome on a string.
- Comment headers updated in `Capture.tsx` to document the new rule. Placeholder text in the input swapped: `"(blank → vault picks)"` → `"(blank → uses generated path)"` so the UI itself describes the option-(d) behavior.

## Tests

Two existing tests flipped to assert the new semantics; no new tests added.

- **`Empty path override`** (More-fields panel): was "→ payload omits `path` (vault auto-assigns)" → now "reverts to the mount-time generated path (notes#126 option d)". Captures the input's pre-fill value before clearing it, asserts the saved payload's `path` equals that value (not `undefined`).
- **`Audio-only with manually cleared path`**: was "falls back to memoPath (rc.6 escape valve)" → now "reverts to the generated path (option d)". Same shape — pre-fill value captured, then cleared, then asserted equal to the saved path.
- Other test "Path override wins over the audio-only memo path" renamed to "Path override wins over the generated default (audio-only)" since the audio-only memo path no longer exists.

Full gate: **81 test files / 741 tests pass** (unchanged count from rc.7 — same tests, flipped semantics). typecheck clean, lint clean, build green.

## Behavior change (worth flagging)

Audio-only captures with a cleared path now land under `Notes/`, not `Memos/`. That's a real behavior change from rc.6 and rc.7. Per the design-cleaner shape — one Notes-side rule across all phases — and aligned with team-lead's reasoning that option (d) doesn't re-introduce hidden magic. If you want `Memos/` back as a user-facing affordance, that's a per-vault setting via `useVaultSettings` (notes-config-as-note thread), not a Capture-side escape valve.

## Test plan

- [ ] `/capture` → expand More fields → path input shows `Notes/<today>/<time>` pre-fill.
- [ ] Clear the path input → type body → Capture. Note lands at the same pre-fill value (not the vault picking).
- [ ] Clear path, record audio only → Capture. Audio memo lands at the generated `Notes/<date>/<time>` (not `Memos/`).
- [ ] Type a custom path over the pre-fill → save → note lands at the custom path (unchanged behavior).
- [ ] Multiple saves on the same Capture mount land at the same generated path (the ref doesn't re-roll). Open a new `/capture` route → fresh path with current minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)