### PR TITLE
fix(capture): autosave draft model + text-size global zoom (0.3.15-rc.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+### Capture draft-save + global text-size zoom
+
+- **fix(capture): autosave is now a background draft, not a finalize-and-
+  clear (0.3.15-rc.10).** P0 bug from Aaron's morning report: typing
+  "hello world" in Capture and waiting 5s wiped the textarea. Root
+  cause: `save()`'s success path called `reset()` (clears content +
+  path) AND never set `phase: "idle"` back, so `canSubmit` stayed
+  false and the textarea (`disabled={phase === "saving"}`) stayed
+  locked.
+  - The redesign: a new `draftSave()` writes a partial as a background
+    draft. First fire enqueues `create-note` with a fresh localId;
+    subsequent fires on the same mount enqueue `update-note` for the
+    same localId (no duplicate notes). Never touches `phase`, never
+    clears `content`. A `draftRef.current` carries
+    `{ localId, hasEnqueuedCreate }` across the mount.
+  - The manual Capture click (and ⌘↵) is the finalize action — if a
+    draft is in flight, it enqueues `update-note` (the create already
+    shipped) and clears `draftRef` via `reset()`. Phase explicitly
+    resets to `idle` after success so the textarea unlocks for the
+    next capture on the same mount.
+  - Unmount-flush mirrors the same shape: enqueues `update-note` if
+    a draft is in flight (otherwise `create-note`). Nav-away no longer
+    duplicates the draft.
+  - Subtle "Draft saved · <relative time>" indicator below the
+    textarea (right-aligned, `text-fg-dim` micro size). Only renders
+    after the first successful draft save.
+  - Audio captures still finalize-and-clear via the manual Capture
+    click — autosave stays suppressed when `phase === "have-audio"`.
+
+- **fix(ui): text-size knob now scales the whole app, not just `.prose-
+  note` + CodeMirror (0.3.15-rc.10).** Aaron reported the Larger /
+  Largest radios "appeared to do nothing" on Settings. rc.6's scope
+  was too narrow: only `.prose-note` and CodeMirror consumed the
+  `--font-size-*` variables, so headers, lists, capture, Settings,
+  bottom-tab — none scaled. Added `font-size` on the html root inside
+  the `:root[data-text-size="larger"]` (17.5px) and `"largest"` (19px)
+  blocks. Tailwind sizes are rem-based, so every chrome element scales
+  proportionally. The prose / editor variables stay so the reader
+  remains slightly larger than the chrome (read-content > navigation
+  feels right).
+
+- **Tests.** 4 existing autosave tests rewritten for draft-save
+  semantics — assert queue rows directly instead of "Captured." toast,
+  assert content is preserved across autosaves (the bug), assert
+  update-note enqueues on the second draft fire and on unmount-flush
+  after a draft. Test names renamed to reflect the new model.
+
 ### Schema-ensure audit UI — Settings panel + connect-time banner
 
 - **feat(schema): audit UI for the required Notes schema (0.3.15-rc.9).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.9",
+  "version": "0.3.15-rc.10",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/routes/Capture.test.tsx
+++ b/src/app/routes/Capture.test.tsx
@@ -969,7 +969,12 @@ describe("Capture — inactivity autosave (5s)", () => {
     vi.restoreAllMocks();
   });
 
-  it("typing + 5s of inactivity fires save()", async () => {
+  it("typing + 5s of inactivity fires draftSave() in the background", async () => {
+    // rc.10 redesign: autosave is now a silent background draft (NOT a
+    // finalize-and-clear). After 5s of inactivity, the create-note hits
+    // the queue but the textarea content stays — the user can keep typing.
+    // No toast (it's not a user action), no `phase: "saving"` (no textarea
+    // disable). The visible signal is the "Draft saved" pill below.
     renderAt("/capture");
     await waitForReady();
     const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
@@ -989,18 +994,27 @@ describe("Capture — inactivity autosave (5s)", () => {
     await act(async () => {
       vi.advanceTimersByTime(2_000);
     });
-    await waitFor(() => {
-      expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+
+    await waitFor(async () => {
+      const dbInner = await openLensDB();
+      const rows = await listPending(dbInner, "dev");
+      dbInner.close();
+      expect(rows.length).toBe(1);
     });
+
     db = await openLensDB();
     const rows = await listPending(db, "dev");
-    expect(rows.length).toBe(1);
     if (rows[0]?.mutation.kind !== "create-note") throw new Error("expected create-note");
     expect(rows[0].mutation.payload.content).toBe("auto-saved thought");
     db.close();
+
+    // Content is preserved (not cleared by a reset).
+    expect(textarea.value).toBe("auto-saved thought");
+    // No "Captured." toast — that's reserved for explicit Capture clicks.
+    expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(false);
   });
 
-  it("further edits within the 5s window reset the timer", async () => {
+  it("further edits within the 5s window reset the timer (draft-save)", async () => {
     renderAt("/capture");
     await waitForReady();
     const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
@@ -1027,8 +1041,11 @@ describe("Capture — inactivity autosave (5s)", () => {
     await act(async () => {
       vi.advanceTimersByTime(1_000);
     });
-    await waitFor(() => {
-      expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+    await waitFor(async () => {
+      const dbInner = await openLensDB();
+      const rows = await listPending(dbInner, "dev");
+      dbInner.close();
+      expect(rows.length).toBe(1);
     });
     db = await openLensDB();
     const rows = await listPending(db, "dev");
@@ -1076,52 +1093,60 @@ describe("Capture — inactivity autosave (5s)", () => {
     db.close();
   });
 
-  it("second autosave after first fires (savingRef releases on success)", async () => {
-    // Regression for the data-loss bug reviewer caught on #123: the success
-    // path of save() never reset savingRef.current. With autosave, the user
-    // stays on the page after a save, so subsequent autosaves would always
-    // bail at the `if (savingRef.current) return` guard. Two autosaves means
-    // two enqueued notes, not one.
+  it("second autosave after first enqueues update-note (rc.10 draft-save)", async () => {
+    // rc.10 redesign: autosave is now a background draft. First fire
+    // enqueues create-note; second fire on the same mount enqueues
+    // update-note targeting the same localId — NOT a second create. The
+    // textarea content is preserved across autosaves so the user can keep
+    // typing into the same thought.
     renderAt("/capture");
     await waitForReady();
     const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
 
-    // First autosave.
+    // First autosave — enqueues create-note.
     await act(async () => {
       fireEvent.change(textarea, { target: { value: "first thought" } });
     });
     await act(async () => {
       vi.advanceTimersByTime(5_500);
     });
-    await waitFor(() => {
-      expect(useToastStore.getState().toasts.length).toBeGreaterThanOrEqual(1);
+    await waitFor(async () => {
+      const dbInner = await openLensDB();
+      const rows = await listPending(dbInner, "dev");
+      dbInner.close();
+      expect(rows.length).toBe(1);
     });
     let db = await openLensDB();
-    expect((await listPending(db, "dev")).length).toBe(1);
+    let rows = await listPending(db, "dev");
+    expect(rows[0]?.mutation.kind).toBe("create-note");
     db.close();
 
-    // After save the textarea is cleared by reset(); type again.
+    // Textarea content is preserved — user keeps editing the same thought.
+    expect(textarea.value).toBe("first thought");
+
+    // Type more, wait for second autosave — should enqueue update-note.
     await act(async () => {
-      fireEvent.change(textarea, { target: { value: "second thought" } });
+      fireEvent.change(textarea, { target: { value: "first thought, expanded" } });
     });
     await act(async () => {
       vi.advanceTimersByTime(5_500);
     });
-    await waitFor(() => {
-      // Two captures means two success toasts.
-      expect(useToastStore.getState().toasts.filter((t) => t.message === "Captured.").length).toBe(
-        2,
-      );
+    await waitFor(async () => {
+      const dbInner = await openLensDB();
+      const rs = await listPending(dbInner, "dev");
+      dbInner.close();
+      expect(rs.length).toBe(2);
     });
     db = await openLensDB();
-    const rows = await listPending(db, "dev");
-    expect(rows.length).toBe(2);
-    const contents = rows
-      .filter((r) => r.mutation.kind === "create-note")
-      .map((r) => (r.mutation.kind === "create-note" ? r.mutation.payload.content : ""));
-    expect(contents).toContain("first thought");
-    expect(contents).toContain("second thought");
+    rows = await listPending(db, "dev");
+    expect(rows[0]?.mutation.kind).toBe("create-note");
+    expect(rows[1]?.mutation.kind).toBe("update-note");
+    if (rows[1]?.mutation.kind === "update-note") {
+      expect(rows[1].mutation.payload.content).toBe("first thought, expanded");
+    }
     db.close();
+    // No "Captured." toasts during background drafts.
+    expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(false);
   });
 
   it("unmount-flush after a successful autosave still flushes new typed content", async () => {
@@ -1159,11 +1184,17 @@ describe("Capture — inactivity autosave (5s)", () => {
     await act(async () => {
       vi.advanceTimersByTime(5_500);
     });
-    await waitFor(() => {
-      expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+    // Wait for the first draft to land in the queue.
+    await waitFor(async () => {
+      const db = await openLensDB();
+      const rows = await listPending(db, "dev");
+      db.close();
+      expect(rows.length).toBe(1);
     });
 
-    // Type more (post-autosave-reset), then unmount before the next timer fires.
+    // Type more (the textarea is preserved across the autosave under
+    // rc.10's draft-save model — no clobber), then unmount before the
+    // next timer fires.
     await act(async () => {
       fireEvent.change(textarea, { target: { value: "post-autosave draft" } });
     });
@@ -1174,6 +1205,8 @@ describe("Capture — inactivity autosave (5s)", () => {
       expect(screen.getByText("unmounted")).toBeInTheDocument();
     });
 
+    // Unmount-flush should have written an update-note for the in-flight
+    // draft (NOT a fresh create-note that would duplicate the row).
     await waitFor(async () => {
       const db = await openLensDB();
       const rows = await listPending(db, "dev");
@@ -1182,11 +1215,14 @@ describe("Capture — inactivity autosave (5s)", () => {
     });
     const db = await openLensDB();
     const rows = await listPending(db, "dev");
-    const contents = rows
-      .filter((r) => r.mutation.kind === "create-note")
-      .map((r) => (r.mutation.kind === "create-note" ? r.mutation.payload.content : ""));
-    expect(contents).toContain("first");
-    expect(contents).toContain("post-autosave draft");
+    expect(rows[0]?.mutation.kind).toBe("create-note");
+    expect(rows[1]?.mutation.kind).toBe("update-note");
+    if (rows[0]?.mutation.kind === "create-note") {
+      expect(rows[0].mutation.payload.content).toBe("first");
+    }
+    if (rows[1]?.mutation.kind === "update-note") {
+      expect(rows[1].mutation.payload.content).toBe("post-autosave draft");
+    }
     db.close();
   });
 });

--- a/src/app/routes/Capture.tsx
+++ b/src/app/routes/Capture.tsx
@@ -9,6 +9,7 @@ import {
   requestMic,
 } from "@/lib/capture/recorder";
 import { blobRef, enqueue, newBlobId, newLocalId } from "@/lib/sync";
+import { relativeTime } from "@/lib/time";
 import { useToastStore } from "@/lib/toast/store";
 import { useTagRoles, useVaultStore } from "@/lib/vault";
 import { useActiveVaultClient } from "@/lib/vault/queries";
@@ -102,6 +103,28 @@ export function Capture({
   const [summary, setSummary] = useState("");
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const [elapsedMs, setElapsedMs] = useState(0);
+  // Background draft-save state (notes#127-followup, rc.10):
+  //
+  // Autosave used to call the full `save()` which set phase=saving (disabling
+  // the textarea) and called `reset()` (clearing content). Aaron's
+  // mid-thought typing got wiped. The redesign: autosave writes a DRAFT —
+  // it enqueues create-note on first fire, then update-note on subsequent
+  // fires (same localId), and NEVER touches phase or content. The user
+  // keeps typing into the same textarea; the draft updates in the
+  // background. Manual Capture is still the "I'm done" finalize action:
+  // if a draft is in flight, it enqueues update-note (the create already
+  // shipped) and clears the draft state on reset.
+  //
+  // draftRef.current === null means no draft is in flight. Once a draft
+  // exists, `hasEnqueuedCreate` toggles to true after the create-note
+  // hits the queue, so subsequent saves enqueue update-note instead.
+  const draftRef = useRef<{
+    localId: string;
+    hasEnqueuedCreate: boolean;
+  } | null>(null);
+  // Wall-clock ms of the most recent successful background draft save.
+  // Drives the "Draft saved · just now" indicator next to the textarea.
+  const [draftSavedAt, setDraftSavedAt] = useState<number | null>(null);
 
   const recorderRef = useRef<RecorderController | null>(null);
   const previewUrlRef = useRef<string | null>(null);
@@ -214,6 +237,10 @@ export function Capture({
   }, []);
 
   const reset = useCallback(() => {
+    // Finalize the current capture session — clear background draft state
+    // too. The next note typed in this mount starts a fresh draft.
+    draftRef.current = null;
+    setDraftSavedAt(null);
     setContent("");
     setTags([]);
     setTagInput("");
@@ -259,7 +286,12 @@ export function Capture({
       new Set([...modeTags, ...explicitTags, ...extracted].filter((t) => t.length > 0)),
     );
 
-    const localId = newLocalId();
+    // For the text-only path, prefer the in-flight draft's localId so the
+    // manual Capture click finalizes the same note the autosave was
+    // building — otherwise we'd duplicate. For audio captures (no draft
+    // path) and the no-draft text case, mint a fresh id.
+    const draft = draftRef.current;
+    const localId = draft?.localId ?? newLocalId();
 
     // Path resolution (notes#126 reshape, option d): empty input reverts to
     // the mount-time generated value — clearing the path never hands
@@ -332,8 +364,28 @@ export function Capture({
           },
           { vaultId: activeVault.id },
         );
+      } else if (draft?.hasEnqueuedCreate) {
+        // Finalize an in-flight background draft (rc.10). The create-note
+        // already shipped via the first autosave; enqueue an update-note
+        // with the latest content + tags + path. `path` and `tags` go
+        // through here too because the operator may have edited them in
+        // More-fields between autosaves and the manual Capture click.
+        await enqueue(
+          db,
+          {
+            kind: "update-note",
+            targetId: localId,
+            payload: {
+              content,
+              path: pathToSave,
+              ...(finalTags.length ? { tags: { add: finalTags } } : {}),
+              ...(metadata ? { metadata } : {}),
+            },
+          },
+          { vaultId: activeVault.id },
+        );
       } else {
-        // Text only.
+        // Text only, no draft in flight — fresh create.
         await enqueue(
           db,
           {
@@ -352,11 +404,14 @@ export function Capture({
       void engine?.runOnce();
       pushToast(audio ? "Captured — syncing audio." : "Captured.", "success");
       reset();
-      // Critical for autosave: the user stays on the page after a successful
-      // autosave, so this in-flight flag has to release or every subsequent
-      // autosave AND the unmount-flush silently bail. Pre-autosave the manual
-      // Capture click was the only entry point and a fresh mount handled the
-      // reset implicitly; with the 5s timer the mount is reused across saves.
+      // Critical: setPhase wasn't reset to idle here in rc.9 — `canSubmit`
+      // stayed false for the rest of the mount and the textarea
+      // (disabled={phase === "saving"}) stayed locked. Flip back to idle so
+      // the user can keep capturing on the same mount. rc.10 fix.
+      setPhase({ kind: "idle" });
+      // Release the in-flight flag so the unmount-flush will still flush a
+      // later draft if the user keeps typing. Pre-rc.10 this was already
+      // critical; with the new draft-save loop it stays so.
       savingRef.current = false;
     } catch (e) {
       pushToast(e instanceof Error ? `Capture failed: ${e.message}` : "Capture failed.", "error");
@@ -396,6 +451,87 @@ export function Capture({
     engine,
     pushToast,
     reset,
+  ]);
+
+  // Background draft save — runs from the 5s inactivity timer. Unlike
+  // save() this NEVER touches phase (no textarea disable), NEVER clears
+  // content, and quietly retries the next tick if the queue isn't ready
+  // (no toast). First call enqueues create-note; subsequent calls on the
+  // same mount enqueue update-note targeting the same localId.
+  //
+  // Audio is deliberately not handled here — autosave is suppressed when
+  // phase is "have-audio" (the user's explicit Capture action finalizes
+  // audio + content together).
+  const draftSave = useCallback(async () => {
+    if (!db || !activeVault) return;
+    if (phase.kind !== "idle") return;
+    if (!hasText) return;
+
+    const explicit = tags.filter((t) => t.length > 0);
+    const extracted = extractHashtags(content);
+    const all = Array.from(
+      new Set([roles.captureText, ...explicit, ...extracted].filter((t) => t.length > 0)),
+    );
+    const pathValue = pathOverride.trim() || generatedPathRef.current;
+    const summaryValue = summary.trim();
+    const metadata = summaryValue ? { summary: summaryValue } : undefined;
+
+    try {
+      const draft = draftRef.current;
+      if (!draft) {
+        const localId = newLocalId();
+        // Set the ref BEFORE the await so a parallel autosave fire on the
+        // next tick (extremely unlikely, but the timer is debounced) sees
+        // the existing draft and routes to update-note.
+        draftRef.current = { localId, hasEnqueuedCreate: false };
+        await enqueue(
+          db,
+          {
+            kind: "create-note",
+            localId,
+            payload: {
+              content,
+              path: pathValue,
+              ...(all.length ? { tags: all } : {}),
+              ...(metadata ? { metadata } : {}),
+            },
+          },
+          { vaultId: activeVault.id },
+        );
+        draftRef.current = { localId, hasEnqueuedCreate: true };
+      } else {
+        await enqueue(
+          db,
+          {
+            kind: "update-note",
+            targetId: draft.localId,
+            payload: {
+              content,
+              path: pathValue,
+              ...(all.length ? { tags: { add: all } } : {}),
+              ...(metadata ? { metadata } : {}),
+            },
+          },
+          { vaultId: activeVault.id },
+        );
+      }
+      void engine?.runOnce();
+      setDraftSavedAt(Date.now());
+    } catch {
+      // Draft save is best-effort — silent failure. The next tick will
+      // retry; the unmount-flush is the last-ditch safety net.
+    }
+  }, [
+    db,
+    activeVault,
+    phase.kind,
+    hasText,
+    content,
+    tags,
+    pathOverride,
+    summary,
+    roles.captureText,
+    engine,
   ]);
 
   // Cmd/Ctrl+Enter submits — same shortcut TextCapture used to have.
@@ -456,39 +592,63 @@ export function Capture({
       // tests is the SyncProvider closing its IDB handle in the same tick;
       // in production the queue is more durable. Either way, no UI to
       // notify.
-      enqueue(
-        db,
-        {
-          kind: "create-note",
-          localId: newLocalId(),
-          payload: {
-            content,
-            path: pathValue,
-            ...(all.length ? { tags: all } : {}),
-            ...(summaryValue ? { metadata: { summary: summaryValue } } : {}),
-          },
-        },
-        { vaultId: activeVaultId },
-      ).catch(() => {
+      //
+      // If a background draft is in flight (rc.10 draft-save loop), update
+      // that note instead of creating a new one — otherwise nav-away
+      // duplicates the draft as a fresh note. The create-note (if any was
+      // enqueued by the first autosave) already shipped its content; this
+      // PATCH just brings the post-autosave keystrokes along.
+      const draft = draftRef.current;
+      const enqueuePromise = draft?.hasEnqueuedCreate
+        ? enqueue(
+            db,
+            {
+              kind: "update-note",
+              targetId: draft.localId,
+              payload: {
+                content,
+                path: pathValue,
+                ...(all.length ? { tags: { add: all } } : {}),
+                ...(summaryValue ? { metadata: { summary: summaryValue } } : {}),
+              },
+            },
+            { vaultId: activeVaultId },
+          )
+        : enqueue(
+            db,
+            {
+              kind: "create-note",
+              localId: draft?.localId ?? newLocalId(),
+              payload: {
+                content,
+                path: pathValue,
+                ...(all.length ? { tags: all } : {}),
+                ...(summaryValue ? { metadata: { summary: summaryValue } } : {}),
+              },
+            },
+            { vaultId: activeVaultId },
+          );
+      enqueuePromise.catch(() => {
         // best-effort flush on nav-away
       });
     };
   }, []);
 
-  // Inactivity autosave (5s) — fires save() after the user stops editing for
-  // 5 seconds so a long-typed note isn't lost to a browser crash or accidental
-  // close. Skipped while audio is staged (saving with attachment is the user's
-  // explicit Capture-click decision), while recording/saving (mid-state), and
-  // while body is empty (nothing to save). The timer resets on every content,
-  // tags, path, or summary change. Hardcoded 5s per the brief — short enough
-  // to feel snappy on long sessions, long enough not to spam the queue on
-  // every keystroke. Cleanup cancels any in-flight timer on unmount so we
-  // don't race the unmount-flush.
+  // Inactivity autosave (5s) — fires `draftSave()` after the user stops
+  // editing for 5 seconds. Saves a partial as a background draft (notes
+  // #127-followup rc.10 redesign): first fire enqueues create-note, each
+  // subsequent fire enqueues update-note for the same localId. Never
+  // clears content; never disables the textarea. The manual Capture
+  // click is the finalize step.
   //
-  // `tags`, `pathOverride`, `summary` are intentional debounce triggers — a
-  // change in any of them must reset this 5s timer so autosave fires 5s
-  // after the LAST edit, not 5s after the last content edit only. They're
-  // read by save() via its own closure (hence Biome can't see them used).
+  // Skipped while audio is staged (audio capture is finalize-only, the
+  // user's explicit Capture-click decision), while recording (mid-state),
+  // and while body is empty (nothing to save).
+  //
+  // `tags`, `pathOverride`, `summary` are intentional debounce triggers —
+  // a change in any of them must reset this 5s timer so the autosave
+  // fires 5s after the LAST edit. They're read by `draftSave` via its
+  // closure (hence Biome can't see them used).
   // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   useEffect(() => {
     if (phase.kind === "recording" || phase.kind === "requesting" || phase.kind === "saving") {
@@ -498,10 +658,10 @@ export function Capture({
     if (!hasText) return;
     const id = setTimeout(() => {
       if (savingRef.current) return;
-      void save();
+      void draftSave();
     }, 5000);
     return () => clearTimeout(id);
-  }, [phase.kind, hasText, content, tags, pathOverride, summary, save]);
+  }, [phase.kind, hasText, content, tags, pathOverride, summary, draftSave]);
 
   if (!activeVault) return <Navigate to="/" replace />;
 
@@ -528,6 +688,12 @@ export function Capture({
           disabled={phase.kind === "saving"}
           className="min-h-[30vh] w-full resize-y rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-fg-dim focus:border-accent focus:outline-none disabled:opacity-60"
         />
+
+        {draftSavedAt !== null ? (
+          <p className="-mt-2 text-right text-[11px] text-fg-dim" aria-live="polite">
+            Draft saved · {relativeTime(new Date(draftSavedAt).toISOString())}
+          </p>
+        ) : null}
 
         {phase.kind === "have-audio" ? (
           <div className="flex flex-col gap-2 rounded-md border border-accent/30 bg-accent/5 p-3">

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -30,12 +30,25 @@
 }
 
 /* Explicit text-size overrides. `default` removes the attribute entirely
-   so we don't need a third block. */
+   so we don't need a third block.
+
+   rc.10: the original rc.6 scope was too narrow — only `.prose-note` and
+   CodeMirror consumed the `--font-size-*` variables, so the rest of the
+   app (header, lists, Settings, capture textarea, bottom-tab) didn't
+   scale. Aaron reported Larger/Largest "appears to do nothing" while on
+   Settings. Adding `font-size` on the html root makes every rem-based
+   Tailwind size scale app-wide (Tailwind sizes are rem; rem is relative
+   to root font-size). The prose / editor variables stay so the reader
+   and editor can scale slightly MORE than the chrome — `Larger`'s 1.125
+   prose multiplied by 17.5px root = ~19.7px reader text vs ~17.5px
+   chrome, which feels right (read-content larger than navigation). */
 :root[data-text-size="larger"] {
+  font-size: 17.5px;
   --font-size-prose: 1.125rem;
   --font-size-editor: 16px;
 }
 :root[data-text-size="largest"] {
+  font-size: 19px;
   --font-size-prose: 1.25rem;
   --font-size-editor: 18px;
 }


### PR DESCRIPTION
Two issues from Aaron's morning report. P0 autosave bug + P1 text-size scope. Bundle per team-lead's brief.

## P0 — Capture autosave wipes textarea (data-loss UX)

**Repro**: Open `/capture`, type "hello world", wait 5s. The textarea empties.

**Root cause** in `src/app/routes/Capture.tsx`:
1. 5s autosave called full `save()`.
2. `save()` set `phase: "saving"` then `reset()` (clears content + path).
3. `phase` was never reset to `"idle"` on success — `canSubmit` stayed false, textarea (`disabled={phase === "saving"}`) stayed locked.
4. Mid-typing during the async enqueue got clobbered by `setContent("")`.

**Approach taken**: the proper draft-save redesign per the brief (not the disable-timer stopgap).

- New `draftSave()` writes a partial as a background draft. First fire enqueues `create-note`. Subsequent fires on the same mount enqueue `update-note` for the same localId (no duplicate notes).
- `draftRef.current = { localId, hasEnqueuedCreate }` tracks state across the mount.
- Manual Capture click (and ⌘↵) finalizes: if a draft is in flight, enqueues `update-note` (the create-note already shipped) instead of a fresh create-note. Then `reset()` clears content + draftRef.
- **Critical fix**: explicit `setPhase({ kind: "idle" })` after success so the textarea unlocks for the next capture on the same mount.
- Unmount-flush mirrors: `update-note` if draft in flight, otherwise `create-note`. Nav-away no longer duplicates.
- Subtle "Draft saved · 12s ago" indicator below the textarea — right-aligned, `text-fg-dim` micro size, only renders after the first successful draft.
- Audio captures still finalize-and-clear via the manual Capture click — autosave suppressed when `phase === "have-audio"`.

**Why proper version, not stopgap**: the queue already supports `update-note` with localId resolution via `resolveNoteId` in `src/lib/sync/queue.ts:191`. The infrastructure was there; this was a UI bug, not a sync-system bug.

## P1 — Text-size knob too narrow

Aaron reported the Larger / Largest radios "appeared to do nothing" on Settings. rc.6's scope only touched `.prose-note` + CodeMirror via `--font-size-*` variables — chrome, lists, Settings, capture, bottom-tab didn't scale.

**Fix**: added `font-size` on the html root in the existing `:root[data-text-size="larger"]` (17.5px) and `"largest"` (19px) blocks. Tailwind sizes are rem-based, so chrome scales proportionally. The prose / editor variables stay so the reader is slightly larger than chrome — read-content > navigation feels right.

## Patterns check

- `draftSave()` uses the existing `update-note` queue pattern that drains via `resolveNoteId` — no new sync machinery.
- Indicator uses the existing `relativeTime` helper from `lib/time.ts` for consistency with SyncStatusPanel's "Last synced".
- Text-size approach (Option 1, global zoom) is the simplest of the three the brief offered. If chrome feels too large at `largest`, follow-up is to switch to Option 3 (content-only); the variable-based architecture is unchanged so the switch is one CSS file.

## Tests

**4 existing autosave tests rewritten** for draft-save semantics — assert queue rows directly instead of "Captured." toast (which is now reserved for explicit Capture clicks), assert content is preserved across autosaves (the bug), assert `update-note` enqueues on the second draft fire and on unmount-flush after a draft.

- 85 test files / 770 tests pass. typecheck clean, lint clean, build green (1574 KiB precache).

## End-to-end smoke

`parachute restart notes` clean. Browser test plan below.

## Test plan

- [ ] Open `/capture`, type "hello world", wait 5s. **Textarea content stays.** "Draft saved · just now" indicator appears below.
- [ ] Type more after 5s. Indicator updates after another 5s.
- [ ] Click Capture button. Textarea clears, "Captured." toast.
- [ ] Type "second one" → wait 5s → check no duplicate notes appear (just one with localId).
- [ ] Type → wait 5s (draft fires) → navigate to `/today` immediately. Open the note → content is "...". No duplicate row in queue.
- [ ] Settings → Text size → Larger. Header, Settings, lists, capture textarea all scale up visibly. Largest scales further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)