### PR TITLE
feat(render): Phase 2 format-aware rendering — CSV, JSON, YAML, code (closes #138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+### Phase 2 format-aware rendering
+
+- **feat(render): NoteRenderer dispatches CSV / JSON / YAML / code to
+  format-specific renderers (0.3.15-rc.12).** Closes #138. Phase 1
+  (parachute-vault) added file-extension support so non-markdown notes can
+  be stored; Phase 2 (this) renders them appropriately on the read path.
+
+  A new `NoteRenderer` dispatcher in `src/components/NoteRenderer.tsx`
+  examines the note's path extension and routes to one of six renderers:
+  - `MarkdownView` (unchanged) — `.md`, `.mdx`, `.markdown`, no extension
+  - `CsvRenderer` — `.csv` rendered as an HTML table (first row =
+    headers); inline RFC-4180 parser handles quoted cells, escaped
+    quotes, newlines-in-cells, CRLF, missing trailing newline
+  - `JsonRenderer` — `.json` pretty-printed + syntax-highlighted; invalid
+    JSON falls back to the plain monospace block
+  - `YamlRenderer` — `.yaml` / `.yml` syntax-highlighted (no re-emit;
+    bytes render as authored)
+  - `CodeRenderer` — `.ts` / `.tsx` / `.js` / `.jsx` / `.py` / `.rs` /
+    `.go` / `.sh` syntax-highlighted via `highlight.js/lib/core` with
+    explicit per-language registration (avoids the `/common` bundle's
+    ~35 KB of unused languages)
+  - `PlainRenderer` — fallback for unknown extensions and parse failures
+
+  All three existing call sites (`NoteView`, `NoteEditor` preview,
+  `NoteNew` preview) now go through `NoteRenderer`. The editor preview
+  reads `draft.path` so renaming a draft to `.csv` switches the preview
+  live.
+
+  No new dependencies — `highlight.js` was already a dep (used by
+  rehype-highlight for fenced code in markdown notes); the new renderers
+  reuse it directly. The hljs github theme already imported in
+  `styles/index.css` styles both code paths uniformly.
+
+  Bundle: `NoteRenderer` chunk 340.80 kB / 103.55 kB gzip (was
+  `MarkdownView` 337.29 kB / 102.30 kB gzip) — delta **+3.51 kB raw /
+  +1.25 kB gzip**. Total PWA precache 1578.53 KiB (was 1574.85 KiB).
+
+  Deferred (out of scope for #138): MDX with custom React components in
+  the markdown body, image-format thumbnails in non-markdown notes, and
+  CodeMirror language-aware editing (the editor still uses markdown
+  grammar for every note — Phase 3).
+
 ### Text-size ramp retune
 
 - **tune(ui): widen text-size ramp + bump default (0.3.15-rc.11).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Phase 2 polish
+
+- **chore(render): fold reviewer polish nits (0.3.15-rc.13).**
+  `escapeHtml` in `src/lib/render/highlight.ts` now escapes `"` (→
+  `&quot;`) and `'` (→ `&#x27;`) in addition to `&` / `<` / `>` — current
+  callers only use content context, but the generic name invites future
+  attribute-context use, so close the hole up front. Added two test
+  cases in `format.test.ts` pinning `formatForPath` hidden-file behavior
+  (`.gitignore` → `"plain"`, `.ts` → `"code"`) — falls out of the
+  extension-driven model, but worth pinning since it was unspecified.
+
 ### Phase 2 format-aware rendering
 
 - **feat(render): NoteRenderer dispatches CSV / JSON / YAML / code to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.11",
+  "version": "0.3.15-rc.12",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.12",
+  "version": "0.3.15-rc.13",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/routes/NoteEditor.tsx
+++ b/src/app/routes/NoteEditor.tsx
@@ -4,7 +4,8 @@ import { AttachmentUploadList } from "@/components/AttachmentUploadList";
 import type { CodeMirrorEditorHandle } from "@/components/CodeMirrorEditor";
 import { CodeMirrorEditor } from "@/components/CodeMirrorEditor";
 import { DeleteNoteButton } from "@/components/DeleteNoteButton";
-import { MarkdownView, buildWikilinkResolver } from "@/components/MarkdownView";
+import { buildWikilinkResolver } from "@/components/MarkdownView";
+import { NoteRenderer } from "@/components/NoteRenderer";
 import { PinArchiveButtons } from "@/components/PinArchiveButtons";
 import { RemoveAttachmentButton } from "@/components/RemoveAttachmentButton";
 import { TagEditor, normalizeTag } from "@/components/TagEditor";
@@ -316,7 +317,7 @@ function EditorSurface({ note }: { note: Note }) {
             mobilePane === "preview" ? "" : "hidden lg:block"
           }`}
         >
-          <MarkdownView content={previewContent} resolve={resolver} />
+          <NoteRenderer note={{ path: draft.path, content: previewContent }} resolve={resolver} />
         </div>
       </div>
 

--- a/src/app/routes/NoteNew.tsx
+++ b/src/app/routes/NoteNew.tsx
@@ -3,7 +3,8 @@ import { AttachmentPicker } from "@/components/AttachmentPicker";
 import { AttachmentUploadList } from "@/components/AttachmentUploadList";
 import type { CodeMirrorEditorHandle } from "@/components/CodeMirrorEditor";
 import { CodeMirrorEditor } from "@/components/CodeMirrorEditor";
-import { MarkdownView, buildWikilinkResolver } from "@/components/MarkdownView";
+import { buildWikilinkResolver } from "@/components/MarkdownView";
+import { NoteRenderer } from "@/components/NoteRenderer";
 import { TagEditor, normalizeTag } from "@/components/TagEditor";
 import { useAttachmentUploader } from "@/components/useAttachmentUploader";
 import { useToastStore } from "@/lib/toast/store";
@@ -233,7 +234,10 @@ export function NoteNew() {
           </AttachmentDropZone>
           <div className="min-w-0 overflow-auto rounded-md border border-border bg-card p-4">
             {draft.content.trim() ? (
-              <MarkdownView content={draft.content} resolve={resolver} />
+              <NoteRenderer
+                note={{ path: draft.path, content: draft.content }}
+                resolve={resolver}
+              />
             ) : (
               <p className="text-sm text-fg-dim">Preview appears here as you type.</p>
             )}

--- a/src/app/routes/NoteView.tsx
+++ b/src/app/routes/NoteView.tsx
@@ -1,6 +1,7 @@
 import { DeleteNoteButton } from "@/components/DeleteNoteButton";
-import { MarkdownView, buildWikilinkResolver } from "@/components/MarkdownView";
+import { buildWikilinkResolver } from "@/components/MarkdownView";
 import { NeighborhoodGraph } from "@/components/NeighborhoodGraph";
+import { NoteRenderer } from "@/components/NoteRenderer";
 import { PinArchiveButtons } from "@/components/PinArchiveButtons";
 import { TranscriptionStatus } from "@/components/TranscriptionStatus";
 import { pushRecent } from "@/lib/quick-switch/recents";
@@ -92,7 +93,7 @@ function NoteBody({ note }: { note: Note }) {
 
         <TranscriptionStatus content={note.content ?? ""} />
 
-        <MarkdownView content={note.content ?? ""} resolve={resolver} />
+        <NoteRenderer note={note} resolve={resolver} />
 
         {note.attachments && note.attachments.length > 0 ? (
           <section className="mt-10 border-t border-border pt-6">

--- a/src/components/NoteRenderer.test.tsx
+++ b/src/components/NoteRenderer.test.tsx
@@ -1,0 +1,82 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NoteRenderer } from "./NoteRenderer";
+
+// Wikilink resolver isn't exercised in dispatch tests — pass a no-op.
+const NO_RESOLVE = () => null;
+
+describe("NoteRenderer", () => {
+  it("dispatches to markdown for no extension", () => {
+    const { container } = render(
+      <NoteRenderer note={{ path: "Daily/2026-05-18", content: "# Hello" }} resolve={NO_RESOLVE} />,
+    );
+    // Markdown rendering produces an <h1> from `# Hello`.
+    expect(container.querySelector("h1")?.textContent).toBe("Hello");
+  });
+
+  it("dispatches to markdown for .md", () => {
+    const { container } = render(
+      <NoteRenderer note={{ path: "notes/foo.md", content: "**bold**" }} resolve={NO_RESOLVE} />,
+    );
+    expect(container.querySelector("strong")?.textContent).toBe("bold");
+  });
+
+  it("dispatches to CSV for .csv", () => {
+    const { container } = render(
+      <NoteRenderer
+        note={{ path: "data/ledger.csv", content: "name,age\nA,1\n" }}
+        resolve={NO_RESOLVE}
+      />,
+    );
+    expect(container.querySelector("table")).not.toBeNull();
+  });
+
+  it("dispatches to JSON for .json (and pretty-prints)", () => {
+    const { container } = render(
+      <NoteRenderer
+        note={{ path: "config.json", content: '{"a":1,"b":2}' }}
+        resolve={NO_RESOLVE}
+      />,
+    );
+    const code = container.querySelector("pre code");
+    expect(code?.className).toMatch(/language-json/);
+    expect(code?.textContent).toMatch(/"a": 1/);
+  });
+
+  it("dispatches to YAML for .yml", () => {
+    const { container } = render(
+      <NoteRenderer note={{ path: "x.yml", content: "a: 1\n" }} resolve={NO_RESOLVE} />,
+    );
+    expect(container.querySelector("pre code")?.className).toMatch(/language-yaml/);
+  });
+
+  it("dispatches to code for known code extensions", () => {
+    const { container } = render(
+      <NoteRenderer
+        note={{ path: "foo.ts", content: "const x: number = 1;" }}
+        resolve={NO_RESOLVE}
+      />,
+    );
+    expect(container.querySelector("pre code")?.className).toMatch(/language-typescript/);
+  });
+
+  it("falls back to plain text for an unknown extension", () => {
+    const { container } = render(
+      <NoteRenderer note={{ path: "blob.xyz", content: "weird bytes" }} resolve={NO_RESOLVE} />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe("weird bytes");
+    // No syntax highlighting on the fallback path.
+    expect(pre?.querySelector("code")?.className ?? "").not.toMatch(/language-/);
+  });
+
+  it("falls back to plain on JSON parse error", () => {
+    const { container } = render(
+      <NoteRenderer note={{ path: "bad.json", content: "{ broken" }} resolve={NO_RESOLVE} />,
+    );
+    const code = container.querySelector("pre code");
+    expect(code?.textContent).toBe("{ broken");
+    expect(code?.className ?? "").not.toMatch(/language-json/);
+  });
+});

--- a/src/components/NoteRenderer.tsx
+++ b/src/components/NoteRenderer.tsx
@@ -1,0 +1,54 @@
+import { CodeRenderer } from "@/components/render/CodeRenderer";
+import { CsvRenderer } from "@/components/render/CsvRenderer";
+import { JsonRenderer } from "@/components/render/JsonRenderer";
+import { PlainRenderer } from "@/components/render/PlainRenderer";
+import { YamlRenderer } from "@/components/render/YamlRenderer";
+import type { WikilinkResolver } from "@/lib/markdown/remark-wikilinks";
+import { CODE_EXTENSIONS, extensionOf, formatForPath } from "@/lib/render/format";
+import { MarkdownView } from "./MarkdownView";
+
+// Phase 2 dispatcher: pick the right format-specific renderer based on the
+// note's path extension. Markdown stays the default (no extension or
+// .md/.mdx/.markdown). Everything else is read-only — the editor still uses
+// CodeMirror with markdown grammar, that's a separate Phase 3 concern.
+
+export interface NoteLike {
+  path?: string;
+  content?: string;
+}
+
+export function NoteRenderer({
+  note,
+  resolve,
+  className,
+}: {
+  note: NoteLike;
+  // Required only for the markdown branch; the other renderers don't carry
+  // wikilinks. Kept required at the type level so existing call sites
+  // (NoteView, NoteEditor preview, NoteNew preview) which already build a
+  // resolver pass it without thinking — and so future markdown notes don't
+  // silently lose wikilink resolution.
+  resolve: WikilinkResolver;
+  className?: string;
+}) {
+  const content = note.content ?? "";
+  const format = formatForPath(note.path);
+
+  switch (format) {
+    case "markdown":
+      return <MarkdownView content={content} resolve={resolve} className={className} />;
+    case "csv":
+      return <CsvRenderer content={content} />;
+    case "json":
+      return <JsonRenderer content={content} />;
+    case "yaml":
+      return <YamlRenderer content={content} />;
+    case "code": {
+      const ext = extensionOf(note.path);
+      const language = CODE_EXTENSIONS[ext] ?? "plaintext";
+      return <CodeRenderer content={content} language={language} />;
+    }
+    default:
+      return <PlainRenderer content={content} />;
+  }
+}

--- a/src/components/render/CodeRenderer.tsx
+++ b/src/components/render/CodeRenderer.tsx
@@ -1,0 +1,30 @@
+import { highlightAs } from "@/lib/render/highlight";
+import { useMemo } from "react";
+
+// Render `content` as highlighted code for `language` (a highlight.js
+// language ID). Output is wrapped in `<pre><code class="hljs language-X">`
+// — same markup the rehype-highlight markdown pipeline produces, so the
+// existing github.css theme styles both paths uniformly.
+
+export function CodeRenderer({
+  content,
+  language,
+}: {
+  content: string;
+  language: string;
+}) {
+  const html = useMemo(() => highlightAs(content, language), [content, language]);
+  return (
+    <div className="prose-note">
+      <pre>
+        {/* highlight.js output is sanitized HTML built from escaped tokens;
+            no user-controlled attribute slots flow through. */}
+        <code
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: see comment above
+          dangerouslySetInnerHTML={{ __html: html }}
+          className={`hljs language-${language}`}
+        />
+      </pre>
+    </div>
+  );
+}

--- a/src/components/render/CsvRenderer.test.tsx
+++ b/src/components/render/CsvRenderer.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CsvRenderer } from "./CsvRenderer";
+
+describe("CsvRenderer", () => {
+  it("renders a basic CSV as a table with first row as headers", () => {
+    const { container } = render(<CsvRenderer content={"name,age\nAaron,40\nBert,32\n"} />);
+    const table = container.querySelector("table");
+    expect(table).not.toBeNull();
+    const ths = container.querySelectorAll("th");
+    expect(Array.from(ths).map((th) => th.textContent)).toEqual(["name", "age"]);
+    const tds = container.querySelectorAll("tbody td");
+    expect(Array.from(tds).map((td) => td.textContent)).toEqual(["Aaron", "40", "Bert", "32"]);
+  });
+
+  it("matches snapshot for the basic case", () => {
+    const { container } = render(<CsvRenderer content={"a,b\n1,2\n3,4\n"} />);
+    // Snapshot the table only — the wrapper div has Tailwind classes we
+    // don't care to lock down.
+    expect(container.querySelector("table")?.outerHTML).toMatchInlineSnapshot(
+      `"<table><thead><tr><th scope="col">a</th><th scope="col">b</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table>"`,
+    );
+  });
+
+  it("preserves quoted commas + escaped quotes", () => {
+    const { container } = render(
+      <CsvRenderer content={'title,note\n"hello, world","he said ""hi"""\n'} />,
+    );
+    const tds = container.querySelectorAll("tbody td");
+    expect(tds[0]?.textContent).toBe("hello, world");
+    expect(tds[1]?.textContent).toBe('he said "hi"');
+  });
+
+  it("surfaces an inline warning when CSV is truncated", () => {
+    const { container } = render(<CsvRenderer content={'a,b\n"unterminated'} />);
+    expect(container.textContent).toMatch(/malformed/i);
+  });
+
+  it("falls back to plain pre when there are zero rows", () => {
+    const { container } = render(<CsvRenderer content="" />);
+    expect(container.querySelector("table")).toBeNull();
+    expect(container.querySelector("pre")).not.toBeNull();
+  });
+});

--- a/src/components/render/CsvRenderer.tsx
+++ b/src/components/render/CsvRenderer.tsx
@@ -1,0 +1,62 @@
+import { parseCsv } from "@/lib/render/csv";
+import { useMemo } from "react";
+import { PlainRenderer } from "./PlainRenderer";
+
+// Render CSV content as an HTML table — first row treated as the header.
+// On a fatally malformed CSV (unterminated quote at EOF) we surface what we
+// parsed plus an inline warning. If we ended up with no rows at all we fall
+// back to the plain-text monospace renderer.
+
+export function CsvRenderer({ content }: { content: string }) {
+  const parsed = useMemo(() => parseCsv(content), [content]);
+
+  if (parsed.rows.length === 0) {
+    return <PlainRenderer content={content} />;
+  }
+
+  const [header, ...body] = parsed.rows;
+  // If only one row, render it as the header so users still see the data;
+  // otherwise the body would be empty and the table would look wrong.
+  const hasBody = body.length > 0;
+  const columnCount = Math.max(header?.length ?? 0, ...body.map((r) => r.length));
+
+  return (
+    <div className="prose-note">
+      {parsed.truncated ? (
+        <p className="mb-2 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
+          This CSV looks malformed (unterminated quoted cell). Showing the rows we could parse.
+        </p>
+      ) : null}
+      {/* Column/row positions are the only stable identity for CSV cells
+          (no header column we can rely on for keys), so all three loops below
+          use array index as key. */}
+      <div className="overflow-x-auto">
+        <table>
+          <thead>
+            <tr>
+              {Array.from({ length: columnCount }).map((_, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: positional
+                <th key={i} scope="col">
+                  {header?.[i] ?? ""}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          {hasBody ? (
+            <tbody>
+              {body.map((row, ri) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: positional
+                <tr key={ri}>
+                  {Array.from({ length: columnCount }).map((_, ci) => (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: positional
+                    <td key={ci}>{row[ci] ?? ""}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          ) : null}
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/render/JsonRenderer.test.tsx
+++ b/src/components/render/JsonRenderer.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { JsonRenderer } from "./JsonRenderer";
+
+describe("JsonRenderer", () => {
+  it("pretty-prints valid JSON", () => {
+    const { container } = render(<JsonRenderer content={'{"a":1,"b":[2,3]}'} />);
+    const code = container.querySelector("pre code");
+    expect(code).not.toBeNull();
+    // Pretty-printed output contains newlines + 2-space indent.
+    const text = code?.textContent ?? "";
+    expect(text).toMatch(/"a": 1/);
+    expect(text).toMatch(/"b": \[/);
+    expect(text.includes("\n")).toBe(true);
+  });
+
+  it("emits a hljs language-json class for highlighting", () => {
+    const { container } = render(<JsonRenderer content={'{"a":1}'} />);
+    const code = container.querySelector("pre code");
+    expect(code?.className).toMatch(/language-json/);
+    expect(code?.className).toMatch(/hljs/);
+  });
+
+  it("falls back to plain pre on invalid JSON", () => {
+    const { container } = render(<JsonRenderer content="{ not json" />);
+    const code = container.querySelector("pre code");
+    expect(code?.textContent).toBe("{ not json");
+    // No language- class on the fallback path.
+    expect(code?.className ?? "").not.toMatch(/language-json/);
+  });
+});

--- a/src/components/render/JsonRenderer.tsx
+++ b/src/components/render/JsonRenderer.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+import { CodeRenderer } from "./CodeRenderer";
+import { PlainRenderer } from "./PlainRenderer";
+
+// Pretty-print + syntax-highlight a JSON note. Shipping the code-view variant
+// (not the tree-view) per the Phase 2 brief — simpler to ship, no
+// expand/collapse state, and lines up with the YAML + code paths.
+//
+// On invalid JSON we fall back to the plain renderer so the user still sees
+// their bytes. We don't reformat the original string in that case — the
+// authors's spacing/indentation is signal too.
+
+export function JsonRenderer({ content }: { content: string }) {
+  const pretty = useMemo(() => {
+    try {
+      const parsed = JSON.parse(content);
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return null;
+    }
+  }, [content]);
+
+  if (pretty === null) {
+    return <PlainRenderer content={content} />;
+  }
+  return <CodeRenderer content={pretty} language="json" />;
+}

--- a/src/components/render/PlainRenderer.tsx
+++ b/src/components/render/PlainRenderer.tsx
@@ -1,0 +1,14 @@
+// Fallback renderer: plain text in a monospace block. Used for unknown
+// extensions and as a graceful-fallback target when a format-specific
+// renderer can't parse its input. Reuses the `.prose-note pre` styling so
+// the visual treatment matches markdown code blocks.
+
+export function PlainRenderer({ content }: { content: string }) {
+  return (
+    <div className="prose-note">
+      <pre>
+        <code>{content}</code>
+      </pre>
+    </div>
+  );
+}

--- a/src/components/render/YamlRenderer.test.tsx
+++ b/src/components/render/YamlRenderer.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { YamlRenderer } from "./YamlRenderer";
+
+describe("YamlRenderer", () => {
+  it("renders YAML without throwing", () => {
+    const yaml = "name: parachute\nversion: 0.3.15\nfeatures:\n  - notes\n  - vault\n";
+    const { container } = render(<YamlRenderer content={yaml} />);
+    const code = container.querySelector("pre code");
+    expect(code).not.toBeNull();
+    expect(code?.className).toMatch(/language-yaml/);
+    // textContent collapses the highlight span markup back to the source.
+    expect(code?.textContent).toContain("parachute");
+    expect(code?.textContent).toContain("features:");
+  });
+});

--- a/src/components/render/YamlRenderer.tsx
+++ b/src/components/render/YamlRenderer.tsx
@@ -1,0 +1,10 @@
+import { CodeRenderer } from "./CodeRenderer";
+
+// YAML is just highlighted code — there's no equivalent of JSON.parse to
+// pretty-print, and re-emitting via a YAML library would be a real
+// dependency and a real source of surprises (anchors, key ordering, comment
+// stripping). Render the bytes as-authored with highlight.js coloring.
+
+export function YamlRenderer({ content }: { content: string }) {
+  return <CodeRenderer content={content} language="yaml" />;
+}

--- a/src/lib/render/csv.test.ts
+++ b/src/lib/render/csv.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { parseCsv } from "./csv";
+
+describe("parseCsv", () => {
+  it("parses a basic two-column file", () => {
+    const { rows, truncated } = parseCsv("name,age\nAaron,40\nBert,32\n");
+    expect(truncated).toBe(false);
+    expect(rows).toEqual([
+      ["name", "age"],
+      ["Aaron", "40"],
+      ["Bert", "32"],
+    ]);
+  });
+
+  it("handles a missing trailing newline", () => {
+    const { rows } = parseCsv("name,age\nAaron,40");
+    expect(rows).toEqual([
+      ["name", "age"],
+      ["Aaron", "40"],
+    ]);
+  });
+
+  it("handles quoted cells containing commas", () => {
+    const { rows } = parseCsv('title,note\n"hello, world","a, b, c"\n');
+    expect(rows).toEqual([
+      ["title", "note"],
+      ["hello, world", "a, b, c"],
+    ]);
+  });
+
+  it("handles escaped quotes inside a quoted cell", () => {
+    const { rows } = parseCsv('quote\n"she said ""hi"""\n');
+    expect(rows).toEqual([["quote"], [`she said "hi"`]]);
+  });
+
+  it("handles newlines inside a quoted cell", () => {
+    const { rows } = parseCsv('a,b\n"line one\nline two",ok\n');
+    expect(rows).toEqual([
+      ["a", "b"],
+      ["line one\nline two", "ok"],
+    ]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const { rows } = parseCsv("a,b\r\n1,2\r\n3,4\r\n");
+    expect(rows).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+      ["3", "4"],
+    ]);
+  });
+
+  it("parses a single-column file", () => {
+    const { rows } = parseCsv("alpha\nbeta\ngamma\n");
+    expect(rows).toEqual([["alpha"], ["beta"], ["gamma"]]);
+  });
+
+  it("returns no rows for empty input", () => {
+    expect(parseCsv("")).toEqual({ rows: [], truncated: false });
+  });
+
+  it("flags truncated on an unterminated quote", () => {
+    // EOF inside a quoted cell — surface what we managed to extract but mark
+    // truncated so the renderer can warn.
+    const { rows, truncated } = parseCsv('a,b\n"unterminated');
+    expect(truncated).toBe(true);
+    expect(rows[0]).toEqual(["a", "b"]);
+  });
+
+  it("preserves empty cells", () => {
+    const { rows } = parseCsv("a,b,c\n,2,\n");
+    expect(rows).toEqual([
+      ["a", "b", "c"],
+      ["", "2", ""],
+    ]);
+  });
+});

--- a/src/lib/render/csv.ts
+++ b/src/lib/render/csv.ts
@@ -1,0 +1,98 @@
+// RFC 4180 CSV parser — hand-rolled to keep the PWA bundle lean (a CSV-only
+// dep like papaparse is ~45 KB minified for features we don't need).
+//
+// Handles:
+//   - quoted cells: `"hello, world",2`
+//   - escaped quotes inside quoted cells: `"she said ""hi"""`
+//   - newlines inside quoted cells (LF or CRLF)
+//   - missing trailing newline
+//   - single-column input
+//   - empty input
+//
+// On a fatally malformed row (unterminated quote at EOF) the parser returns
+// the rows it managed to extract plus the partial row, with `truncated: true`.
+// Callers (CsvRenderer) surface that via an inline warning + plain-text
+// fallback.
+
+export interface ParsedCsv {
+  rows: string[][];
+  truncated: boolean;
+}
+
+export function parseCsv(input: string): ParsedCsv {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+  let truncated = false;
+
+  const len = input.length;
+  let i = 0;
+  while (i < len) {
+    const ch = input[i];
+
+    if (inQuotes) {
+      if (ch === '"') {
+        // Escaped quote ("") inside a quoted cell stays as a single quote.
+        if (i + 1 < len && input[i + 1] === '"') {
+          cell += '"';
+          i += 2;
+          continue;
+        }
+        // Closing quote — exit quoted mode. Anything until the next delimiter
+        // is appended verbatim (Excel does this; strict RFC would error, but
+        // gentle wins).
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      cell += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+
+    if (ch === ",") {
+      row.push(cell);
+      cell = "";
+      i += 1;
+      continue;
+    }
+
+    if (ch === "\n" || ch === "\r") {
+      row.push(cell);
+      cell = "";
+      rows.push(row);
+      row = [];
+      // Consume CRLF as a single line terminator.
+      if (ch === "\r" && i + 1 < len && input[i + 1] === "\n") {
+        i += 2;
+      } else {
+        i += 1;
+      }
+      continue;
+    }
+
+    cell += ch;
+    i += 1;
+  }
+
+  // Flush trailing cell/row. If we end inside an unterminated quote we still
+  // surface whatever we collected, but mark it truncated so the caller can
+  // warn.
+  if (inQuotes) {
+    truncated = true;
+  }
+  // Edge: a single empty input shouldn't synthesize an empty row.
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+
+  return { rows, truncated };
+}

--- a/src/lib/render/format.test.ts
+++ b/src/lib/render/format.test.ts
@@ -39,6 +39,17 @@ describe("formatForPath", () => {
     expect(formatForPath("blob.bin")).toBe("plain");
     expect(formatForPath("snap.png")).toBe("plain");
   });
+
+  // Pin the documented intent for hidden-file paths (no body before the
+  // dot). The dispatch is purely extension-driven, so `.gitignore` reads
+  // as ext="gitignore" → "plain", and `.ts` reads as ext="ts" → "code".
+  // This isn't a deliberate hidden-file rule — it falls out of the
+  // extension model — but the behavior is the right one to keep, so pin
+  // it.
+  it("treats hidden-file paths by extension (no special-case)", () => {
+    expect(formatForPath(".gitignore")).toBe("plain");
+    expect(formatForPath(".ts")).toBe("code");
+  });
 });
 
 describe("extensionOf", () => {

--- a/src/lib/render/format.test.ts
+++ b/src/lib/render/format.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { extensionOf, formatForPath } from "./format";
+
+describe("formatForPath", () => {
+  it("treats no path as markdown", () => {
+    expect(formatForPath(undefined)).toBe("markdown");
+    expect(formatForPath("")).toBe("markdown");
+  });
+
+  it("treats no extension as markdown", () => {
+    expect(formatForPath("Daily/2026-05-18")).toBe("markdown");
+    expect(formatForPath("Inbox/idea")).toBe("markdown");
+  });
+
+  it("treats .md / .mdx / .markdown as markdown", () => {
+    expect(formatForPath("readme.md")).toBe("markdown");
+    expect(formatForPath("docs/Readme.MDX")).toBe("markdown");
+    expect(formatForPath("post.markdown")).toBe("markdown");
+  });
+
+  it("dispatches CSV / JSON / YAML", () => {
+    expect(formatForPath("ledger.csv")).toBe("csv");
+    expect(formatForPath("config.json")).toBe("json");
+    expect(formatForPath("config.yaml")).toBe("yaml");
+    expect(formatForPath("config.yml")).toBe("yaml");
+  });
+
+  it("dispatches recognized code extensions", () => {
+    expect(formatForPath("foo.ts")).toBe("code");
+    expect(formatForPath("foo.tsx")).toBe("code");
+    expect(formatForPath("foo.js")).toBe("code");
+    expect(formatForPath("foo.py")).toBe("code");
+    expect(formatForPath("foo.rs")).toBe("code");
+    expect(formatForPath("foo.go")).toBe("code");
+    expect(formatForPath("foo.sh")).toBe("code");
+  });
+
+  it("falls back to plain for unknown extensions", () => {
+    expect(formatForPath("blob.bin")).toBe("plain");
+    expect(formatForPath("snap.png")).toBe("plain");
+  });
+});
+
+describe("extensionOf", () => {
+  it("returns the lowercase extension", () => {
+    expect(extensionOf("foo.TS")).toBe("ts");
+    expect(extensionOf("dir/sub/file.yaml")).toBe("yaml");
+  });
+
+  it("returns empty for no-extension paths", () => {
+    expect(extensionOf("foo")).toBe("");
+    expect(extensionOf("dir.with.dots/foo")).toBe("");
+    expect(extensionOf(undefined)).toBe("");
+    expect(extensionOf("trailing.")).toBe("");
+  });
+});

--- a/src/lib/render/format.ts
+++ b/src/lib/render/format.ts
@@ -1,0 +1,52 @@
+// Format dispatch for the NoteRenderer.
+//
+// Phase 1 (parachute-vault) added file-extension support so non-markdown
+// notes (CSV, YAML, JSON, code) can be stored. Phase 2 (this) renders them
+// appropriately. The decision is purely extension-driven for now — content
+// sniffing could be added later but is out of scope per issue #138.
+
+export type NoteFormat = "markdown" | "csv" | "json" | "yaml" | "code" | "plain";
+
+// Map of known code-file extensions to the highlight.js language ID. The
+// CodeRenderer registers each lazily — see code-langs.ts.
+export const CODE_EXTENSIONS: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  py: "python",
+  rs: "rust",
+  go: "go",
+  sh: "bash",
+};
+
+export function formatForPath(path: string | undefined): NoteFormat {
+  if (!path) return "markdown";
+  // Trim a fragment or anything past a `?` defensively; vault paths shouldn't
+  // contain either but the dispatcher should be robust.
+  const cleaned = path.split(/[?#]/)[0] ?? path;
+  const ext = cleaned.toLowerCase().split(".").pop();
+  // No dot, or a path that ends with a dot — treat as markdown (the legacy
+  // default).
+  if (!ext || ext === cleaned.toLowerCase()) return "markdown";
+
+  if (ext === "md" || ext === "mdx" || ext === "markdown") return "markdown";
+  if (ext === "csv") return "csv";
+  if (ext === "json") return "json";
+  if (ext === "yaml" || ext === "yml") return "yaml";
+  if (ext in CODE_EXTENSIONS) return "code";
+  return "plain";
+}
+
+// Extract the lowercase extension (without the dot) from a path. Returns
+// the empty string for no-extension paths.
+export function extensionOf(path: string | undefined): string {
+  if (!path) return "";
+  const cleaned = path.split(/[?#]/)[0] ?? path;
+  const lower = cleaned.toLowerCase();
+  const dot = lower.lastIndexOf(".");
+  if (dot < 0 || dot === lower.length - 1) return "";
+  // If the last "." is in a directory portion, there's no extension.
+  if (lower.lastIndexOf("/") > dot) return "";
+  return lower.slice(dot + 1);
+}

--- a/src/lib/render/highlight.ts
+++ b/src/lib/render/highlight.ts
@@ -45,6 +45,15 @@ export function highlightAs(code: string, language: string): string {
   }
 }
 
+// Complete for both content (`<code>…</code>`) and attribute (`="…"`)
+// contexts. Current callers only use the content form, but the generic
+// name invites future attribute-context use — escape both quote chars
+// up front so a future caller doesn't reintroduce an XSS surface.
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
 }

--- a/src/lib/render/highlight.ts
+++ b/src/lib/render/highlight.ts
@@ -1,0 +1,50 @@
+// Singleton highlight.js instance used by the non-markdown renderers
+// (CodeRenderer, JsonRenderer, YamlRenderer).
+//
+// We use the `core` build and register only the languages we actually need;
+// the `common` build adds ~35 KB of languages we never reach for in the Notes
+// PWA. The markdown path keeps using `rehype-highlight`, which has its own
+// bundled language set — that's a separate concern.
+
+import hljsCore from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import go from "highlight.js/lib/languages/go";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import python from "highlight.js/lib/languages/python";
+import rust from "highlight.js/lib/languages/rust";
+import typescript from "highlight.js/lib/languages/typescript";
+import yaml from "highlight.js/lib/languages/yaml";
+
+let registered = false;
+
+function ensureRegistered(): typeof hljsCore {
+  if (registered) return hljsCore;
+  hljsCore.registerLanguage("typescript", typescript);
+  hljsCore.registerLanguage("javascript", javascript);
+  hljsCore.registerLanguage("python", python);
+  hljsCore.registerLanguage("rust", rust);
+  hljsCore.registerLanguage("go", go);
+  hljsCore.registerLanguage("bash", bash);
+  hljsCore.registerLanguage("json", json);
+  hljsCore.registerLanguage("yaml", yaml);
+  registered = true;
+  return hljsCore;
+}
+
+// Highlight `code` as `language`. Falls back to the empty string when the
+// language isn't registered — the renderer will then emit unstyled `<pre>`
+// text, which is still readable.
+export function highlightAs(code: string, language: string): string {
+  const hljs = ensureRegistered();
+  if (!hljs.getLanguage(language)) return escapeHtml(code);
+  try {
+    return hljs.highlight(code, { language, ignoreIllegals: true }).value;
+  } catch {
+    return escapeHtml(code);
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}


### PR DESCRIPTION
## Summary

Phase 2 of the file-extension work (Phase 1 in `parachute-vault` lets notes
store as CSV / JSON / YAML / code; Phase 2 — this PR — renders them
appropriately).

A new `NoteRenderer` dispatcher in `src/components/NoteRenderer.tsx`
examines the note's path extension and routes to one of six renderers:

- **`MarkdownView`** (unchanged) — `.md`, `.mdx`, `.markdown`, no extension
- **`CsvRenderer`** — `.csv` as an HTML `<table>` (first row = headers)
  via a hand-rolled RFC-4180 parser (quoted cells, escaped quotes,
  newlines-in-cells, CRLF, missing trailing newline)
- **`JsonRenderer`** — `.json` pretty-printed + syntax-highlighted; invalid
  JSON falls back to plain
- **`YamlRenderer`** — `.yaml` / `.yml` syntax-highlighted (no re-emit; the
  bytes render as authored)
- **`CodeRenderer`** — `.ts` / `.tsx` / `.js` / `.jsx` / `.py` / `.rs` /
  `.go` / `.sh` highlighted via `highlight.js/lib/core` with explicit
  per-language registration (skips the `/common` bundle's ~35 KB of unused
  languages)
- **`PlainRenderer`** — fallback for unknown extensions + parse failures

All three existing call sites (`NoteView`, `NoteEditor` preview,
`NoteNew` preview) now go through `NoteRenderer`. Editor preview reads
`draft.path` so renaming a draft to `.csv` flips the preview live.

**No new dependencies.** `highlight.js` was already a dep (used by
`rehype-highlight` for fenced markdown code blocks). The new renderers
reuse it directly; the github hljs theme already in `styles/index.css`
styles both code paths uniformly.

## Bundle size

| Chunk | Before | After | Δ |
|---|---|---|---|
| Largest lazy chunk (markdown / renderer family) | 337.29 kB / 102.30 kB gzip | 340.80 kB / 103.55 kB gzip | **+3.51 kB raw / +1.25 kB gzip** |
| Total PWA precache | 1574.85 KiB | 1578.53 KiB | +3.68 KiB |

The CSV parser is ~50 LOC inline; YAML / JSON / code rendering reuse the
already-present `highlight.js`. The only new bundle weight is the eight
language packs (`typescript`, `javascript`, `python`, `rust`, `go`,
`bash`, `json`, `yaml`).

## Test results

- **805/805 tests pass** across 91 files
- New tests:
  - `src/lib/render/csv.test.ts` — 10 parser cases (basic, quoted,
    escaped quotes, newlines-in-cells, CRLF, single column, empty,
    truncated, empty cells, missing trailing newline)
  - `src/lib/render/format.test.ts` — 8 dispatch cases
  - `src/components/render/CsvRenderer.test.tsx` — 5 cases incl. inline
    snapshot of the rendered table, truncated-warning surface, zero-row
    fallback
  - `src/components/render/JsonRenderer.test.tsx` — 3 cases (pretty-print,
    hljs class, invalid-JSON fallback)
  - `src/components/render/YamlRenderer.test.tsx` — 1 smoke test
  - `src/components/NoteRenderer.test.tsx` — 8 dispatcher cases (each
    extension + unknown-extension fallback + parse-error fallback)

## Gates

| Gate | Result |
|---|---|
| `bun run typecheck` | clean |
| `bun run lint` (biome) | clean (225 files, 0 errors) |
| `bun run test` (vitest) | **805 passed / 805 total** |
| `bun run build` | succeeds, bundle delta as above |

## Deliberately deferred

Out of scope for #138 — file as follow-ups when needed:

- **MDX with custom React components** — `.mdx` currently routes to
  `MarkdownView` like `.md`. Full MDX (component imports, JSX expressions)
  is a separate dep + threat-model question.
- **Image-format thumbnails for notes** — `.png` / `.jpg` / etc. notes
  currently fall through to the plain renderer (they'd need vault-blob
  fetch, which the attachment path has but the note-content path doesn't).
- **CodeMirror language-aware editing** — the editor still uses markdown
  grammar for every note. Renaming a draft to `.csv` switches the
  preview live but not the editor. Phase 3.

## Test plan

- [ ] Open a `.csv` note in Notes → renders as a table with headers
- [ ] Open a `.json` note → pretty-printed + syntax colors
- [ ] Open a `.yaml` note → syntax colors
- [ ] Open a `.ts` note → syntax colors
- [ ] Open a `.md` note (or no-extension) → markdown renders unchanged
- [ ] Open a `.xyz` note → plain monospace block
- [ ] In NoteEditor, rename a markdown draft path to `.csv` → preview
      switches to table view live as the path changes
- [ ] Malformed CSV (unterminated quote) → inline warning + partial table
- [ ] Invalid JSON → plain monospace fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)