### PR TITLE
refactor(notes): move InsecureContextBanner to src/components/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.16-rc.2 (2026-05-21)
+
+- **refactor(notes): move `InsecureContextBanner` to `src/components/`.**
+  The banner was originally defined and exported from
+  `src/app/routes/AddVault.tsx` (where it was first used) and imported
+  from there by `VaultPopover.tsx` and `VaultStatusBanner.tsx`. That's
+  a components-importing-from-routes dependency inversion — routes
+  should be leaves. Relocated to
+  `src/components/InsecureContextBanner.tsx` with no behavior change;
+  three import sites updated. Closes #143.
+
 ## 0.3.16-rc.1 (2026-05-20)
 
 - **fix(notes): clear error message when OAuth attempted from insecure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.16-rc.1",
+  "version": "0.3.16-rc.2",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/routes/AddVault.tsx
+++ b/src/app/routes/AddVault.tsx
@@ -1,3 +1,4 @@
+import { InsecureContextBanner } from "@/components/InsecureContextBanner";
 import { beginOAuth, normalizeVaultUrl, useOriginVaultProbe } from "@/lib/vault";
 import { InsecureContextError } from "@/lib/vault/pkce";
 import { type FormEvent, useEffect, useRef, useState } from "react";
@@ -109,56 +110,6 @@ export function AddVault() {
           {submitting ? "Starting OAuth…" : "Continue"}
         </button>
       </form>
-    </div>
-  );
-}
-
-/**
- * Distinct banner for the insecure-context failure mode (Web Crypto
- * unavailable). Amber / warning palette deliberately — visually
- * different from the generic red "Connection failed" error above so
- * the operator can tell at a glance this isn't "your hub is down" but
- * "your browser refuses to OAuth from this URL." The body lists both
- * remediations (use localhost form, or terminate HTTPS at a tunnel /
- * reverse proxy) and shows the exact origin the browser flagged so
- * there's no ambiguity about which URL the user is on.
- *
- * Exported for use by other OAuth-initiating components
- * (`VaultStatusBanner`'s reconnect path, `VaultPopover`'s connect
- * button) so the messaging stays identical wherever PKCE can fail.
- */
-export function InsecureContextBanner() {
-  // `window.location.origin` is safe in the React render path — Notes
-  // is a browser SPA, there's no SSR. Showing it back to the operator
-  // verbatim is the whole point: they need to see the exact URL the
-  // browser is treating as insecure, not a generic "this page."
-  const currentOrigin =
-    typeof window !== "undefined" && window.location ? window.location.origin : "(unknown origin)";
-  return (
-    <div
-      role="alert"
-      aria-live="assertive"
-      data-testid="insecure-context-banner"
-      className="rounded-md border border-amber-400/40 bg-amber-400/10 px-3 py-3 text-sm text-amber-100"
-    >
-      <p className="mb-2 flex items-center gap-2 font-medium text-amber-100">
-        <span aria-hidden>⚠</span>
-        Insecure context — OAuth unavailable
-      </p>
-      <p className="mb-2 text-xs text-amber-100/90">
-        Your hub URL must be served over HTTPS or accessed at <code>http://localhost</code>. This
-        page is at <code className="font-mono">{currentOrigin}</code>, which the browser treats as
-        insecure for Web Crypto. To connect:
-      </p>
-      <ul className="ml-4 list-disc space-y-1 text-xs text-amber-100/90">
-        <li>
-          Use <code>http://localhost</code> or <code>http://127.0.0.1</code> directly (replace your
-          hub URL with the localhost form), <strong>or</strong>
-        </li>
-        <li>
-          Serve your hub over HTTPS via Tailscale Serve, Cloudflare Tunnel, or a reverse proxy.
-        </li>
-      </ul>
     </div>
   );
 }

--- a/src/components/InsecureContextBanner.tsx
+++ b/src/components/InsecureContextBanner.tsx
@@ -1,0 +1,49 @@
+/**
+ * Distinct banner for the insecure-context failure mode (Web Crypto
+ * unavailable). Amber / warning palette deliberately — visually
+ * different from the generic red "Connection failed" error so the
+ * operator can tell at a glance this isn't "your hub is down" but
+ * "your browser refuses to OAuth from this URL." The body lists both
+ * remediations (use localhost form, or terminate HTTPS at a tunnel /
+ * reverse proxy) and shows the exact origin the browser flagged so
+ * there's no ambiguity about which URL the user is on.
+ *
+ * Used by every OAuth-initiating call site (`AddVault`,
+ * `VaultStatusBanner`'s reconnect path, `VaultPopover`'s connect
+ * button) so the messaging stays identical wherever PKCE can fail.
+ */
+export function InsecureContextBanner() {
+  // `window.location.origin` is safe in the React render path — Notes
+  // is a browser SPA, there's no SSR. Showing it back to the operator
+  // verbatim is the whole point: they need to see the exact URL the
+  // browser is treating as insecure, not a generic "this page."
+  const currentOrigin =
+    typeof window !== "undefined" && window.location ? window.location.origin : "(unknown origin)";
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      data-testid="insecure-context-banner"
+      className="rounded-md border border-amber-400/40 bg-amber-400/10 px-3 py-3 text-sm text-amber-100"
+    >
+      <p className="mb-2 flex items-center gap-2 font-medium text-amber-100">
+        <span aria-hidden>⚠</span>
+        Insecure context — OAuth unavailable
+      </p>
+      <p className="mb-2 text-xs text-amber-100/90">
+        Your hub URL must be served over HTTPS or accessed at <code>http://localhost</code>. This
+        page is at <code className="font-mono">{currentOrigin}</code>, which the browser treats as
+        insecure for Web Crypto. To connect:
+      </p>
+      <ul className="ml-4 list-disc space-y-1 text-xs text-amber-100/90">
+        <li>
+          Use <code>http://localhost</code> or <code>http://127.0.0.1</code> directly (replace your
+          hub URL with the localhost form), <strong>or</strong>
+        </li>
+        <li>
+          Serve your hub over HTTPS via Tailscale Serve, Cloudflare Tunnel, or a reverse proxy.
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/components/VaultPopover.tsx
+++ b/src/components/VaultPopover.tsx
@@ -1,4 +1,4 @@
-import { InsecureContextBanner } from "@/app/routes/AddVault";
+import { InsecureContextBanner } from "@/components/InsecureContextBanner";
 import {
   type HubVaultEntry,
   type VaultRecord,

--- a/src/components/VaultStatusBanner.tsx
+++ b/src/components/VaultStatusBanner.tsx
@@ -1,4 +1,4 @@
-import { InsecureContextBanner } from "@/app/routes/AddVault";
+import { InsecureContextBanner } from "@/components/InsecureContextBanner";
 import { useAuthHaltStore } from "@/lib/vault/auth-halt-store";
 import { beginOAuth } from "@/lib/vault/oauth";
 import { InsecureContextError } from "@/lib/vault/pkce";


### PR DESCRIPTION
Closes #143.

`InsecureContextBanner` was defined and exported from `src/app/routes/AddVault.tsx` (where it was first used in notes#142) and imported from there by `src/components/VaultPopover.tsx` and `src/components/VaultStatusBanner.tsx`. That's a components-importing-from-routes dependency inversion — routes should be leaves in the dependency tree.

This PR moves the component to `src/components/InsecureContextBanner.tsx` with no behavior change and updates the three import sites.

## Files

- new: `src/components/InsecureContextBanner.tsx`
- `src/app/routes/AddVault.tsx` — remove local definition, import from `@/components/InsecureContextBanner`
- `src/components/VaultPopover.tsx` — switch import path
- `src/components/VaultStatusBanner.tsx` — switch import path

## Versioning

Bumps `0.3.16-rc.1` → `0.3.16-rc.2`. CHANGELOG entry added.

## Verification

- `bun run typecheck` clean
- `bun run lint` (biome) clean
- `bun run test` — 813 passed / 813 (same as pre-change baseline)
- `bun run build` — SPA + SW build clean

## Note on issue scope

Issue #143 also mentions adding component-level tests for the insecure-context catch paths in `VaultPopover` and `VaultStatusBanner` ("`AddVault.test.tsx` already has end-to-end coverage; the other two only have indirect coverage via the pkce.ts unit tests"). This PR is scoped to the relocation only per the brief; the additional component tests can be a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)