### PR TITLE
feat(schema): audit UI for the required Notes schema (0.3.15-rc.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 ## Unreleased
 
+### Schema-ensure audit UI — Settings panel + connect-time banner
+
+- **feat(schema): audit UI for the required Notes schema (0.3.15-rc.9).**
+  Closes notes#129. Builds directly on rc.8's `NOTES_REQUIRED_SCHEMA` +
+  `ensureNotesSchema`. Until now schema-ensure was first-capture-driven
+  (idempotent, silent). This PR adds the operator-facing audit: a
+  Settings panel that shows expected-vs-actual for each declared tag, a
+  connect-time banner that surfaces when the active vault is missing or
+  has misaligned tags, and a one-click "Set up missing tags" action.
+  - **`auditSchema(client)`** (`src/lib/vault/schema-audit.ts`) calls
+    `GET /api/tags?include_schema=true` and diffs each declared tag
+    against the vault row. Returns `{ ok, missing, misaligned, rows }`
+    with per-tag `differences: ("description" | "parent_names")[]`.
+    Treats null and empty-array `parent_names` as equivalent.
+  - **`VaultClient.listTagsWithSchema()`** wraps the schema-detail
+    variant of `GET /api/tags`. Narrow return type — only the fields
+    audit reads.
+  - **`fixSchema(vaultId, client)`** in `schema-ensure.ts` is the
+    user-driven entry point. Bypasses the per-session ensure guard
+    (user explicitly asked to write), rethrows on failure so UI can
+    show "fix failed" toast / banner error, and marks the vault as
+    ensured on success so subsequent first-captures don't redo work.
+  - **`useSchemaAuditStore`** (volatile, not persisted) holds per-vault
+    audit results with `ensure(vaultId, client)` (cache-respecting,
+    5min TTL) + `refresh()` (force-refetch) + `set()` (post-fix update
+    without refetch). Mirrors `auth-halt-store` shape.
+  - **`useSchemaBannerStore`** (persisted) tracks per-vault banner
+    dismissal under `notes:schema-banner-dismissed:<vaultId>` so
+    dismissal survives reloads. Mirrors `auth-halt-store` cross-tab
+    pattern.
+  - **`SchemaAuditRunnerMount`** at the App root auto-fires `ensure`
+    when the active vault or its client changes. No DOM, only effect.
+  - **`SchemaAuditBanner`** (`src/components/`) renders below
+    `VaultStatusBanner` — amber/yellow, less urgent than auth-halt or
+    unreachable. Two affordances: "Set up" → calls `fixSchema` then
+    marks the cached audit ok; "Dismiss" → persists per-vault. Uses
+    `<output role="status" aria-live="polite">` rather than `<div
+    role="status">` per Biome's a11y rule.
+  - **Settings "Vault schema" section** (top of the Settings page —
+    above Text size). Status pill (ok = emerald, !ok = amber), per-tag
+    rows showing expected description + parent_names, a "Refresh" link
+    and a "Set up missing tags" button. "Schema updated." toast on
+    success.
+  - **Tests.** 7 new in `schema-audit.test.ts` (ok / missing / desc
+    misalignment / parent_names misalignment / null-vs-empty
+    equivalence / row completeness / extra-tags-don't-flag). 3 new in
+    `schema-ensure.test.ts` (fixSchema bypasses session guard /
+    rethrows on failure / marks ensured after success). 4 new in
+    `schema-banner-store.test.ts` (dismiss + clear + multi-vault +
+    cross-tab reload). 6 new in `SchemaAuditBanner.test.tsx` (renders
+    nothing pre-audit / nothing on ok / renders on misalign / hides
+    when dismissed / Dismiss persists / Set up calls updateTag for
+    each + marks ok).
+
 ### Capture reshape — hierarchical capture/* tags + schema-ensure + option (d) + path-collision fix
 
 - **feat(capture): hierarchical capture tags + schema-ensure + option (d) +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.8",
+  "version": "0.3.15-rc.9",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { BottomTabBar } from "@/components/BottomTabBar";
 import { Header } from "@/components/Header";
 import { QuickSwitchMount } from "@/components/QuickSwitchMount";
+import { SchemaAuditBanner } from "@/components/SchemaAuditBanner";
 import { TextSizeShortcutsMount } from "@/components/TextSizeControl";
 import { Toaster } from "@/components/Toaster";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -10,6 +11,7 @@ import { useVaultStore } from "@/lib/vault";
 import { useCrossTabVaultSync } from "@/lib/vault/cross-tab-sync";
 import { useActiveVaultClient } from "@/lib/vault/queries";
 import { useReachabilityProbe } from "@/lib/vault/reachability-probe";
+import { SchemaAuditRunnerMount } from "@/lib/vault/schema-audit-runner";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { SyncProvider } from "@/providers/SyncProvider";
 import { Suspense, lazy, useEffect } from "react";
@@ -107,12 +109,14 @@ export function App() {
     <QueryProvider>
       <SyncProvider>
         <ReachabilityProbeMount />
+        <SchemaAuditRunnerMount />
         <TextSizeShortcutsMount />
         <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "") || undefined}>
           <div className="min-h-dvh overflow-x-hidden bg-bg text-fg pb-16 md:pb-0">
             <Toaster />
             <UpdateBanner />
             <VaultStatusBanner />
+            <SchemaAuditBanner />
             <Header />
             <QuickSwitchMount />
             <main>

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -18,6 +18,11 @@ import {
   useTags,
   useVaultStore,
 } from "@/lib/vault";
+import { useActiveVaultClient } from "@/lib/vault/queries";
+import type { TagAuditRow } from "@/lib/vault/schema-audit";
+import { useSchemaAuditStore } from "@/lib/vault/schema-audit-store";
+import { useSchemaBannerStore } from "@/lib/vault/schema-banner-store";
+import { fixSchema } from "@/lib/vault/schema-ensure";
 import { useEffect, useId, useMemo, useState } from "react";
 import { Link, Navigate } from "react-router";
 
@@ -41,11 +46,156 @@ export function Settings() {
         </p>
       </header>
 
+      <VaultSchemaSection vaultId={activeVault.id} />
       <TextSizeSection />
       <PathTreeSection vaultId={activeVault.id} />
       <TagRolesSection vaultId={activeVault.id} />
       <InstallStateSection />
     </div>
+  );
+}
+
+// "Vault schema" section (notes#129): surfaces the audit result for the
+// active vault + offers a one-click fix. The audit runs automatically at
+// the App root via `SchemaAuditRunnerMount`; this section reads the cached
+// result and exposes a manual Refresh. The fix path uses `fixSchema` from
+// schema-ensure.ts (bypasses the per-session ensure guard since this is
+// the user explicitly asking us to write).
+function VaultSchemaSection({ vaultId }: { vaultId: string }) {
+  const audit = useSchemaAuditStore((s) => s.byVault[vaultId] ?? null);
+  const refresh = useSchemaAuditStore((s) => s.refresh);
+  const setAudit = useSchemaAuditStore((s) => s.set);
+  const clearDismissed = useSchemaBannerStore((s) => s.clearDismissed);
+  const client = useActiveVaultClient();
+  const pushToast = useToastStore((s) => s.push);
+  const [fixing, setFixing] = useState(false);
+
+  const onRefresh = async () => {
+    if (!client) return;
+    await refresh(vaultId, client);
+  };
+
+  const onFix = async () => {
+    if (!client) return;
+    setFixing(true);
+    try {
+      await fixSchema(vaultId, client);
+      // Update cached audit to ok without a refetch — the fix wrote every
+      // declared row, so the diff resolves clean. Clear the dismissed
+      // flag so a future drift (user-edited tag) re-surfaces the banner.
+      const okRows = audit?.result?.rows.map((r) => ({
+        ...r,
+        status: "ok" as const,
+        differences: [],
+      }));
+      if (okRows) setAudit(vaultId, { ok: true, missing: [], misaligned: [], rows: okRows });
+      clearDismissed(vaultId);
+      pushToast("Schema updated.", "success");
+    } catch (err) {
+      pushToast(
+        err instanceof Error ? `Schema fix failed: ${err.message}` : "Schema fix failed.",
+        "error",
+      );
+    } finally {
+      setFixing(false);
+    }
+  };
+
+  // Pre-audit (mount before runner fires) and error states get a small
+  // status hint rather than a full per-tag table.
+  const isLoading = audit?.loading ?? !audit;
+  const result = audit?.result ?? null;
+  const error = audit?.error ?? null;
+
+  return (
+    <section className="mt-6 space-y-4 rounded-xl border border-border bg-card p-6">
+      <div className="flex items-baseline justify-between gap-3">
+        <div>
+          <h2 className="font-serif text-xl text-fg">Vault schema</h2>
+          <p className="mt-1 text-xs text-fg-dim">
+            Notes declares three tags it uses to classify captures: <code>capture</code>,{" "}
+            <code>capture/text</code>, <code>capture/voice</code>. This panel confirms the active
+            vault has them set up; one click writes any missing or misaligned rows. Doesn't touch
+            your Tag Role choices below.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void onRefresh()}
+          disabled={isLoading || !client}
+          className="shrink-0 text-xs text-fg-dim hover:text-accent disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isLoading ? "Checking…" : "Refresh"}
+        </button>
+      </div>
+
+      {error ? (
+        <p className="rounded-md border border-red-500/30 bg-red-500/5 px-3 py-2 text-xs text-red-300">
+          Audit failed: {error}
+        </p>
+      ) : null}
+
+      {!result && !error ? <p className="text-xs text-fg-dim">Loading audit…</p> : null}
+
+      {result ? (
+        <>
+          <SchemaStatusPill ok={result.ok} />
+          <ul className="space-y-2">
+            {result.rows.map((row) => (
+              <SchemaRow key={row.name} row={row} />
+            ))}
+          </ul>
+          {!result.ok ? (
+            <button
+              type="button"
+              onClick={() => void onFix()}
+              disabled={fixing || !client}
+              className="min-h-11 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {fixing ? "Setting up…" : "Set up missing tags"}
+            </button>
+          ) : null}
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function SchemaStatusPill({ ok }: { ok: boolean }) {
+  return (
+    <p
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs ${
+        ok ? "bg-emerald-500/20 text-emerald-300" : "bg-amber-500/20 text-amber-300"
+      }`}
+    >
+      <span
+        aria-hidden
+        className={`h-1.5 w-1.5 rounded-full ${ok ? "bg-emerald-400" : "bg-amber-400"}`}
+      />
+      {ok ? "Matches Notes' schema" : "Needs setup"}
+    </p>
+  );
+}
+
+function SchemaRow({ row }: { row: TagAuditRow }) {
+  const label = row.status === "ok" ? "ok" : row.status === "missing" ? "missing" : "misaligned";
+  const labelClass = row.status === "ok" ? "text-emerald-300" : "text-amber-300";
+  return (
+    <li className="rounded-md border border-border bg-bg/40 px-3 py-2 text-xs">
+      <div className="flex items-center justify-between gap-2">
+        <code className="font-mono text-sm text-fg">{row.name}</code>
+        <span className={`text-xs ${labelClass}`}>{label}</span>
+      </div>
+      {row.status === "misaligned" ? (
+        <p className="mt-1 text-fg-dim">Differs in: {row.differences.join(", ")}</p>
+      ) : null}
+      <p className="mt-1 text-fg-dim">{row.expected.description}</p>
+      {row.expected.parent_names ? (
+        <p className="text-fg-dim">
+          Parent: <code className="font-mono">{row.expected.parent_names.join(", ")}</code>
+        </p>
+      ) : null}
+    </li>
   );
 }
 

--- a/src/components/SchemaAuditBanner.test.tsx
+++ b/src/components/SchemaAuditBanner.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+import { SchemaAuditBanner } from "@/components/SchemaAuditBanner";
+import { useSchemaAuditStore } from "@/lib/vault/schema-audit-store";
+import { useSchemaBannerStore } from "@/lib/vault/schema-banner-store";
+import { useVaultStore } from "@/lib/vault/store";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The banner uses useActiveVaultClient for the "Set up" button. Stub.
+const mockClient = {
+  updateTag: vi.fn(async () => {}),
+};
+vi.mock("@/lib/vault/queries", () => ({
+  useActiveVaultClient: () => mockClient,
+}));
+
+function seedVault() {
+  useVaultStore.setState({
+    vaults: {
+      v: {
+        id: "v",
+        url: "http://localhost:1940",
+        name: "dev",
+        issuer: "http://localhost:1940",
+        clientId: "c",
+        scope: "full",
+        addedAt: "2026-04-18T00:00:00.000Z",
+        lastUsedAt: "2026-04-18T00:00:00.000Z",
+      },
+    },
+    activeVaultId: "v",
+  });
+}
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <SchemaAuditBanner />
+    </MemoryRouter>,
+  );
+}
+
+describe("SchemaAuditBanner", () => {
+  beforeEach(() => {
+    seedVault();
+    localStorage.clear();
+    useSchemaAuditStore.setState({ byVault: {} });
+    useSchemaBannerStore.setState({ dismissedByVault: {} });
+    mockClient.updateTag.mockClear();
+  });
+  afterEach(() => {
+    useVaultStore.setState({ vaults: {}, activeVaultId: null });
+    localStorage.clear();
+    useSchemaAuditStore.setState({ byVault: {} });
+    useSchemaBannerStore.setState({ dismissedByVault: {} });
+  });
+
+  it("renders nothing when no audit yet", () => {
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when audit ok", () => {
+    useSchemaAuditStore.setState({
+      byVault: {
+        v: {
+          vaultId: "v",
+          result: { ok: true, missing: [], misaligned: [], rows: [] },
+          loading: false,
+          error: null,
+          lastCheckedAt: Date.now(),
+        },
+      },
+    });
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders when audit has misalignments", () => {
+    useSchemaAuditStore.setState({
+      byVault: {
+        v: {
+          vaultId: "v",
+          result: {
+            ok: false,
+            missing: [
+              {
+                name: "capture",
+                status: "missing",
+                expected: { name: "capture", description: "x" },
+                actual: null,
+                differences: [],
+              },
+            ],
+            misaligned: [],
+            rows: [],
+          },
+          loading: false,
+          error: null,
+          lastCheckedAt: Date.now(),
+        },
+      },
+    });
+    renderBanner();
+    expect(screen.getByText(/vault schema needs setup/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /set up/i })).toBeInTheDocument();
+  });
+
+  it("hides when dismissed for that vault", () => {
+    useSchemaAuditStore.setState({
+      byVault: {
+        v: {
+          vaultId: "v",
+          result: {
+            ok: false,
+            missing: [
+              {
+                name: "capture",
+                status: "missing",
+                expected: { name: "capture", description: "x" },
+                actual: null,
+                differences: [],
+              },
+            ],
+            misaligned: [],
+            rows: [],
+          },
+          loading: false,
+          error: null,
+          lastCheckedAt: Date.now(),
+        },
+      },
+    });
+    useSchemaBannerStore.setState({ dismissedByVault: { v: true } });
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("Dismiss persists per-vault to localStorage", () => {
+    useSchemaAuditStore.setState({
+      byVault: {
+        v: {
+          vaultId: "v",
+          result: {
+            ok: false,
+            missing: [
+              {
+                name: "capture",
+                status: "missing",
+                expected: { name: "capture", description: "x" },
+                actual: null,
+                differences: [],
+              },
+            ],
+            misaligned: [],
+            rows: [],
+          },
+          loading: false,
+          error: null,
+          lastCheckedAt: Date.now(),
+        },
+      },
+    });
+    renderBanner();
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(useSchemaBannerStore.getState().dismissedByVault.v).toBe(true);
+  });
+
+  it("Set up calls updateTag for each declared tag, marks ok in store", async () => {
+    useSchemaAuditStore.setState({
+      byVault: {
+        v: {
+          vaultId: "v",
+          result: {
+            ok: false,
+            missing: [
+              {
+                name: "capture",
+                status: "missing",
+                expected: { name: "capture", description: "x" },
+                actual: null,
+                differences: [],
+              },
+            ],
+            misaligned: [],
+            rows: [
+              {
+                name: "capture",
+                status: "missing",
+                expected: { name: "capture", description: "x" },
+                actual: null,
+                differences: [],
+              },
+              {
+                name: "capture/text",
+                status: "missing",
+                expected: { name: "capture/text", description: "y", parent_names: ["capture"] },
+                actual: null,
+                differences: [],
+              },
+              {
+                name: "capture/voice",
+                status: "missing",
+                expected: { name: "capture/voice", description: "z", parent_names: ["capture"] },
+                actual: null,
+                differences: [],
+              },
+            ],
+          },
+          loading: false,
+          error: null,
+          lastCheckedAt: Date.now(),
+        },
+      },
+    });
+    renderBanner();
+    fireEvent.click(screen.getByRole("button", { name: /set up/i }));
+
+    await waitFor(() => {
+      expect(useSchemaAuditStore.getState().byVault.v?.result?.ok).toBe(true);
+    });
+    // Three required tags → three PUTs (capture, capture/text, capture/voice).
+    expect(mockClient.updateTag).toHaveBeenCalledTimes(3);
+    // After fix, banner should disappear.
+    expect(screen.queryByText(/vault schema needs setup/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/SchemaAuditBanner.tsx
+++ b/src/components/SchemaAuditBanner.tsx
@@ -1,0 +1,120 @@
+import { useActiveVaultClient } from "@/lib/vault/queries";
+import { useSchemaAuditStore } from "@/lib/vault/schema-audit-store";
+import { useSchemaBannerStore } from "@/lib/vault/schema-banner-store";
+import { fixSchema } from "@/lib/vault/schema-ensure";
+import { useVaultStore } from "@/lib/vault/store";
+import { useState } from "react";
+import { Link } from "react-router";
+
+// Connect-time banner for notes#129. Surfaces when the active vault's
+// schema audit comes back `!ok` and the operator hasn't dismissed it.
+//
+// Renders BELOW `VaultStatusBanner` (auth-halt + unreachable) so the
+// stack reads: critical-vault-down > auth-needs-reconnect > schema-
+// out-of-date. Schema misalignment doesn't break capture (the per-
+// capture ensure still runs), so it shouldn't block higher-priority
+// recovery actions.
+//
+// Two affordances:
+//   - "Set up" → calls `fixSchema` (the user-driven entry point in
+//     schema-ensure.ts, which bypasses the per-session guard). On
+//     success, re-audit + dismiss. On failure, log + leave banner up.
+//   - "Dismiss" → persist per-vault to localStorage. The Settings panel
+//     still surfaces the audit state for the operator who wants to
+//     return to it later.
+
+export function SchemaAuditBanner() {
+  const activeVaultId = useVaultStore((s) => s.activeVaultId);
+  const audit = useSchemaAuditStore((s) =>
+    activeVaultId ? (s.byVault[activeVaultId] ?? null) : null,
+  );
+  const setAudit = useSchemaAuditStore((s) => s.set);
+  const dismissed = useSchemaBannerStore((s) =>
+    activeVaultId ? !!s.dismissedByVault[activeVaultId] : false,
+  );
+  const dismiss = useSchemaBannerStore((s) => s.dismiss);
+  const client = useActiveVaultClient();
+  const [fixing, setFixing] = useState(false);
+  const [fixError, setFixError] = useState<string | null>(null);
+
+  // Render conditions — keep the banner out of the DOM whenever
+  // possible so screen readers don't get a brief flash before the
+  // audit lands.
+  if (!activeVaultId) return null;
+  if (!audit?.result) return null; // No audit yet — wait for it.
+  if (audit.result.ok) return null;
+  if (dismissed) return null;
+
+  const missingCount = audit.result.missing.length;
+  const misalignedCount = audit.result.misaligned.length;
+
+  async function onSetUp() {
+    if (!client || !activeVaultId) return;
+    setFixing(true);
+    setFixError(null);
+    try {
+      await fixSchema(activeVaultId, client);
+      // Replace the cached audit with a known-ok result instead of
+      // re-fetching — the fix wrote every declared row, so we know the
+      // shape now. Saves a round-trip; the Settings panel's "Refresh"
+      // button is the explicit re-verify if the operator wants it.
+      setAudit(activeVaultId, {
+        ok: true,
+        missing: [],
+        misaligned: [],
+        rows: audit?.result?.rows.map((r) => ({ ...r, status: "ok", differences: [] })) ?? [],
+      });
+    } catch (err) {
+      setFixError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setFixing(false);
+    }
+  }
+
+  return (
+    // <output> carries an implicit `role="status"` (Biome's preferred form
+    // over `<div role="status">`) and aria-live="polite". `RouteFallback`
+    // uses the same shape — see App.tsx.
+    <output
+      aria-live="polite"
+      className="block border-b border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-200 md:px-6"
+    >
+      <div className="mx-auto flex max-w-5xl flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="font-medium text-amber-100">Vault schema needs setup</p>
+          <p className="text-xs text-amber-200/80">
+            {missingCount > 0 && misalignedCount > 0
+              ? `${missingCount} missing, ${misalignedCount} misaligned`
+              : missingCount > 0
+                ? `${missingCount} missing tag${missingCount === 1 ? "" : "s"} Notes uses`
+                : `${misalignedCount} tag${misalignedCount === 1 ? "" : "s"} need realignment`}{" "}
+            (capture / capture/text / capture/voice).{" "}
+            <Link to="/settings" className="underline hover:text-amber-100">
+              Review in Settings
+            </Link>
+            .
+          </p>
+          {fixError ? <p className="mt-1 text-xs text-red-300">{fixError}</p> : null}
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => void onSetUp()}
+            disabled={fixing || !client}
+            className="min-h-11 self-start rounded-md bg-amber-500/30 px-3 py-1.5 text-xs font-medium text-amber-50 hover:bg-amber-500/50 disabled:cursor-not-allowed disabled:opacity-60 md:self-auto"
+          >
+            {fixing ? "Setting up…" : "Set up"}
+          </button>
+          <button
+            type="button"
+            onClick={() => dismiss(activeVaultId)}
+            className="min-h-11 self-start rounded-md px-3 py-1.5 text-xs text-amber-200/80 hover:text-amber-100 md:self-auto"
+            aria-label="Dismiss schema setup banner"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </output>
+  );
+}

--- a/src/lib/vault/client.ts
+++ b/src/lib/vault/client.ts
@@ -315,6 +315,20 @@ export class VaultClient {
     return this.request<TagSummary[]>("/api/tags");
   }
 
+  // Same as listTags but with the full tag-identity record per row
+  // (description, parent_names, etc). Used by the schema-audit path
+  // (notes#129) to diff vault state against `NOTES_REQUIRED_SCHEMA`.
+  async listTagsWithSchema(): Promise<
+    Array<{
+      name: string;
+      count: number;
+      description: string | null;
+      parent_names: string[] | null;
+    }>
+  > {
+    return this.request("/api/tags?include_schema=true");
+  }
+
   async deleteTag(name: string): Promise<void> {
     await this.request<undefined>(`/api/tags/${encodeURIComponent(name)}`, {
       method: "DELETE",

--- a/src/lib/vault/cross-tab-sync.test.tsx
+++ b/src/lib/vault/cross-tab-sync.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AUTH_HALT_KEY_PREFIX, useAuthHaltStore } from "./auth-halt-store";
 import { useCrossTabVaultSync } from "./cross-tab-sync";
+import { SCHEMA_BANNER_KEY_PREFIX, useSchemaBannerStore } from "./schema-banner-store";
 import { ACTIVE_KEY, VAULTS_KEY } from "./storage";
 import { useVaultStore } from "./store";
 import type { VaultRecord } from "./types";
@@ -33,12 +34,14 @@ describe("useCrossTabVaultSync", () => {
     localStorage.clear();
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
     useAuthHaltStore.setState({ byVault: {} });
+    useSchemaBannerStore.setState({ dismissedByVault: {} });
   });
 
   afterEach(() => {
     localStorage.clear();
     useVaultStore.setState({ vaults: {}, activeVaultId: null });
     useAuthHaltStore.setState({ byVault: {} });
+    useSchemaBannerStore.setState({ dismissedByVault: {} });
   });
 
   it("picks up active-vault changes written by another tab", () => {
@@ -76,10 +79,24 @@ describe("useCrossTabVaultSync", () => {
     expect(useAuthHaltStore.getState().byVault.v1?.reason).toBe("from sibling tab");
   });
 
+  it("picks up schema-banner dismissals written by another tab (notes#129)", () => {
+    // Sibling tab dismissed the schema-audit banner for `v1`. The reload-
+    // from-storage path mirrors auth-halt-store's shape — same one-line
+    // fix that wired in PR #133's F1 fold.
+    localStorage.setItem(`${SCHEMA_BANNER_KEY_PREFIX}v1`, "1");
+
+    renderHook(() => useCrossTabVaultSync());
+
+    expect(useSchemaBannerStore.getState().dismissedByVault.v1).toBeUndefined();
+    fireStorageEvent(`${SCHEMA_BANNER_KEY_PREFIX}v1`, "1");
+    expect(useSchemaBannerStore.getState().dismissedByVault.v1).toBe(true);
+  });
+
   it("handles a wholesale localStorage.clear() by reloading every mirrored slice", () => {
     // Seed the store with state, then simulate a sibling clearing storage.
     useVaultStore.setState({ vaults: { v1: makeVault("v1") }, activeVaultId: "v1" });
     useAuthHaltStore.setState({ byVault: { v1: { vaultId: "v1", reason: "stale", at: 0 } } });
+    useSchemaBannerStore.setState({ dismissedByVault: { v1: true } });
 
     renderHook(() => useCrossTabVaultSync());
     fireStorageEvent(null, null);
@@ -87,17 +104,20 @@ describe("useCrossTabVaultSync", () => {
     expect(useVaultStore.getState().vaults).toEqual({});
     expect(useVaultStore.getState().activeVaultId).toBeNull();
     expect(useAuthHaltStore.getState().byVault).toEqual({});
+    expect(useSchemaBannerStore.getState().dismissedByVault).toEqual({});
   });
 
   it("ignores unrelated keys", () => {
     renderHook(() => useCrossTabVaultSync());
     const before = useVaultStore.getState();
     const beforeHalt = useAuthHaltStore.getState();
+    const beforeBanner = useSchemaBannerStore.getState();
 
     fireStorageEvent("some-other-app:setting", "value");
 
     expect(useVaultStore.getState()).toBe(before);
     expect(useAuthHaltStore.getState()).toBe(beforeHalt);
+    expect(useSchemaBannerStore.getState()).toBe(beforeBanner);
   });
 
   it("removes the listener on unmount", () => {

--- a/src/lib/vault/cross-tab-sync.ts
+++ b/src/lib/vault/cross-tab-sync.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { AUTH_HALT_KEY_PREFIX, useAuthHaltStore } from "./auth-halt-store";
+import { SCHEMA_BANNER_KEY_PREFIX, useSchemaBannerStore } from "./schema-banner-store";
 import { ACTIVE_KEY, VAULTS_KEY, loadActiveVaultId, loadVaults } from "./storage";
 import { useVaultStore } from "./store";
 
@@ -11,11 +12,14 @@ import { useVaultStore } from "./store";
 // save.
 //
 // Keys we mirror:
-//   - lens:vaults           (full vault list)
-//   - lens:active_vault     (active vault id; vault-switch-aware components
-//                            (QuickSwitchMount etc.) react via existing hooks)
-//   - lens:auth-halt:<id>   (per-vault auth halt; reload entire halt store
-//                            because there's no per-key removal in zustand)
+//   - lens:vaults                       (full vault list)
+//   - lens:active_vault                 (active vault id; vault-switch-aware
+//                                        components react via existing hooks)
+//   - lens:auth-halt:<id>               (per-vault auth halt; reload entire
+//                                        halt store because there's no per-
+//                                        key removal in zustand)
+//   - notes:schema-banner-dismissed:<id> (per-vault schema-banner dismissal
+//                                        from notes#129 — same pattern)
 
 export function useCrossTabVaultSync(): void {
   useEffect(() => {
@@ -29,6 +33,7 @@ export function useCrossTabVaultSync(): void {
           activeVaultId: loadActiveVaultId(),
         });
         useAuthHaltStore.getState().reloadFromStorage();
+        useSchemaBannerStore.getState().reloadFromStorage();
         return;
       }
       if (e.key === ACTIVE_KEY) {
@@ -41,6 +46,10 @@ export function useCrossTabVaultSync(): void {
       }
       if (e.key.startsWith(AUTH_HALT_KEY_PREFIX)) {
         useAuthHaltStore.getState().reloadFromStorage();
+        return;
+      }
+      if (e.key.startsWith(SCHEMA_BANNER_KEY_PREFIX)) {
+        useSchemaBannerStore.getState().reloadFromStorage();
         return;
       }
     }

--- a/src/lib/vault/schema-audit-runner.ts
+++ b/src/lib/vault/schema-audit-runner.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useActiveVaultClient } from "./queries";
+import { useSchemaAuditStore } from "./schema-audit-store";
+import { useVaultStore } from "./store";
+
+// Auto-runs the schema audit when the active vault (or its client)
+// changes. Wired once at the App root via `<SchemaAuditRunnerMount />` —
+// no DOM, only an effect — so the Settings panel and the connect-time
+// banner can both read the cached result without re-fetching. Uses the
+// store's `ensure` (cache-respecting); manual refresh in Settings calls
+// `refresh` directly.
+export function useSchemaAuditRunner(): void {
+  const activeVaultId = useVaultStore((s) => s.activeVaultId);
+  const client = useActiveVaultClient();
+  const ensure = useSchemaAuditStore((s) => s.ensure);
+
+  useEffect(() => {
+    if (!activeVaultId || !client) return;
+    void ensure(activeVaultId, client);
+  }, [activeVaultId, client, ensure]);
+}
+
+export function SchemaAuditRunnerMount(): null {
+  useSchemaAuditRunner();
+  return null;
+}

--- a/src/lib/vault/schema-audit-store.ts
+++ b/src/lib/vault/schema-audit-store.ts
@@ -1,0 +1,134 @@
+import { create } from "zustand";
+import type { VaultClient } from "./client";
+import { type SchemaAuditResult, auditSchema } from "./schema-audit";
+
+// Volatile per-vault audit result. NOT persisted — runs fresh on every
+// vault add / switch / manual refresh. The persisted state (whether the
+// banner is dismissed) lives in `schema-banner-store.ts`.
+//
+// Mirror of `auth-halt-store` shape: per-vault entries, three methods
+// (run, refresh, clear). The "loading" state is per-vault rather than a
+// single boolean because a fast vault-switch could overlap audits on
+// two different vault ids.
+
+export interface SchemaAuditEntry {
+  vaultId: string;
+  // Most recent result. `null` while the first audit is in flight.
+  result: SchemaAuditResult | null;
+  // True while a fetch is in flight. UI uses this for the spinner /
+  // disabled state on the Refresh button.
+  loading: boolean;
+  // Set when the fetch errors (network failure, 401 before refresh).
+  // The Settings panel shows it; the connect-time banner stays hidden
+  // (no banner is better than a misleading one).
+  error: string | null;
+  // Wall-clock ms of the most recent successful result. UI shows
+  // "Last checked: 2 min ago" for the operator.
+  lastCheckedAt: number | null;
+}
+
+interface SchemaAuditState {
+  byVault: Record<string, SchemaAuditEntry>;
+  // Run-or-skip: if the cached result is fresh enough (default 5 min) and
+  // matches the requested vault, returns the existing entry without
+  // re-fetching. Connect-time banner + Settings auto-load use this.
+  ensure: (vaultId: string, client: VaultClient) => Promise<void>;
+  // Force a fresh audit regardless of cache age. Settings "Refresh" button.
+  refresh: (vaultId: string, client: VaultClient) => Promise<void>;
+  // Drop a vault's entry (e.g. on vault removal).
+  clear: (vaultId: string) => void;
+  // Replace an entry directly — used by the fix path so the post-fix
+  // re-audit's result becomes the canonical entry without going through
+  // a second `auditSchema` call.
+  set: (vaultId: string, result: SchemaAuditResult) => void;
+}
+
+const FRESH_MS = 5 * 60 * 1_000;
+
+function startEntry(prev: SchemaAuditEntry | undefined, vaultId: string): SchemaAuditEntry {
+  return {
+    vaultId,
+    result: prev?.result ?? null,
+    loading: true,
+    error: null,
+    lastCheckedAt: prev?.lastCheckedAt ?? null,
+  };
+}
+
+async function runAudit(
+  vaultId: string,
+  client: VaultClient,
+  set: (updater: (s: SchemaAuditState) => Partial<SchemaAuditState>) => void,
+): Promise<void> {
+  try {
+    const result = await auditSchema(client);
+    set((s) => ({
+      byVault: {
+        ...s.byVault,
+        [vaultId]: {
+          vaultId,
+          result,
+          loading: false,
+          error: null,
+          lastCheckedAt: Date.now(),
+        },
+      },
+    }));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    set((s) => ({
+      byVault: {
+        ...s.byVault,
+        [vaultId]: {
+          ...(s.byVault[vaultId] ?? startEntry(undefined, vaultId)),
+          loading: false,
+          error: message,
+        },
+      },
+    }));
+  }
+}
+
+export const useSchemaAuditStore = create<SchemaAuditState>((set, get) => ({
+  byVault: {},
+
+  async ensure(vaultId, client) {
+    const existing = get().byVault[vaultId];
+    if (existing?.result && existing.lastCheckedAt) {
+      if (Date.now() - existing.lastCheckedAt < FRESH_MS) return;
+    }
+    if (existing?.loading) return;
+    set((s) => ({ byVault: { ...s.byVault, [vaultId]: startEntry(existing, vaultId) } }));
+    await runAudit(vaultId, client, set);
+  },
+
+  async refresh(vaultId, client) {
+    const existing = get().byVault[vaultId];
+    if (existing?.loading) return;
+    set((s) => ({ byVault: { ...s.byVault, [vaultId]: startEntry(existing, vaultId) } }));
+    await runAudit(vaultId, client, set);
+  },
+
+  clear(vaultId) {
+    set((s) => {
+      if (!(vaultId in s.byVault)) return s;
+      const { [vaultId]: _removed, ...rest } = s.byVault;
+      return { byVault: rest };
+    });
+  },
+
+  set(vaultId, result) {
+    set((s) => ({
+      byVault: {
+        ...s.byVault,
+        [vaultId]: {
+          vaultId,
+          result,
+          loading: false,
+          error: null,
+          lastCheckedAt: Date.now(),
+        },
+      },
+    }));
+  },
+}));

--- a/src/lib/vault/schema-audit.test.ts
+++ b/src/lib/vault/schema-audit.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { VaultClient } from "./client";
+import { NOTES_REQUIRED_SCHEMA } from "./schema";
+import { auditSchema } from "./schema-audit";
+
+function makeClient(rows: unknown[]): VaultClient {
+  const fetchImpl = vi.fn(async () => {
+    return new Response(JSON.stringify(rows), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  return new VaultClient({
+    vaultUrl: "http://localhost:1940",
+    accessToken: "tok_test",
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+// Helper — every test starts with the canonical "ok" shape and then
+// mutates one row to exercise the diff branches.
+function okShape() {
+  return NOTES_REQUIRED_SCHEMA.tags.map((decl) => ({
+    name: decl.name,
+    count: 0,
+    description: decl.description,
+    parent_names: decl.parent_names ?? null,
+  }));
+}
+
+describe("auditSchema", () => {
+  it("returns ok=true when every declared tag matches", async () => {
+    const client = makeClient(okShape());
+    const result = await auditSchema(client);
+    expect(result.ok).toBe(true);
+    expect(result.missing).toHaveLength(0);
+    expect(result.misaligned).toHaveLength(0);
+    for (const row of result.rows) {
+      expect(row.status).toBe("ok");
+      expect(row.differences).toEqual([]);
+    }
+  });
+
+  it("detects a missing tag", async () => {
+    // Vault doesn't have `capture/voice` yet.
+    const rows = okShape().filter((r) => r.name !== "capture/voice");
+    const client = makeClient(rows);
+    const result = await auditSchema(client);
+    expect(result.ok).toBe(false);
+    expect(result.missing).toHaveLength(1);
+    expect(result.missing[0]?.name).toBe("capture/voice");
+    expect(result.misaligned).toHaveLength(0);
+  });
+
+  it("detects misaligned description", async () => {
+    const rows = okShape();
+    rows[0]!.description = "something else";
+    const client = makeClient(rows);
+    const result = await auditSchema(client);
+    expect(result.ok).toBe(false);
+    expect(result.misaligned).toHaveLength(1);
+    expect(result.misaligned[0]?.name).toBe(rows[0]!.name);
+    expect(result.misaligned[0]?.differences).toContain("description");
+  });
+
+  it("detects misaligned parent_names", async () => {
+    const rows = okShape();
+    // `capture/text` declares parent_names: ["capture"]. Mutate to wrong parent.
+    const captureText = rows.find((r) => r.name === "capture/text")!;
+    captureText.parent_names = ["note"];
+    const client = makeClient(rows);
+    const result = await auditSchema(client);
+    expect(result.ok).toBe(false);
+    expect(result.misaligned).toHaveLength(1);
+    expect(result.misaligned[0]?.name).toBe("capture/text");
+    expect(result.misaligned[0]?.differences).toContain("parent_names");
+  });
+
+  it("treats null and empty-array parent_names as equivalent for parent tags", async () => {
+    // Parent `capture` declares no parent_names. Vault could store the
+    // column as `null` OR `[]` — both mean "no parents". Both must pass.
+    const rows = okShape();
+    const capture = rows.find((r) => r.name === "capture")!;
+    capture.parent_names = [];
+    const client = makeClient(rows);
+    const result = await auditSchema(client);
+    expect(result.ok).toBe(true);
+  });
+
+  it("includes every declared tag in `rows` regardless of status", async () => {
+    const rows = okShape().filter((r) => r.name !== "capture/voice");
+    const client = makeClient(rows);
+    const result = await auditSchema(client);
+    expect(result.rows).toHaveLength(NOTES_REQUIRED_SCHEMA.tags.length);
+    const names = result.rows.map((r) => r.name);
+    for (const decl of NOTES_REQUIRED_SCHEMA.tags) {
+      expect(names).toContain(decl.name);
+    }
+  });
+
+  it("does not flag extra vault tags (user-owned tags are not audited)", async () => {
+    // A vault that has the required schema PLUS the user's own tags
+    // (e.g. "pinned", "voice" leftover from rc.6) must still come back ok.
+    // Audit is narrow — surface-required only.
+    const rows = [
+      ...okShape(),
+      { name: "pinned", count: 5, description: null, parent_names: null },
+      { name: "voice", count: 3, description: null, parent_names: null },
+    ];
+    const client = makeClient(rows);
+    const result = await auditSchema(client);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/lib/vault/schema-audit.ts
+++ b/src/lib/vault/schema-audit.ts
@@ -1,0 +1,108 @@
+import type { VaultClient } from "./client";
+import { NOTES_REQUIRED_SCHEMA, type RequiredTagDecl } from "./schema";
+
+// Audit helper for notes#129 — compare the vault's current tag schema
+// against `NOTES_REQUIRED_SCHEMA` and return a structured diff. Powers
+// the Settings panel (per-tag rows + one-click fix) AND the connect-time
+// banner. Idempotent + side-effect free — the fix path goes through
+// `ensureNotesSchema()` (which re-uses the audit's misaligned set).
+//
+// Distinguished from `schema-ensure.ts` so this module can be imported
+// without dragging in the per-session ref guard. The audit is read-only;
+// ensure is a write.
+
+// One tag row from `GET /api/tags?include_schema=true`. Notes only needs
+// the identity fields the audit compares against — `description` and
+// `parent_names`. The vault returns more (`fields`, `relationships`,
+// `created_at`, etc.) but they're not part of `NOTES_REQUIRED_SCHEMA`.
+export interface TagSchemaRow {
+  name: string;
+  count?: number;
+  description?: string | null;
+  parent_names?: string[] | null;
+}
+
+// Per-tag audit verdict. `missing` if the vault has no row for the
+// declared name; `misaligned` if the row exists but doesn't match the
+// expected description/parent_names; `ok` otherwise.
+export type TagAuditStatus = "missing" | "misaligned" | "ok";
+
+export interface TagAuditRow {
+  name: string;
+  status: TagAuditStatus;
+  expected: RequiredTagDecl;
+  // `null` when missing; the vault row otherwise. UI shows expected-vs-
+  // actual side by side for misaligned.
+  actual: TagSchemaRow | null;
+  // Concrete fields that differ. Empty for `ok` and `missing` (everything
+  // is a difference when missing — the UI shows expected only).
+  differences: ("description" | "parent_names")[];
+}
+
+export interface SchemaAuditResult {
+  // True when every declared tag has status `ok`. The UI surfaces this
+  // as the green-or-yellow status indicator.
+  ok: boolean;
+  // Pre-split for cheap rendering — UI groups by status anyway.
+  missing: TagAuditRow[];
+  misaligned: TagAuditRow[];
+  rows: TagAuditRow[];
+}
+
+// String[] equality with null/undefined normalization. `parent_names: null`
+// from vault means "no parents"; `[]` means same thing. Schema declares
+// either `["capture"]` or nothing — normalize both sides before compare.
+function parentNamesEqual(a: string[] | null | undefined, b: string[] | null | undefined): boolean {
+  const av = a ?? [];
+  const bv = b ?? [];
+  if (av.length !== bv.length) return false;
+  // Order matters semantically (the vault stores them as an array) but
+  // both Notes and any same-pattern client emit them in the order the
+  // schema declares. If we ever support multiple parents and ordering
+  // becomes meaningful, this assertion stands.
+  for (let i = 0; i < av.length; i++) {
+    if (av[i] !== bv[i]) return false;
+  }
+  return true;
+}
+
+function diffOne(decl: RequiredTagDecl, row: TagSchemaRow | undefined): TagAuditRow {
+  if (!row) {
+    return {
+      name: decl.name,
+      status: "missing",
+      expected: decl,
+      actual: null,
+      differences: [],
+    };
+  }
+  const differences: ("description" | "parent_names")[] = [];
+  if ((row.description ?? "") !== decl.description) differences.push("description");
+  const expectedParents = decl.parent_names ?? null;
+  if (!parentNamesEqual(row.parent_names, expectedParents)) differences.push("parent_names");
+  return {
+    name: decl.name,
+    status: differences.length === 0 ? "ok" : "misaligned",
+    expected: decl,
+    actual: row,
+    differences,
+  };
+}
+
+// Fetches the vault's tag schema and diffs against `NOTES_REQUIRED_SCHEMA`.
+// Network failures bubble — callers decide whether to retry / surface in
+// UI. The Settings panel renders an error state; the connect-time banner
+// silently skips (no banner is better than a misleading one).
+export async function auditSchema(client: VaultClient): Promise<SchemaAuditResult> {
+  const rows = await client.listTagsWithSchema();
+  const byName = new Map(rows.map((r) => [r.name, r] as const));
+  const audited = NOTES_REQUIRED_SCHEMA.tags.map((decl) => diffOne(decl, byName.get(decl.name)));
+  const missing = audited.filter((r) => r.status === "missing");
+  const misaligned = audited.filter((r) => r.status === "misaligned");
+  return {
+    ok: missing.length === 0 && misaligned.length === 0,
+    missing,
+    misaligned,
+    rows: audited,
+  };
+}

--- a/src/lib/vault/schema-banner-store.test.ts
+++ b/src/lib/vault/schema-banner-store.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SCHEMA_BANNER_KEY_PREFIX, useSchemaBannerStore } from "./schema-banner-store";
+
+describe("useSchemaBannerStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSchemaBannerStore.setState({ dismissedByVault: {} });
+  });
+  afterEach(() => {
+    localStorage.clear();
+    useSchemaBannerStore.setState({ dismissedByVault: {} });
+  });
+
+  it("dismiss persists to localStorage + updates the store", () => {
+    useSchemaBannerStore.getState().dismiss("v1");
+    expect(useSchemaBannerStore.getState().dismissedByVault.v1).toBe(true);
+    expect(localStorage.getItem(`${SCHEMA_BANNER_KEY_PREFIX}v1`)).toBe("1");
+  });
+
+  it("clearDismissed removes the flag from both store and localStorage", () => {
+    useSchemaBannerStore.getState().dismiss("v1");
+    expect(useSchemaBannerStore.getState().dismissedByVault.v1).toBe(true);
+
+    useSchemaBannerStore.getState().clearDismissed("v1");
+    expect(useSchemaBannerStore.getState().dismissedByVault.v1).toBeUndefined();
+    expect(localStorage.getItem(`${SCHEMA_BANNER_KEY_PREFIX}v1`)).toBeNull();
+  });
+
+  it("tracks vaults independently", () => {
+    useSchemaBannerStore.getState().dismiss("v1");
+    useSchemaBannerStore.getState().dismiss("v2");
+    expect(useSchemaBannerStore.getState().dismissedByVault.v1).toBe(true);
+    expect(useSchemaBannerStore.getState().dismissedByVault.v2).toBe(true);
+
+    useSchemaBannerStore.getState().clearDismissed("v1");
+    expect(useSchemaBannerStore.getState().dismissedByVault.v1).toBeUndefined();
+    expect(useSchemaBannerStore.getState().dismissedByVault.v2).toBe(true);
+  });
+
+  it("reloadFromStorage picks up entries written by another tab", () => {
+    localStorage.setItem(`${SCHEMA_BANNER_KEY_PREFIX}v1`, "1");
+    expect(useSchemaBannerStore.getState().dismissedByVault.v1).toBeUndefined();
+    useSchemaBannerStore.getState().reloadFromStorage();
+    expect(useSchemaBannerStore.getState().dismissedByVault.v1).toBe(true);
+  });
+});

--- a/src/lib/vault/schema-banner-store.ts
+++ b/src/lib/vault/schema-banner-store.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+
+// Per-vault dismissal state for the schema-audit connect-time banner
+// (notes#129). When the audit comes back `!ok` and the user dismisses,
+// we want it to stay dismissed across reloads — so this lives in
+// localStorage. The schema-audit result itself is volatile (re-runs on
+// every mount or vault switch) and lives in `schema-audit-store.ts`.
+//
+// Mirrors `auth-halt-store.ts` shape: per-vault entries, persisted to
+// localStorage under a fixed prefix, cross-tab synced via the storage
+// event (cross-tab-sync.ts dispatches reloadFromStorage for the right
+// prefix).
+
+const DISMISSED_PREFIX = "notes:schema-banner-dismissed:";
+
+interface SchemaBannerState {
+  dismissedByVault: Record<string, boolean>;
+  dismiss: (vaultId: string) => void;
+  // Used after a successful fix: clear so a future re-audit that surfaces
+  // a NEW misalignment (e.g. user edited the tag manually in vault) re-
+  // raises the banner.
+  clearDismissed: (vaultId: string) => void;
+  reloadFromStorage: () => void;
+}
+
+function readAllFromStorage(): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  if (typeof localStorage === "undefined") return out;
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key?.startsWith(DISMISSED_PREFIX)) continue;
+      const vaultId = key.slice(DISMISSED_PREFIX.length);
+      if (vaultId) out[vaultId] = true;
+    }
+  } catch {
+    // localStorage unavailable (privacy mode) — best-effort.
+  }
+  return out;
+}
+
+export const useSchemaBannerStore = create<SchemaBannerState>((set) => ({
+  dismissedByVault: readAllFromStorage(),
+
+  dismiss(vaultId) {
+    try {
+      localStorage.setItem(DISMISSED_PREFIX + vaultId, "1");
+    } catch {
+      // Best-effort.
+    }
+    set((s) => ({ dismissedByVault: { ...s.dismissedByVault, [vaultId]: true } }));
+  },
+
+  clearDismissed(vaultId) {
+    try {
+      localStorage.removeItem(DISMISSED_PREFIX + vaultId);
+    } catch {
+      // Best-effort.
+    }
+    set((s) => {
+      if (!(vaultId in s.dismissedByVault)) return s;
+      const { [vaultId]: _removed, ...rest } = s.dismissedByVault;
+      return { dismissedByVault: rest };
+    });
+  },
+
+  reloadFromStorage() {
+    set({ dismissedByVault: readAllFromStorage() });
+  },
+}));
+
+export const SCHEMA_BANNER_KEY_PREFIX = DISMISSED_PREFIX;

--- a/src/lib/vault/schema-ensure.test.ts
+++ b/src/lib/vault/schema-ensure.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VaultClient } from "./client";
 import { NOTES_REQUIRED_SCHEMA } from "./schema";
-import { _resetEnsuredVaultsForTesting, ensureNotesSchema } from "./schema-ensure";
+import { _resetEnsuredVaultsForTesting, ensureNotesSchema, fixSchema } from "./schema-ensure";
 
 function makeClient(fetchImpl: ReturnType<typeof vi.fn>): VaultClient {
   return new VaultClient({
@@ -118,5 +118,46 @@ describe("ensureNotesSchema", () => {
     expect(warnSpy).toHaveBeenCalled();
 
     warnSpy.mockRestore();
+  });
+});
+
+describe("fixSchema (notes#129 user-driven path)", () => {
+  beforeEach(() => {
+    _resetEnsuredVaultsForTesting();
+  });
+  afterEach(() => {
+    _resetEnsuredVaultsForTesting();
+  });
+
+  it("PUTs every declared tag (bypasses the per-session guard)", async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const client = makeClient(fetchImpl);
+
+    // First, ensure once — the session guard marks v1 as ensured.
+    await ensureNotesSchema("v1", client);
+    const callsAfterEnsure = fetchImpl.mock.calls.length;
+    expect(callsAfterEnsure).toBe(NOTES_REQUIRED_SCHEMA.tags.length);
+
+    // ensureNotesSchema would skip. fixSchema must not.
+    await fixSchema("v1", client);
+    expect(fetchImpl.mock.calls.length).toBe(callsAfterEnsure + NOTES_REQUIRED_SCHEMA.tags.length);
+  });
+
+  it("rethrows on failure (unlike ensureNotesSchema which swallows)", async () => {
+    const fetchImpl = vi.fn(async () => new Response("boom", { status: 500 }));
+    const client = makeClient(fetchImpl);
+
+    await expect(fixSchema("v1", client)).rejects.toBeDefined();
+  });
+
+  it("marks the vault as ensured after success — next ensure call is a no-op", async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const client = makeClient(fetchImpl);
+
+    await fixSchema("v1", client);
+    const callsAfterFix = fetchImpl.mock.calls.length;
+
+    await ensureNotesSchema("v1", client);
+    expect(fetchImpl.mock.calls.length).toBe(callsAfterFix);
   });
 });

--- a/src/lib/vault/schema-ensure.ts
+++ b/src/lib/vault/schema-ensure.ts
@@ -52,6 +52,25 @@ export async function ensureNotesSchema(vaultId: string, client: VaultClient): P
   }
 }
 
+// User-driven fix path (notes#129). Always runs the full sweep — bypasses
+// the per-session guard, because the user is explicitly asking us to ensure
+// the schema (Settings panel button or connect-time banner action). Marks
+// the vault as ensured on success so subsequent first-captures don't redo
+// the work. Throws on failure so the UI can show "fix failed" rather than
+// silently swallowing (unlike `ensureNotesSchema` which is fire-and-forget
+// from capture's save path).
+export async function fixSchema(vaultId: string, client: VaultClient): Promise<void> {
+  for (const decl of NOTES_REQUIRED_SCHEMA.tags) {
+    await client.updateTag(decl.name, {
+      description: decl.description,
+      ...(decl.parent_names ? { parent_names: decl.parent_names } : {}),
+    });
+  }
+  // Fix succeeded → in-session "we ensured this vault" is now true. Skip
+  // re-running on the next capture.
+  ensuredVaults.add(vaultId);
+}
+
 // Test-only escape hatch — resets the in-session guard so a test can
 // exercise the ensure-once behavior across multiple captures without
 // reloading the module.


### PR DESCRIPTION
Closes #129. Builds directly on rc.8's `NOTES_REQUIRED_SCHEMA` + `ensureNotesSchema`. Until now schema-ensure was first-capture-driven (idempotent, silent). This PR adds the operator-facing audit:

- Settings panel showing expected-vs-actual for each declared tag.
- Connect-time banner when the active vault is missing or misaligned.
- One-click "Set up missing tags" action.

## Summary

**Audit primitives (read-only):**
- `auditSchema(client)` in `src/lib/vault/schema-audit.ts` — diffs declared schema against vault rows. Returns `{ ok, missing, misaligned, rows }` with per-tag `differences`.
- `VaultClient.listTagsWithSchema()` — `GET /api/tags?include_schema=true` wrapper, narrow return type.

**User-driven fix path:**
- `fixSchema(vaultId, client)` in `schema-ensure.ts` bypasses the per-session ensure guard (user explicitly asked to write), rethrows on failure so UI can surface it, marks the vault as ensured on success.

**State:**
- `useSchemaAuditStore` — volatile, per-vault. `ensure` (cache-respecting, 5min TTL) + `refresh` (force) + `set` (post-fix update without refetch).
- `useSchemaBannerStore` — persisted per-vault dismissal at `notes:schema-banner-dismissed:<vaultId>`. Mirrors auth-halt-store cross-tab pattern.

**UI:**
- `SchemaAuditRunnerMount` at App root auto-fires `ensure` on active vault/client change. No DOM.
- `SchemaAuditBanner` (amber, less urgent than auth-halt / unreachable). "Set up" calls fixSchema + marks cached audit ok. "Dismiss" persists per-vault. Uses `<output>` for implicit `role="status"` per Biome's a11y rule.
- Settings "Vault schema" section (top of page). Status pill, per-tag rows with expected description + parent_names, Refresh link, "Set up missing tags" button.

## Respect for user overrides

Doesn't touch Tag Role values. A user with `captureText="quick"` from a pre-rc.8 vault keeps that — only the surface-required `capture` / `capture/text` / `capture/voice` rows are ensured. Operator's Tag Role choices are independent.

## Patterns check

- Mirrors `auth-halt-store` shape for both the audit-result store and the banner-dismiss store. Per-vault entries, persisted vs volatile split, cross-tab reload pattern.
- Schema audit is read-only; the existing `fixSchema` is the write path. Settings panel and banner both go through the same `fixSchema` call — no duplicate write logic.
- `<output>` for the banner element + `<output>` already in use in App.tsx's `RouteFallback`. Matches the existing semantic-elements pattern.

## Tests

**20 new across 4 files** — 85 test files / 769 tests pass (was 749 in rc.8). typecheck clean, lint clean, build green (1568 KiB precache).

- `schema-audit.test.ts` (7): ok / missing / description misalign / parent_names misalign / null-vs-empty equivalence / row completeness / extra-tags-don't-flag.
- `schema-ensure.test.ts` (3 new): `fixSchema` bypasses session guard / rethrows on failure / marks ensured after success.
- `schema-banner-store.test.ts` (4): dismiss + clear + multi-vault + cross-tab reload.
- `SchemaAuditBanner.test.tsx` (6): renders nothing pre-audit / nothing on ok / renders on misalign / hides when dismissed / Dismiss persists / Set up calls updateTag for each + marks ok.

## End-to-end smoke

`parachute restart notes` clean. Bundle contains `SchemaAuditBanner`, `NOTES_REQUIRED_SCHEMA`, `capture/text`, "Vault schema". Browser exercise below.

## Test plan

- [ ] Fresh vault → first load → audit runs → banner appears (yellow): "Vault schema needs setup, 3 missing tags…". Click "Set up" → tags written, toast confirms, banner disappears.
- [ ] Settings → Vault schema section → status pill goes green ("Matches Notes' schema"), per-tag rows show ok.
- [ ] Click "Refresh" in Settings → audit re-fetches, pill stays green.
- [ ] Dismiss the banner without setting up → banner gone, reload → still gone (per-vault localStorage).
- [ ] Switch to a different vault that needs setup → banner reappears for that vault.
- [ ] User-set Tag Role values are NOT changed by the fix (existing `captureText="quick"` stays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)