### PR TITLE
chore(release): 0.3.15 stable (rc chain → @latest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.3.15] - 2026-05-20
+## 0.3.15 (2026-05-20)
 
 Stable release. Cumulative changes since `0.3.14`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.3.15] - 2026-05-20
+
+Stable release. Cumulative changes since `0.3.14`:
+
+- **Format-aware rendering Phase 2** (#139): native rendering for CSV (table), JSON (pretty-print), YAML (formatted), code (syntax-highlighted) note bodies. Auto-detected by content type.
+- **Hierarchical capture** (#134, others): autosave draft model + text-size global zoom + capture-flow polish across multiple rc.10-rc.13 iterations.
+- **Cross-tab sync** (#131, others): notes edited in one tab reflect in others within seconds.
+- **Schema-audit UI** (#136): surface vault schema state from the notes UI.
+- **Pending-approval render polish** (#140): dropped the CLI alternative from the OAuth pending-approval screen — the web-based approval path is now the only displayed path. Added "Retry now" button that navigates back to `/add` (works correctly with single-use OAuth codes).
+
+See individual rc entries below for full detail.
+
 ## Unreleased
 
 ### OAuth pending-approval polish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.15-rc.14",
+  "version": "0.3.15",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",


### PR DESCRIPTION
## Summary

Capping the `0.3.15-rc.1` through `0.3.15-rc.14` chain into stable `0.3.15`. No code changes — version bump in `package.json` + stable entry at the top of `CHANGELOG.md`.

## Cumulative changes since 0.3.14

- **Format-aware rendering Phase 2** (#139): native rendering for CSV (table), JSON (pretty-print), YAML (formatted), code (syntax-highlighted) note bodies. Auto-detected by content type.
- **Hierarchical capture** (#134, others): autosave draft model + text-size global zoom + capture-flow polish across rc.10-rc.13.
- **Cross-tab sync** (#131, others): notes edited in one tab reflect in others within seconds.
- **Schema-audit UI** (#136): surface vault schema state from the notes UI.
- **Pending-approval render polish** (#140): dropped the CLI alternative from the OAuth pending-approval screen; added "Retry now" button.

## Verification

- `bun run test` → 806/806 passing across 91 test files
- `bun run build` → clean

## Aaron's next action (post-merge)

```
npm publish --tag latest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)