### PR TITLE
feat(capture): hierarchical capture/* tags + schema-ensure + option (d) + path-collision fix (0.3.15-rc.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 ## Unreleased
 
+### Capture reshape — hierarchical capture/* tags + schema-ensure + option (d) + path-collision fix
+
+- **feat(capture): hierarchical capture tags + schema-ensure + option (d) +
+  path-collision fix (0.3.15-rc.8).** Closes notes#126 (reshaped scope).
+  Builds on rc.7's `quickPath()` pre-fill with Aaron's confirmed `capture/*`
+  classification model + several reviewer follow-ups bundled.
+  - **`NOTES_REQUIRED_SCHEMA` in `src/lib/vault/schema.ts`** declares the
+    `capture` parent + `capture/text` + `capture/voice` children with
+    `parent_names: ["capture"]`. First instance of patterns#57 (surface-
+    declares-required-schema). Future extensions (`capture/photo`,
+    `capture/web-clip`) slot in without rename.
+  - **Tag Role defaults rename**: `DEFAULT_TAG_ROLES.captureText` →
+    `"capture/text"`, `DEFAULT_TAG_ROLES.captureVoice` → `"capture/voice"`.
+    **Existing vaults preserve their stored values** — if a user has
+    `captureText = "quick"` from rc.6, that stays. Only fresh-vault
+    inheritance changes.
+  - **`update-tag` client method + idempotent `ensureNotesSchema()` hook**
+    in `src/lib/vault/schema-ensure.ts`. PUTs each declared tag against
+    `/api/tags/:name` (field-merged vault-side; no-op when already-correct).
+    Per-vault per-session ref guard so repeated captures don't hammer the
+    vault. Failure rolls back the guard so the next capture retries.
+    Captures-side wiring is fire-and-forget — schema setup doesn't block
+    the user's save.
+  - **Option (d) bundled** (was the closed PR #131): clearing the path
+    input reverts to the mount-time generated value, never vault-picks.
+    Resolution becomes `pathOverride.trim() || generatedPathRef.current`.
+    The rc.6 `memoPath()` audio-only fallback is dropped — unreachable
+    under option (d). One canonical Notes-side rule, no phase-dependent
+    forks. Aaron's framing: don't re-introduce hidden vault-picks magic
+    via the cleared-input path.
+  - **Path-collision fix** (raised in #130 review): `quickPath()` is
+    second-granularity, so two captures within the same wall-clock second
+    would land at the same path. `reset()` after successful save now
+    regenerates `quickPath()` AND updates the input — but only when the
+    operator hasn't manually edited. A user typing an explicit path
+    (e.g. `Daily/2026-05-12`) is capturing into a deliberate location;
+    don't fight them. `pathEditedRef` tracks edit intent; restoring the
+    generated value clears the flag.
+  - **Placeholder text** updated: `"(blank → vault picks)"` →
+    `"(blank → uses generated path)"` so the UI itself describes the
+    option-(d) rule.
+  - **Tests.** 6 new in `schema-ensure.test.ts` (declaration-order PUTs,
+    parent-before-children, per-session per-vault idempotence, multi-vault
+    independence, retry-on-failure, swallow-failure-doesn't-throw). 2 new
+    in `Capture.test.tsx` (regen-on-reset when unedited; preserve user
+    edit across reset). 4 existing tests flipped where defaults changed
+    (captureText → `capture/text`, captureVoice → `capture/voice`,
+    text+voice combined now both hierarchical) or option (d) changed
+    semantics ("empty path reverts to generated", "audio-only cleared
+    path reverts to generated"). `Capture.test.tsx` adds a `vi.mock` for
+    `@/lib/vault/schema-ensure` so capture tests don't hit the real PUT
+    (covered by schema-ensure.test.ts).
+
+### Not in scope (deferred)
+
+- Full Settings audit UI + connect-time banner → notes#129.
+- Per-vault customization of path templates → notes#128.
+
 ### Text-size shortcuts + header control; Capture path pre-fill
 
 - **feat(ui): accessible text-size (shortcuts + header) + locally-generated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.7",
+  "version": "0.3.15-rc.8",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/routes/Capture.test.tsx
+++ b/src/app/routes/Capture.test.tsx
@@ -44,6 +44,16 @@ vi.mock("@/lib/sync", async () => {
   };
 });
 
+// Schema-ensure (notes#126 reshape) calls a real `PUT /api/tags/:name` via
+// the active vault client. Capture tests don't stub fetch at the network
+// boundary — they stub at the `enqueue` boundary — so the schema-ensure
+// fetch would hang the test environment for 10s+ per case. Stub the
+// ensure module to a no-op here; schema-ensure has its own focused tests
+// in `schema-ensure.test.ts` that exercise the real path.
+vi.mock("@/lib/vault/schema-ensure", () => ({
+  ensureNotesSchema: vi.fn(async () => {}),
+}));
+
 vi.mock("@/lib/capture/recorder", async () => {
   const actual =
     await vi.importActual<typeof import("@/lib/capture/recorder")>("@/lib/capture/recorder");
@@ -214,7 +224,8 @@ describe("Capture (unified)", () => {
     // on mount, so the payload's path is `Notes/<YYYY>/<MM-DD>/<HH-MM-SS>`.
     // Asserting on the prefix keeps the test stable across clock minutes.
     expect(rows[0].mutation.payload.path).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
-    expect(rows[0].mutation.payload.tags).toEqual(["quick", "idea"]);
+    // notes#126 reshape: default captureText role is "capture/text" (was "quick").
+    expect(rows[0].mutation.payload.tags).toEqual(["capture/text", "idea"]);
     db.close();
   });
 
@@ -260,13 +271,15 @@ describe("Capture (unified)", () => {
     ) {
       throw new Error("wrong mutation shape");
     }
-    // With notes#126's pre-fill, pathOverride is seeded with `quickPath()`
-    // on mount and wins over the audio-only memoPath fallback. Audio-only
-    // memos now land under Notes/<date>/<time> by default. To keep them
-    // in Memos/, the user can clear the path input (then memoPath kicks
-    // in — see the "audio-only with cleared path" test below).
+    // With notes#126's pre-fill + option (d), audio-only captures also
+    // land under Notes/<date>/<time> by default. The `memoPath()`
+    // fallback was dropped in the reshape — one canonical Notes-side
+    // rule, no phase-dependent forks. Clearing the path reverts to the
+    // same generated value (see the "audio-only with cleared path" test
+    // below).
     expect(create.mutation.payload.path).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
-    expect(create.mutation.payload.tags).toEqual(["voice"]);
+    // notes#126 reshape: default captureVoice role is "capture/voice" (was "voice").
+    expect(create.mutation.payload.tags).toEqual(["capture/voice"]);
     expect(create.mutation.payload.content).toContain("_Transcript pending._");
     expect(create.mutation.payload.content).toContain("![[");
     expect(link.mutation.pathRef).toBe(`blob:${upload.mutation.blobId}`);
@@ -313,7 +326,8 @@ describe("Capture (unified)", () => {
     expect(create.mutation.payload.path).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
     expect(create.mutation.payload.content).toContain("context for the recording #meeting");
     expect(create.mutation.payload.content).toContain("![[");
-    expect(create.mutation.payload.tags).toEqual(["quick", "voice", "meeting"]);
+    // notes#126 reshape: both default capture roles are hierarchical now.
+    expect(create.mutation.payload.tags).toEqual(["capture/text", "capture/voice", "meeting"]);
     db.close();
   });
 
@@ -418,7 +432,7 @@ describe("Capture (unified)", () => {
     const rows = await listPending(db, "dev");
     if (rows[0]?.mutation.kind === "create-note") {
       expect(rows[0].mutation.payload.content).toBe("walked away mid-thought");
-      expect(rows[0].mutation.payload.tags).toEqual(["quick"]);
+      expect(rows[0].mutation.payload.tags).toEqual(["capture/text"]);
     }
     db.close();
   });
@@ -655,12 +669,17 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     const payload = rows[0].mutation.payload;
     expect(payload.path).toBe("Daily/2026-05-12");
     expect(payload.metadata).toEqual({ summary: "first pass" });
-    expect(payload.tags).toEqual(["quick", "wip"]);
+    expect(payload.tags).toEqual(["capture/text", "wip"]);
     expect(payload.content).toBe("lab notes #wip");
     db.close();
   });
 
-  it("Empty path override → payload omits `path` (vault auto-assigns)", async () => {
+  it("Empty path override reverts to the mount-time generated path (option d)", async () => {
+    // notes#126 reshape, option (d): clearing the path input never falls
+    // back to vault-auto-assign. The generated `quickPath()` value captured
+    // on mount is the truth-default; emptying the input reverts to that
+    // same value at save time. Aaron's framing: "vault auto-assigns" hides
+    // what's happening, so empty-input must not surface that magic again.
     renderAt("/capture");
     await waitForReady();
     const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
@@ -671,6 +690,9 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
 
     const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
     const pathInput = screen.getByLabelText(/path override/i) as HTMLInputElement;
+    const generated = pathInput.value;
+    expect(generated).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
+
     await act(async () => {
       fireEvent.change(textarea, { target: { value: "no path here" } });
       // Whitespace-only is treated as empty per the trim().
@@ -688,12 +710,13 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     const db = await openLensDB();
     const rows = await listPending(db, "dev");
     if (rows[0]?.mutation.kind !== "create-note") throw new Error("expected create-note");
-    expect(rows[0].mutation.payload.path).toBeUndefined();
+    // Empty input → mount-time generated value, not undefined.
+    expect(rows[0].mutation.payload.path).toBe(generated);
     expect(rows[0].mutation.payload.metadata).toBeUndefined();
     db.close();
   });
 
-  it("Path override wins over the audio-only memo path", async () => {
+  it("Path override wins over the generated default (audio-only)", async () => {
     renderAt("/capture");
     await waitForReady();
     const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
@@ -776,12 +799,12 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     db.close();
   });
 
-  it("Audio-only with manually cleared path falls back to memoPath (rc.6 escape valve)", async () => {
-    // notes#126's pre-fill is the new default, but clearing the path
-    // input is the operator's signal of "I want the historical rule".
-    // For audio-only captures, that rule is `memoPath()` → `Memos/`.
-    // This test pins the escape valve so a future refactor doesn't
-    // delete the fallback.
+  it("Audio-only with manually cleared path reverts to the generated path (option d)", async () => {
+    // notes#126 reshape, option (d): clearing the path is NOT an escape
+    // hatch back to historical rules. It reverts to the mount-time
+    // `quickPath()` value. One canonical Notes-side rule, no phase-
+    // dependent forks. Audio captures via this path land under
+    // `Notes/<date>/<time>` just like text captures.
     renderAt("/capture");
     await waitForReady();
     const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
@@ -791,6 +814,9 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     });
 
     const pathInput = screen.getByLabelText(/path override/i) as HTMLInputElement;
+    const generated = pathInput.value;
+    expect(generated).toMatch(/^Notes\/\d{4}\/\d{2}-\d{2}\/\d{2}-\d{2}-\d{2}$/);
+
     await act(async () => {
       fireEvent.change(pathInput, { target: { value: "" } });
     });
@@ -819,8 +845,93 @@ describe("Capture — More fields panel (path + summary overrides)", () => {
     const rows = await listPending(db, "dev");
     const create = rows.find((r) => r.mutation.kind === "create-note")!;
     if (create.mutation.kind !== "create-note") throw new Error("expected create-note");
-    expect(create.mutation.payload.path).toMatch(/^Memos\//);
+    expect(create.mutation.payload.path).toBe(generated);
     db.close();
+  });
+
+  it("Regenerates the path on reset when operator hasn't edited (notes#126 collision fix)", async () => {
+    // Reviewer raised this in #130: `quickPath()` is second-granularity,
+    // so two captures within the same second produce the same path —
+    // collision. The reshape regenerates on `reset()` AFTER successful
+    // save, but only when the operator hasn't manually edited. We need
+    // wall-clock time to actually move BEFORE the reset's quickPath()
+    // call to see a different value — use fake timers and advance the
+    // clock *before* the save click so reset() reads the advanced time.
+    const tFirst = new Date(2026, 4, 12, 14, 30, 5).getTime();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(tFirst);
+    try {
+      renderAt("/capture");
+      await waitForReady();
+      const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
+      await act(async () => {
+        detailsEl.open = true;
+        detailsEl.dispatchEvent(new Event("toggle"));
+      });
+
+      const pathInput = screen.getByLabelText(/path override/i) as HTMLInputElement;
+      const first = pathInput.value;
+      expect(first).toBe("Notes/2026/05-12/14-30-05");
+
+      const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: "thought one" } });
+      });
+
+      // Advance wall-clock BEFORE the click so reset()'s quickPath() reads
+      // the new value. Two captures within the same wall-clock second is
+      // the collision case; the regen-on-reset is the fix.
+      await act(async () => {
+        vi.setSystemTime(tFirst + 7_000);
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+      });
+      await waitFor(() => {
+        expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+      });
+
+      // After reset(), the input value should have regenerated.
+      const second = pathInput.value;
+      expect(second).toBe("Notes/2026/05-12/14-30-12");
+      expect(second).not.toBe(first);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("Preserves a user-edited path across reset (no regen)", async () => {
+    // Counter-test for the collision fix: if the operator typed an
+    // explicit path, they're capturing multiple notes into the same
+    // place (e.g. `Daily/2026-05-12`). Don't fight them.
+    renderAt("/capture");
+    await waitForReady();
+    const detailsEl = screen.getByText(/^more fields$/i).closest("details")!;
+    await act(async () => {
+      detailsEl.open = true;
+      detailsEl.dispatchEvent(new Event("toggle"));
+    });
+
+    const pathInput = screen.getByLabelText(/path override/i) as HTMLInputElement;
+    const userPath = "Daily/2026-05-12";
+    await act(async () => {
+      fireEvent.change(pathInput, { target: { value: userPath } });
+    });
+
+    const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "first daily" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    });
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+    });
+
+    // After reset, the user-typed path should still be in the input.
+    expect(pathInput.value).toBe(userPath);
   });
 });
 

--- a/src/app/routes/Capture.tsx
+++ b/src/app/routes/Capture.tsx
@@ -4,7 +4,6 @@ import {
   type RecorderController,
   createRecorder,
   memoFilename,
-  memoPath,
   pickMimeType,
   quickPath,
   requestMic,
@@ -12,6 +11,8 @@ import {
 import { blobRef, enqueue, newBlobId, newLocalId } from "@/lib/sync";
 import { useToastStore } from "@/lib/toast/store";
 import { useTagRoles, useVaultStore } from "@/lib/vault";
+import { useActiveVaultClient } from "@/lib/vault/queries";
+import { ensureNotesSchema } from "@/lib/vault/schema-ensure";
 import { useSync } from "@/providers/SyncProvider";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, Navigate } from "react-router";
@@ -70,6 +71,7 @@ export function Capture({
   const pushToast = useToastStore((s) => s.push);
   const { db, blobStore, engine } = useSync();
   const { roles } = useTagRoles(activeVault?.id ?? null);
+  const client = useActiveVaultClient();
 
   const [content, setContent] = useState("");
   const [tags, setTags] = useState<string[]>([]);
@@ -79,13 +81,24 @@ export function Capture({
   // operator who needs to override the path or set a one-line summary
   // opens this and gets the structured form without leaving Capture.
   //
-  // pathOverride is now pre-filled with `quickPath()` (notes#126) — the
-  // generated path is Notes-side, deterministic from mount time, and
-  // visible to the operator the moment they expand More fields. They can
-  // accept it, edit it, or clear it. Clearing falls back to "let the
-  // vault auto-assign" (empty string preserves the rc.5 escape valve).
+  // pathOverride is pre-filled with `quickPath()` (notes#126). After save
+  // success, `reset()` regenerates the path so a second capture in the same
+  // mount doesn't collide on the prior second — but ONLY when the operator
+  // hasn't manually edited the value (`pathEditedRef` tracks that). An
+  // empty input at save time reverts to `generatedPathRef.current` (option
+  // d, notes#126 reshape — never falls back to vault-auto-assign). Aaron's
+  // framing: surface the path-gen, don't hide it behind vault magic.
   const [moreFieldsOpen, setMoreFieldsOpen] = useState(moreFieldsOpenDefault);
-  const [pathOverride, setPathOverride] = useState(() => quickPath());
+  const generatedPathRef = useRef(quickPath());
+  const pathEditedRef = useRef(false);
+  const [pathOverride, setPathOverrideRaw] = useState<string>(() => generatedPathRef.current);
+  // Wrap setPathOverride so any user-typed value distinct from the
+  // last-generated path flips the "edited" flag. Restoring the generated
+  // value (or clearing the field) clears the flag.
+  const setPathOverride = useCallback((next: string) => {
+    pathEditedRef.current = next.trim() !== "" && next !== generatedPathRef.current;
+    setPathOverrideRaw(next);
+  }, []);
   const [summary, setSummary] = useState("");
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const [elapsedMs, setElapsedMs] = useState(0);
@@ -204,10 +217,21 @@ export function Capture({
     setContent("");
     setTags([]);
     setTagInput("");
-    // Don't clear pathOverride / summary — the user opened "More fields"
-    // deliberately and may be capturing multiple notes into the same path
-    // (e.g. "Daily/2026-05-12"). They can close the panel or clear the
-    // inputs themselves; resetting silently every time would be surprising.
+    // Path-collision fix (notes#126 reshape, raised in #130 review):
+    // regenerate the default `quickPath()` so a second capture on the same
+    // mount doesn't collide with the first one's second-granularity path.
+    // Only when the operator hasn't manually edited — if they typed an
+    // explicit path (e.g. "Daily/2026-05-12") they probably want to keep
+    // capturing into it. `pathEditedRef` tracks that intent (set by the
+    // setPathOverride wrapper).
+    if (!pathEditedRef.current) {
+      const fresh = quickPath();
+      generatedPathRef.current = fresh;
+      setPathOverrideRaw(fresh);
+    }
+    // Don't clear summary — same reasoning as the audit's "More fields"
+    // deliberate-open: the user is in structured-form mode and silently
+    // resetting their typed summary would be surprising.
     discardAudio();
     textareaRef.current?.focus();
   }, [discardAudio]);
@@ -237,12 +261,23 @@ export function Capture({
 
     const localId = newLocalId();
 
-    // "More fields" overrides: trim once here so empty-after-trim values
-    // don't end up as `path: ""` (vault would reject) or
-    // `metadata.summary: ""` (worthless metadata noise).
-    const pathOverrideValue = pathOverride.trim();
+    // Path resolution (notes#126 reshape, option d): empty input reverts to
+    // the mount-time generated value — clearing the path never hands
+    // generation back to the vault. Summary trim drops empty-string noise.
+    const pathToSave = pathOverride.trim() || generatedPathRef.current;
     const summaryValue = summary.trim();
     const metadata = summaryValue ? { summary: summaryValue } : undefined;
+
+    // Schema-ensure (notes#126 reshape) — fire-and-forget per-session,
+    // per-vault. Idempotent vault-side; refs in schema-ensure.ts gate
+    // repeat calls. Failures don't block the capture; the next save
+    // retries. We DON'T await this — it can race with the create-note
+    // enqueue safely because vault accepts notes with as-yet-unwritten
+    // tag-identity rows (the tag-identity is for hierarchy queries, not
+    // create-note validation).
+    if (client) {
+      void ensureNotesSchema(activeVault.id, client);
+    }
 
     try {
       if (audio) {
@@ -256,11 +291,9 @@ export function Capture({
         const body = hasText
           ? `${content.trim()}\n\n_Transcript pending._\n\n![[${filename}]]\n`
           : `_Transcript pending._\n\n![[${filename}]]\n`;
-        // Path precedence: explicit override > audio-only memo path > let
-        // the vault auto-assign. Override wins on every shape so the user
-        // can place an audio note anywhere they want, including the typed
-        // case (where today we'd let the vault pick).
-        const path = pathOverrideValue || (hasText ? undefined : memoPath(recordedAt));
+        // Option (d): one canonical Notes-side path rule, no phase-dependent
+        // forks. What the operator saw in More fields is what gets written.
+        const path = pathToSave;
 
         if (!blobStore) throw new Error("blob store missing");
         await blobStore.put(blobId, audio.data, audio.mimeType, activeVault.id);
@@ -271,7 +304,7 @@ export function Capture({
             localId,
             payload: {
               content: body,
-              ...(path ? { path } : {}),
+              path,
               ...(finalTags.length ? { tags: finalTags } : {}),
               ...(metadata ? { metadata } : {}),
             },
@@ -308,7 +341,7 @@ export function Capture({
             localId,
             payload: {
               content,
-              ...(pathOverrideValue ? { path: pathOverrideValue } : {}),
+              path: pathToSave,
               ...(finalTags.length ? { tags: finalTags } : {}),
               ...(metadata ? { metadata } : {}),
             },
@@ -350,6 +383,7 @@ export function Capture({
     db,
     activeVault,
     blobStore,
+    client,
     phase,
     hasAudio,
     hasText,
@@ -411,7 +445,10 @@ export function Capture({
       const all = Array.from(
         new Set([roles.captureText, ...explicit, ...extracted].filter((t) => t.length > 0)),
       );
-      const pathValue = pathOverride.trim();
+      // Same path-resolution as save() (option d): trimmed override OR
+      // the mount-time generated path. Never write `path: undefined` to
+      // the queue — the path is always Notes-side.
+      const pathValue = pathOverride.trim() || generatedPathRef.current;
       const summaryValue = summary.trim();
       // Swallow rejections here — we're in the unmount path, so there's no
       // user-visible surface to report a failure (the toaster has already
@@ -426,7 +463,7 @@ export function Capture({
           localId: newLocalId(),
           payload: {
             content,
-            ...(pathValue ? { path: pathValue } : {}),
+            path: pathValue,
             ...(all.length ? { tags: all } : {}),
             ...(summaryValue ? { metadata: { summary: summaryValue } } : {}),
           },
@@ -549,7 +586,7 @@ export function Capture({
                 type="text"
                 value={pathOverride}
                 onChange={(e) => setPathOverride(e.target.value)}
-                placeholder="(blank → vault picks)"
+                placeholder="(blank → uses generated path)"
                 aria-label="Path override"
                 className="rounded-md border border-border bg-card px-2.5 py-1.5 font-mono text-xs text-fg focus:border-accent focus:outline-none"
               />

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -321,6 +321,24 @@ export class VaultClient {
     });
   }
 
+  // Upsert a tag-identity row. `description`, `parent_names`, `fields`,
+  // `relationships` are all field-merged on the vault side — omitted keys
+  // preserve prior values, explicit `null` clears them. Idempotent: calling
+  // with the same payload as-stored is a no-op write. Used by the surface
+  // schema-ensure path (lib/vault/schema.ts → schema-ensure.ts).
+  async updateTag(
+    name: string,
+    body: {
+      description?: string | null;
+      parent_names?: string[] | null;
+    },
+  ): Promise<void> {
+    await this.request<undefined>(`/api/tags/${encodeURIComponent(name)}`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+  }
+
   async renameTag(oldName: string, newName: string): Promise<{ renamed: number }> {
     return this.request<{ renamed: number }>(`/api/tags/${encodeURIComponent(oldName)}/rename`, {
       method: "POST",

--- a/src/lib/vault/schema-ensure.test.ts
+++ b/src/lib/vault/schema-ensure.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VaultClient } from "./client";
+import { NOTES_REQUIRED_SCHEMA } from "./schema";
+import { _resetEnsuredVaultsForTesting, ensureNotesSchema } from "./schema-ensure";
+
+function makeClient(fetchImpl: ReturnType<typeof vi.fn>): VaultClient {
+  return new VaultClient({
+    vaultUrl: "http://localhost:1940",
+    accessToken: "tok_test",
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+describe("ensureNotesSchema", () => {
+  beforeEach(() => {
+    _resetEnsuredVaultsForTesting();
+  });
+  afterEach(() => {
+    _resetEnsuredVaultsForTesting();
+  });
+
+  it("PUTs each required tag in declaration order", async () => {
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const fetchImpl = vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({ url, body: JSON.parse(init.body as string) });
+      return new Response(null, { status: 204 });
+    });
+    const client = makeClient(fetchImpl);
+
+    await ensureNotesSchema("v1", client);
+
+    // One call per declared tag, same order as NOTES_REQUIRED_SCHEMA.tags.
+    expect(calls).toHaveLength(NOTES_REQUIRED_SCHEMA.tags.length);
+    for (let i = 0; i < NOTES_REQUIRED_SCHEMA.tags.length; i++) {
+      const decl = NOTES_REQUIRED_SCHEMA.tags[i]!;
+      const call = calls[i]!;
+      expect(call.url).toBe(`http://localhost:1940/api/tags/${encodeURIComponent(decl.name)}`);
+      expect(call.body).toMatchObject({ description: decl.description });
+      if (decl.parent_names) {
+        expect(call.body).toMatchObject({ parent_names: decl.parent_names });
+      } else {
+        // Parent rows omit parent_names from the payload.
+        expect(call.body).not.toHaveProperty("parent_names");
+      }
+    }
+  });
+
+  it("ensures the `capture` parent BEFORE its children", async () => {
+    const order: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      const match = (url as string).match(/\/api\/tags\/(.+)$/);
+      if (match) order.push(decodeURIComponent(match[1]!));
+      return new Response(null, { status: 204 });
+    });
+    await ensureNotesSchema("v1", makeClient(fetchImpl));
+
+    expect(order[0]).toBe("capture");
+    expect(order.indexOf("capture")).toBeLessThan(order.indexOf("capture/text"));
+    expect(order.indexOf("capture")).toBeLessThan(order.indexOf("capture/voice"));
+  });
+
+  it("is idempotent per-session per-vault (second call within session is a no-op)", async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const client = makeClient(fetchImpl);
+
+    await ensureNotesSchema("v1", client);
+    const callsAfterFirst = fetchImpl.mock.calls.length;
+    expect(callsAfterFirst).toBe(NOTES_REQUIRED_SCHEMA.tags.length);
+
+    // Same vault, same session — guard should block all repeat calls.
+    await ensureNotesSchema("v1", client);
+    expect(fetchImpl.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it("tracks vaults independently — ensures per-vault separately", async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const client = makeClient(fetchImpl);
+
+    await ensureNotesSchema("v1", client);
+    await ensureNotesSchema("v2", client);
+
+    // 2 vaults × N tags each.
+    expect(fetchImpl.mock.calls.length).toBe(NOTES_REQUIRED_SCHEMA.tags.length * 2);
+  });
+
+  it("rolls back the guard on failure so the next call can retry", async () => {
+    let fail = true;
+    const fetchImpl = vi.fn(async () => {
+      if (fail) return new Response("boom", { status: 500 });
+      return new Response(null, { status: 204 });
+    });
+    const client = makeClient(fetchImpl);
+
+    // Suppress the warn so the test output stays clean.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await ensureNotesSchema("v1", client);
+    // First call fired ONE PUT (the parent), then 500'd → no further calls.
+    expect(fetchImpl.mock.calls.length).toBe(1);
+
+    // Flip success, retry — guard should let us through.
+    fail = false;
+    await ensureNotesSchema("v1", client);
+    // Full sweep this time.
+    expect(fetchImpl.mock.calls.length).toBe(1 + NOTES_REQUIRED_SCHEMA.tags.length);
+
+    warnSpy.mockRestore();
+  });
+
+  it("swallows failures (does not throw to caller)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("network down");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureNotesSchema("v1", makeClient(fetchImpl))).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/lib/vault/schema-ensure.ts
+++ b/src/lib/vault/schema-ensure.ts
@@ -1,0 +1,60 @@
+import type { VaultClient } from "./client";
+import { NOTES_REQUIRED_SCHEMA } from "./schema";
+
+// Per-session ref guard so we don't hammer the vault on every capture. The
+// `update-tag` calls are idempotent (already-correct rows are no-op writes
+// vault-side), but there's no point making the network round-trip if we
+// already ensured this vault's schema in this session.
+//
+// Module-level Set rather than a hook because the call sites
+// (Capture's save) are short-lived components and we want the guard to
+// survive remount. localStorage was the alternative but it has the
+// "delete localStorage = re-run forever" failure mode the team-lead
+// flagged — refs in a module are the right scope: ephemeral, but
+// session-stable.
+const ensuredVaults = new Set<string>();
+
+// Surface schema-ensure entry point. Fires the `update-tag` calls for the
+// declared schema (NOTES_REQUIRED_SCHEMA) against the given vault.
+// Idempotent: subsequent calls per (vault, session) are skipped via the
+// module-level guard. First-call failures are logged but not rethrown —
+// schema-ensure is plumbing, not a user-actionable surface; the next
+// capture will retry. If the user needs visibility into schema state,
+// notes#129 will add the audit UI.
+export async function ensureNotesSchema(vaultId: string, client: VaultClient): Promise<void> {
+  if (ensuredVaults.has(vaultId)) return;
+  // Mark as ensured BEFORE the async calls so concurrent invocations don't
+  // race into a double-fire (Capture's save can run in parallel via the
+  // 5s autosave + manual click in the same tick).
+  ensuredVaults.add(vaultId);
+  try {
+    // Sequential rather than Promise.all — vault writes the parent first
+    // so children can resolve `parent_names`. The vault's PUT is permissive
+    // about ordering (children can reference yet-to-exist parents), but
+    // keeping the order matches the conceptual model + makes failure modes
+    // clearer in logs.
+    for (const decl of NOTES_REQUIRED_SCHEMA.tags) {
+      await client.updateTag(decl.name, {
+        description: decl.description,
+        ...(decl.parent_names ? { parent_names: decl.parent_names } : {}),
+      });
+    }
+  } catch (err) {
+    // Roll back the guard so a future capture can retry. Schema-ensure is
+    // best-effort; a transient 5xx shouldn't permanently disable it for the
+    // session.
+    ensuredVaults.delete(vaultId);
+    // Don't rethrow — the capture itself still succeeds without the schema
+    // setup. Log for debugging; notes#129 will surface this in the audit UI.
+    if (typeof console !== "undefined") {
+      console.warn(`[schema-ensure] failed to ensure required schema for vault ${vaultId}:`, err);
+    }
+  }
+}
+
+// Test-only escape hatch — resets the in-session guard so a test can
+// exercise the ensure-once behavior across multiple captures without
+// reloading the module.
+export function _resetEnsuredVaultsForTesting(): void {
+  ensuredVaults.clear();
+}

--- a/src/lib/vault/schema.ts
+++ b/src/lib/vault/schema.ts
@@ -1,0 +1,44 @@
+// Required tag schema Notes ensures exists on the active vault. First instance
+// of patterns#57 (surface-declares-required-schema). Aaron's framing: every
+// note in a vault IS a note, so `#note` is tautological. `#capture`
+// distinguishes notes-the-user-captured from imported / generated / derived
+// ones — that's a real semantic axis.
+//
+// The hierarchy uses vault's `parent_names` column (parachute-vault
+// core/src/tag-hierarchy.ts): a query for `tag: "capture"` auto-expands to
+// notes tagged `capture/text` or `capture/voice`. Future extensions
+// (`capture/photo`, `capture/web-clip`) slot in without rename.
+//
+// Notes "ensures" this schema — doesn't force-migrate the user's stored Tag
+// Role *values*. If a user has `captureText = "quick"` from rc.6, that stays.
+// The ensure call only writes the tag-identity rows; the per-vault setting
+// for which tag to apply on capture is the operator's choice.
+
+export interface RequiredTagDecl {
+  name: string;
+  description: string;
+  parent_names?: string[];
+}
+
+export interface RequiredSchema {
+  tags: readonly RequiredTagDecl[];
+}
+
+export const NOTES_REQUIRED_SCHEMA: RequiredSchema = {
+  tags: [
+    {
+      name: "capture",
+      description: "Notes captured directly by the user (text or voice).",
+    },
+    {
+      name: "capture/text",
+      parent_names: ["capture"],
+      description: "Text capture.",
+    },
+    {
+      name: "capture/voice",
+      parent_names: ["capture"],
+      description: "Voice capture.",
+    },
+  ],
+};

--- a/src/lib/vault/tag-roles.ts
+++ b/src/lib/vault/tag-roles.ts
@@ -27,8 +27,15 @@ export interface TagRoles {
 export const DEFAULT_TAG_ROLES: TagRoles = {
   pinned: "pinned",
   archived: "archived",
-  captureVoice: "voice",
-  captureText: "quick",
+  // captureVoice/captureText default to the hierarchical `capture/*` shape
+  // (notes#126 reshape). The matching parent + parent_names rows are
+  // declared in `NOTES_REQUIRED_SCHEMA` (schema.ts) and ensured on first
+  // capture per session via `ensureNotesSchema()` — so `tag: "capture"`
+  // queries auto-expand to both children. Existing vaults that have stored
+  // "voice"/"quick" in their settings note keep those values (no
+  // force-migrate); only the defaults a fresh vault inherits change here.
+  captureVoice: "capture/voice",
+  captureText: "capture/text",
   view: "view",
 };
 


### PR DESCRIPTION
feat(capture): hierarchical capture/* tags + schema-ensure + option (d) + path-collision fix (0.3.15-rc.8)

Closes notes#126 (reshaped scope per Aaron's design conversation).
Builds on rc.7's `quickPath()` pre-fill (PR #130) with the confirmed
`capture/*` classification model plus three reviewer follow-ups bundled.

## What landed

**Hierarchical capture tags (notes#126 reshape):**

- New file `src/lib/vault/schema.ts` declaring `NOTES_REQUIRED_SCHEMA`:
  - `capture` (parent, no parent_names)
  - `capture/text` (parent_names: ["capture"])
  - `capture/voice` (parent_names: ["capture"])
  First instance of patterns#57 (surface-declares-required-schema).
- `DEFAULT_TAG_ROLES.captureText` → `"capture/text"`,
  `DEFAULT_TAG_ROLES.captureVoice` → `"capture/voice"`. Existing
  vaults preserve their stored values — no force-migrate.

**Idempotent schema-ensure:**

- New `VaultClient.updateTag(name, { description, parent_names })` —
  PUT /api/tags/:name, field-merged vault-side.
- New `src/lib/vault/schema-ensure.ts` exposes `ensureNotesSchema()`.
  Per-vault per-session module-level ref guard so repeated captures
  don't hammer the vault. Failure rolls back the guard so next
  capture retries; success is silent (it's plumbing, not user-
  actionable — notes#129 will add the audit UI).
- Capture wires `ensureNotesSchema(activeVault.id, client)` as a
  fire-and-forget call inside save(). Doesn't block the save or
  surface failures.

**Option (d) bundled** (closed PR #131 absorbed here):

- `pathOverride.trim() || generatedPathRef.current` resolves to
  the mount-time generated value when input is empty. Never falls
  back to vault-picks. The rc.6 `memoPath()` audio-only fallback
  is unreachable and dropped — one canonical Notes-side rule.
- Placeholder text updated: "(blank → vault picks)" → "(blank →
  uses generated path)".

**Path-collision fix** (raised in #130 review):

- `reset()` after successful save now regenerates `quickPath()` and
  updates the input — but only when the operator hasn't manually
  edited (`pathEditedRef`). User-typed paths survive across captures
  on the same mount; auto-generated paths roll forward in time.

## Behavior changes

- Text captures: default tag is `capture/text` instead of `quick`.
- Voice captures: default tag is `capture/voice` instead of `voice`.
- Existing vaults with stored values are NOT migrated — their
  `quick`/`voice` choices stand. Schema-ensure still writes the
  parent + parent_names rows so hierarchy queries work either way.
- Audio captures with cleared path no longer go to `Memos/` — they
  land under `Notes/` like text captures (single canonical rule).
- Two captures within the same wall-clock second no longer collide
  on the auto-generated path.

## Tests

- 6 new in `schema-ensure.test.ts`: declaration-order PUTs,
  parent-before-children, per-session per-vault idempotence,
  multi-vault independence, retry-after-failure, swallow-doesn't-
  throw.
- 2 new in `Capture.test.tsx`: regen-on-reset-when-unedited (with
  fake-timer `setSystemTime` + shouldAdvanceTime for waitFor),
  preserve-user-edit-across-reset.
- 4 existing tests flipped for the default rename + option (d):
  - `"quick"`/`"voice"` → `"capture/text"`/`"capture/voice"` in tag
    assertions.
  - "Empty path → omits path" → "Empty path reverts to generated".
  - "Audio-only cleared path → memoPath" → "Audio-only cleared
    path → generated path".
- `Capture.test.tsx` adds `vi.mock("@/lib/vault/schema-ensure")` so
  capture tests don't hit the real PUT (covered by the dedicated
  schema-ensure tests).

## Not in scope

- Full Settings audit UI + connect-time banner → notes#129.
- Per-vault path-template customization → notes#128.

Gates: 82 test files / 749 tests pass (+8 from rc.7's 741). typecheck
clean, lint clean, build green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

