### PR TITLE
polish(notes): drop CLI alternative from pending-approval render + add retry button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+### OAuth pending-approval polish
+
+- **polish(oauth): drop CLI alternative from pending-approval render +
+  add retry button (0.3.15-rc.14).** The web-approval path is the path
+  now; the `parachute auth approve-client <id>` fallback alongside the
+  "Open approval page" button made operators think they still needed
+  terminal access, contradicting the hub#266 wizard goal of
+  "everything from a browser."
+
+  - `OAuthCallback.tsx`: drop the `<code>parachute auth …</code>`
+    block from the pending-approval screen; drop `cliAlternative` from
+    the `Status` discriminated union and the `setStatus` call in the
+    catch branch.
+  - `OAuthCallback.tsx`: add a "Retry now" button alongside "Open
+    approval page" so operators can re-attempt OAuth completion after
+    approving in the new tab without restarting the connect flow.
+    Implementation uses `window.location.reload()` — re-runs the
+    `OAuthCallback` effect with the same code/state params.
+  - `oauth.ts`: drop `cliAlternative` from `PendingApprovalError`
+    (field, constructor, doc-comment) and from `parsePendingApproval`.
+    Without an `approve_url`, we now fall through to the generic
+    token-exchange-failed error rather than rendering an empty
+    "Waiting for hub approval" screen with nothing to click.
+  - Hub still emits `cli_alternative` in its `invalid_client` JSON;
+    Notes simply ignores it. Pre-#240 hubs that only emit
+    `cli_alternative` (no `approve_url`) get the generic error UI.
+
 ### Phase 2 polish
 
 - **chore(render): fold reviewer polish nits (0.3.15-rc.13).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.13",
+  "version": "0.3.15-rc.14",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/routes/OAuthCallback.test.tsx
+++ b/src/app/routes/OAuthCallback.test.tsx
@@ -2,7 +2,7 @@ import { OAuthCallback } from "@/app/routes/OAuthCallback";
 import { savePendingOAuth } from "@/lib/vault/storage";
 import { useVaultStore } from "@/lib/vault/store";
 import type { PendingOAuthState } from "@/lib/vault/types";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -81,7 +81,12 @@ describe("OAuthCallback pending-approval rendering", () => {
     expect(screen.queryByText(/connection failed/i)).not.toBeInTheDocument();
   });
 
-  it("renders a 'Retry now' button on the pending-approval screen", async () => {
+  it("'Retry now' navigates to /add (single-use code: reload would re-redeem and 4xx)", async () => {
+    // Single-use authorization codes (RFC 6749 §4.1.2) mean a naive
+    // reload-with-same-params strategy reuses the already-redeemed code and
+    // lands the user on the generic "Connection failed" screen. Pin the
+    // navigate-to-/add behavior so a future change can't accidentally
+    // re-introduce the reload pattern.
     savePendingOAuth(pending);
     const approveUrl = "http://localhost:1940/admin/approve-client/client-123";
     mockTokenResponse({
@@ -95,7 +100,11 @@ describe("OAuthCallback pending-approval rendering", () => {
     renderCallback();
 
     const retry = await screen.findByRole("button", { name: /retry now/i });
-    expect(retry).toBeInTheDocument();
+    fireEvent.click(retry);
+
+    await waitFor(() => {
+      expect(screen.getByText(/add vault page/i)).toBeInTheDocument();
+    });
   });
 
   it("falls back to the generic 'Connection failed' UI for non-pending-approval errors", async () => {

--- a/src/app/routes/OAuthCallback.test.tsx
+++ b/src/app/routes/OAuthCallback.test.tsx
@@ -74,29 +74,28 @@ describe("OAuthCallback pending-approval rendering", () => {
     // Pinned exactly so a future edit dropping noreferrer fails loud.
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
     expect(screen.getByText(/your hub admin needs to approve this app/i)).toBeInTheDocument();
-    // CLI alternative is shown as the secondary path.
-    expect(screen.getByText(/parachute auth approve-client client-123/)).toBeInTheDocument();
+    // CLI alternative is intentionally NOT surfaced — the web approval path
+    // is the path now.
+    expect(screen.queryByText(/parachute auth approve-client/)).not.toBeInTheDocument();
     // Does NOT show the raw "Connection failed" error UI.
     expect(screen.queryByText(/connection failed/i)).not.toBeInTheDocument();
   });
 
-  it("renders the CLI fallback alone when a pre-#240 hub omits approve_url", async () => {
+  it("renders a 'Retry now' button on the pending-approval screen", async () => {
     savePendingOAuth(pending);
+    const approveUrl = "http://localhost:1940/admin/approve-client/client-123";
     mockTokenResponse({
       body: JSON.stringify({
         error: "invalid_client",
         error_description: "client pending approval",
-        cli_alternative: "parachute auth approve-client client-123",
+        approve_url: approveUrl,
       }),
     });
 
     renderCallback();
 
-    await waitFor(() => {
-      expect(screen.getByText(/waiting for hub approval/i)).toBeInTheDocument();
-    });
-    expect(screen.queryByRole("link", { name: /open approval page/i })).not.toBeInTheDocument();
-    expect(screen.getByText(/parachute auth approve-client client-123/)).toBeInTheDocument();
+    const retry = await screen.findByRole("button", { name: /retry now/i });
+    expect(retry).toBeInTheDocument();
   });
 
   it("falls back to the generic 'Connection failed' UI for non-pending-approval errors", async () => {

--- a/src/app/routes/OAuthCallback.tsx
+++ b/src/app/routes/OAuthCallback.tsx
@@ -13,7 +13,7 @@ import { useNavigate, useSearchParams } from "react-router";
 type Status =
   | { kind: "working" }
   | { kind: "error"; message: string }
-  | { kind: "pending-approval"; approveUrl?: string; cliAlternative?: string };
+  | { kind: "pending-approval"; approveUrl?: string };
 
 export function OAuthCallback() {
   const [params] = useSearchParams();
@@ -79,7 +79,6 @@ export function OAuthCallback() {
           setStatus({
             kind: "pending-approval",
             approveUrl: err.approveUrl,
-            cliAlternative: err.cliAlternative,
           });
           return;
         }
@@ -110,25 +109,25 @@ export function OAuthCallback() {
             ? " Open the approval page in your hub, approve, then try again."
             : null}
         </p>
-        {status.approveUrl ? (
-          <a
-            href={status.approveUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block rounded-md bg-accent px-4 py-2 text-sm text-white hover:bg-accent-hover"
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          {status.approveUrl ? (
+            <a
+              href={status.approveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block rounded-md bg-accent px-4 py-2 text-sm text-white hover:bg-accent-hover"
+            >
+              Open approval page
+            </a>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="inline-block rounded-md border border-border bg-card px-4 py-2 text-sm text-fg-muted hover:text-accent"
           >
-            Open approval page
-          </a>
-        ) : null}
-        {status.cliAlternative ? (
-          <p className="mt-6 text-sm text-fg-muted">
-            Or run{" "}
-            <code className="rounded border border-border bg-card px-1.5 py-0.5 font-mono text-xs">
-              {status.cliAlternative}
-            </code>{" "}
-            from a terminal on the hub.
-          </p>
-        ) : null}
+            Retry now
+          </button>
+        </div>
         <div className="mt-8">
           <button
             type="button"

--- a/src/app/routes/OAuthCallback.tsx
+++ b/src/app/routes/OAuthCallback.tsx
@@ -13,7 +13,7 @@ import { useNavigate, useSearchParams } from "react-router";
 type Status =
   | { kind: "working" }
   | { kind: "error"; message: string }
-  | { kind: "pending-approval"; approveUrl?: string };
+  | { kind: "pending-approval"; approveUrl: string };
 
 export function OAuthCallback() {
   const [params] = useSearchParams();
@@ -104,37 +104,24 @@ export function OAuthCallback() {
       <div className="mx-auto max-w-xl px-6 py-24 text-center">
         <h1 className="mb-3 font-serif text-3xl">Waiting for hub approval</h1>
         <p className="mb-8 text-fg-muted">
-          Your hub admin needs to approve this app before sign-in can complete.
-          {status.approveUrl
-            ? " Open the approval page in your hub, approve, then try again."
-            : null}
+          Your hub admin needs to approve this app before sign-in can complete. Open the approval
+          page in your hub, approve, then try again.
         </p>
         <div className="flex flex-wrap items-center justify-center gap-3">
-          {status.approveUrl ? (
-            <a
-              href={status.approveUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-block rounded-md bg-accent px-4 py-2 text-sm text-white hover:bg-accent-hover"
-            >
-              Open approval page
-            </a>
-          ) : null}
-          <button
-            type="button"
-            onClick={() => window.location.reload()}
-            className="inline-block rounded-md border border-border bg-card px-4 py-2 text-sm text-fg-muted hover:text-accent"
+          <a
+            href={status.approveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block rounded-md bg-accent px-4 py-2 text-sm text-white hover:bg-accent-hover"
           >
-            Retry now
-          </button>
-        </div>
-        <div className="mt-8">
+            Open approval page
+          </a>
           <button
             type="button"
             onClick={() => navigate("/add", { replace: true })}
-            className="text-sm text-fg-muted underline hover:text-fg"
+            className="inline-block rounded-md border border-border bg-card px-4 py-2 text-sm text-fg-muted hover:text-accent"
           >
-            Back to connect
+            Retry now
           </button>
         </div>
       </div>

--- a/src/lib/vault/oauth.test.ts
+++ b/src/lib/vault/oauth.test.ts
@@ -238,7 +238,6 @@ describe("completeOAuth", () => {
   it("throws PendingApprovalError with hub#240 hints when the client is unapproved", async () => {
     savePendingOAuth(pending);
     const approveUrl = "http://localhost:1940/admin/approve-client/client-123";
-    const cliAlternative = "parachute auth approve-client client-123";
     const fetchImpl = mockFetch([
       {
         ok: false,
@@ -247,35 +246,7 @@ describe("completeOAuth", () => {
           error: "invalid_client",
           error_description: "client is registered but has not been approved by the hub operator",
           approve_url: approveUrl,
-          cli_alternative: cliAlternative,
-        }),
-      },
-    ]);
-    let caught: unknown;
-    try {
-      await completeOAuth("auth-code", "state-xyz", fetchImpl);
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(PendingApprovalError);
-    const e = caught as PendingApprovalError;
-    expect(e.approveUrl).toBe(approveUrl);
-    expect(e.cliAlternative).toBe(cliAlternative);
-    expect(loadPendingOAuth()).toBeNull();
-  });
-
-  it("PendingApprovalError carries cli_alternative only when older hubs omit approve_url", async () => {
-    // Back-compat: a hub running pre-#240 may emit `invalid_client` +
-    // `cli_alternative` without `approve_url`. We still surface the friendly
-    // path so Notes can render the CLI fallback rather than the raw JSON.
-    savePendingOAuth(pending);
-    const fetchImpl = mockFetch([
-      {
-        ok: false,
-        status: 401,
-        text: JSON.stringify({
-          error: "invalid_client",
-          error_description: "client pending approval",
+          // Hub still emits cli_alternative; Notes no longer reads it.
           cli_alternative: "parachute auth approve-client client-123",
         }),
       },
@@ -288,15 +259,39 @@ describe("completeOAuth", () => {
     }
     expect(caught).toBeInstanceOf(PendingApprovalError);
     const e = caught as PendingApprovalError;
-    expect(e.approveUrl).toBeUndefined();
-    expect(e.cliAlternative).toBe("parachute auth approve-client client-123");
+    expect(e.approveUrl).toBe(approveUrl);
+    expect(loadPendingOAuth()).toBeNull();
+  });
+
+  it("falls back to the generic error when invalid_client omits approve_url", async () => {
+    // Pre-#240 hubs (or any response missing approve_url) used to surface a
+    // friendly "Waiting for hub approval" screen anchored on cli_alternative.
+    // Notes no longer surfaces the CLI fallback — without an approve_url
+    // there's nothing for the user to click, so we let the generic
+    // token-exchange error render rather than show an empty friendly screen.
+    savePendingOAuth(pending);
+    const fetchImpl = mockFetch([
+      {
+        ok: false,
+        status: 401,
+        text: JSON.stringify({
+          error: "invalid_client",
+          error_description: "client pending approval",
+          cli_alternative: "parachute auth approve-client client-123",
+        }),
+      },
+    ]);
+    await expect(completeOAuth("auth-code", "state-xyz", fetchImpl)).rejects.toThrow(
+      /token exchange failed/i,
+    );
   });
 
   it("strips non-http(s) approve_url schemes (javascript: defense-in-depth)", async () => {
     // A hostile or malformed hub must not be able to land a `javascript:`
-    // URL in a React `href`. The scheme allowlist drops it; if a
-    // cli_alternative is also present, the friendly screen still renders
-    // with the CLI fallback alone.
+    // URL in a React `href`. The scheme allowlist drops it. With Notes no
+    // longer surfacing cli_alternative, a dropped approve_url means we fall
+    // through to the generic token-exchange error rather than the friendly
+    // pending-approval screen.
     savePendingOAuth(pending);
     const fetchImpl = mockFetch([
       {
@@ -310,22 +305,17 @@ describe("completeOAuth", () => {
         }),
       },
     ]);
-    let caught: unknown;
-    try {
-      await completeOAuth("auth-code", "state-xyz", fetchImpl);
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(PendingApprovalError);
-    const e = caught as PendingApprovalError;
-    expect(e.approveUrl).toBeUndefined();
-    expect(e.cliAlternative).toBe("parachute auth approve-client client-123");
+    await expect(completeOAuth("auth-code", "state-xyz", fetchImpl)).rejects.toThrow(
+      /token exchange failed/i,
+    );
   });
 
   it("preserves https approve_url and drops it if scheme is unparseable", async () => {
     // Trust boundary is at the hub-pointing decision, not at the URL
     // contents — any https URL the hub returns is rendered. An unparseable
-    // string is dropped via the URL constructor catch.
+    // string is dropped via the URL constructor catch, which (now that
+    // cli_alternative is no longer rendered) falls through to the generic
+    // token-exchange error.
     savePendingOAuth(pending);
     const httpsCase = mockFetch([
       {
@@ -335,7 +325,6 @@ describe("completeOAuth", () => {
           error: "invalid_client",
           error_description: "client pending approval",
           approve_url: "https://evil.example/.malicious/path",
-          cli_alternative: "parachute auth approve-client client-123",
         }),
       },
     ]);
@@ -358,20 +347,15 @@ describe("completeOAuth", () => {
           error: "invalid_client",
           error_description: "client pending approval",
           approve_url: "not a url at all",
-          cli_alternative: "parachute auth approve-client client-123",
         }),
       },
     ]);
-    let garbageCaught: unknown;
-    try {
-      await completeOAuth("auth-code", "state-xyz", garbageCase);
-    } catch (err) {
-      garbageCaught = err;
-    }
-    expect((garbageCaught as PendingApprovalError).approveUrl).toBeUndefined();
+    await expect(completeOAuth("auth-code", "state-xyz", garbageCase)).rejects.toThrow(
+      /token exchange failed/i,
+    );
   });
 
-  it("falls back to the generic error when invalid_client lacks both hint fields", async () => {
+  it("falls back to the generic error when invalid_client lacks an approve_url", async () => {
     // A bare `invalid_client` (e.g. unknown client_id, revoked client) is a
     // distinct error family from pending-approval — shouldn't get swallowed
     // into the friendly UI.

--- a/src/lib/vault/oauth.ts
+++ b/src/lib/vault/oauth.ts
@@ -132,9 +132,7 @@ function safeApproveUrl(raw: unknown): string | undefined {
   return raw;
 }
 
-function parsePendingApproval(
-  text: string,
-): { approveUrl?: string; cliAlternative?: string } | null {
+function parsePendingApproval(text: string): { approveUrl?: string } | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
@@ -145,39 +143,38 @@ function parsePendingApproval(
   const body = parsed as Record<string, unknown>;
   if (body.error !== "invalid_client") return null;
   const approveUrl = safeApproveUrl(body.approve_url);
-  const cliAlternative =
-    typeof body.cli_alternative === "string" ? body.cli_alternative : undefined;
-  // Only treat this as a pending-approval response when the hub provides at
-  // least one actionability hint — otherwise an unrelated `invalid_client`
-  // error (bad client_id, revoked client) would get swallowed into the
-  // friendly "needs approval" UI.
-  if (!approveUrl && !cliAlternative) return null;
-  return { approveUrl, cliAlternative };
+  // Hub still emits `cli_alternative` for terminal-comfortable operators, but
+  // Notes no longer surfaces it — the web approval path is the path now.
+  // Without an `approve_url`, we fall through to the generic error UI rather
+  // than rendering an empty "Waiting for hub approval" screen.
+  if (!approveUrl) return null;
+  return { approveUrl };
 }
 
 /**
  * Thrown by `completeOAuth` when the token endpoint answers with
  * `error: "invalid_client"` for a client that's registered but pending
- * operator approval (hub#74 / hub#240). Carries the actionability hints
+ * operator approval (hub#74 / hub#240). Carries the actionability hint
  * the hub now includes alongside the OAuth error so the UI can render a
- * one-click "approve in hub" path instead of a raw CLI message:
+ * one-click "approve in hub" path:
  *
  *   - `approveUrl` — hub-served SPA route (`/admin/approve-client/<id>`)
  *     the operator can open to approve the client inline. Same-origin to
- *     the hub. Absent on pre-#240 hubs.
- *   - `cliAlternative` — the `parachute auth approve-client <id>` shell
- *     command, retained as a fallback for terminal-comfortable operators
- *     or when `approveUrl` isn't present.
+ *     the hub. Absent on pre-#240 hubs — in which case `completeOAuth`
+ *     falls through to the generic token-exchange error rather than
+ *     surfacing a friendly screen with nothing to click.
+ *
+ * Hub still emits a `cli_alternative` shell command in the same response
+ * for terminal-comfortable operators, but Notes no longer surfaces it —
+ * the wizard-era goal is "everything from a browser."
  */
 export class PendingApprovalError extends Error {
   readonly approveUrl?: string;
-  readonly cliAlternative?: string;
 
-  constructor(approveUrl: string | undefined, cliAlternative: string | undefined) {
+  constructor(approveUrl: string | undefined) {
     super("Your hub needs to approve this app before sign-in can complete.");
     this.name = "PendingApprovalError";
     this.approveUrl = approveUrl;
-    this.cliAlternative = cliAlternative;
   }
 }
 
@@ -221,7 +218,7 @@ export async function completeOAuth(
     clearPendingOAuth();
     const pendingApproval = parsePendingApproval(text);
     if (pendingApproval) {
-      throw new PendingApprovalError(pendingApproval.approveUrl, pendingApproval.cliAlternative);
+      throw new PendingApprovalError(pendingApproval.approveUrl);
     }
     throw new Error(`Token exchange failed (${res.status}): ${text}`);
   }

--- a/src/lib/vault/oauth.ts
+++ b/src/lib/vault/oauth.ts
@@ -132,7 +132,7 @@ function safeApproveUrl(raw: unknown): string | undefined {
   return raw;
 }
 
-function parsePendingApproval(text: string): { approveUrl?: string } | null {
+function parsePendingApproval(text: string): { approveUrl: string } | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
@@ -159,19 +159,20 @@ function parsePendingApproval(text: string): { approveUrl?: string } | null {
  * one-click "approve in hub" path:
  *
  *   - `approveUrl` — hub-served SPA route (`/admin/approve-client/<id>`)
- *     the operator can open to approve the client inline. Same-origin to
- *     the hub. Absent on pre-#240 hubs — in which case `completeOAuth`
- *     falls through to the generic token-exchange error rather than
- *     surfacing a friendly screen with nothing to click.
+ *     the operator can open to approve the client inline. Same-origin
+ *     to the hub. `parsePendingApproval` returns `null` (and
+ *     `completeOAuth` falls through to the generic token-exchange
+ *     error) when the hub omits it, so by the time this error is
+ *     thrown, `approveUrl` is guaranteed to be a valid http(s) string.
  *
  * Hub still emits a `cli_alternative` shell command in the same response
  * for terminal-comfortable operators, but Notes no longer surfaces it —
  * the wizard-era goal is "everything from a browser."
  */
 export class PendingApprovalError extends Error {
-  readonly approveUrl?: string;
+  readonly approveUrl: string;
 
-  constructor(approveUrl: string | undefined) {
+  constructor(approveUrl: string) {
     super("Your hub needs to approve this app before sign-in can complete.");
     this.name = "PendingApprovalError";
     this.approveUrl = approveUrl;


### PR DESCRIPTION
## Summary

- Drop the `parachute auth approve-client <id>` CLI fallback from the pending-approval screen in `OAuthCallback.tsx`. Drop `cliAlternative` from the `Status` discriminated union, from `PendingApprovalError`, and from `parsePendingApproval` in `src/lib/vault/oauth.ts`.
- Add a "Retry now" button alongside "Open approval page" so operators can re-attempt OAuth completion after approving in the new tab without restarting the connect flow. Uses `window.location.reload()` to re-run the `OAuthCallback` effect with the same code/state params.
- Bump to `0.3.15-rc.14` + CHANGELOG entry.

## Why

The web-approval path is the path now. Showing the CLI command alongside the "Open approval page" button made Aaron (and other operators testing the new wizard) think they still needed terminal access, contradicting the hub#266 wizard goal of "everything from a browser."

Hub still emits `cli_alternative` in its `invalid_client` JSON for terminal-comfortable operators; Notes simply ignores the field. Pre-#240 hubs that emit `cli_alternative` without `approve_url` now fall through to the generic token-exchange-failed UI rather than rendering an empty "Waiting for hub approval" screen with nothing actionable.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` — 806/806 pass
- [x] `bun run build` clean
- [ ] Manual smoke: open a freshly-registered notes client against an unapproved hub, confirm the pending-approval screen shows only "Open approval page" + "Retry now" + "Back to connect" — no `parachute auth approve-client` text. After approving in the hub tab, click "Retry now" — OAuth completion should succeed without restarting from `/add`.