### PR TITLE
test(notes): component-level insecure-context tests (#143 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.3.16-rc.3] - 2026-05-21
+
+- **test(notes): component-level insecure-context tests for VaultPopover
+  + VaultStatusBanner (#143 follow-up).** The rc.2 refactor pointed both
+  components at the relocated `InsecureContextBanner` but the only
+  insecure-context coverage lived in `AddVault.test.tsx`. Extends each
+  consumer's test file with focused tests pinned at the right
+  boundary: spy on `beginOAuth` and reject with `InsecureContextError`
+  to verify the dedicated banner renders, plus a negative test that a
+  generic `Error` falls through to the regular error UI (and not the
+  insecure-context banner). Catches future refactors that would
+  silently break the wiring.
+
 ## 0.3.16-rc.2 (2026-05-21)
 
 - **refactor(notes): move `InsecureContextBanner` to `src/components/`.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.16-rc.2",
+  "version": "0.3.16-rc.3",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/components/VaultPopover.test.tsx
+++ b/src/components/VaultPopover.test.tsx
@@ -1,6 +1,7 @@
 import { VaultPopover, buildVaultPopoverRows } from "@/components/VaultPopover";
 import type { HubVaultEntry } from "@/lib/vault/hub-discovery";
 import * as oauthModule from "@/lib/vault/oauth";
+import { InsecureContextError } from "@/lib/vault/pkce";
 import { useVaultStore } from "@/lib/vault/store";
 import type { VaultRecord } from "@/lib/vault/types";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -273,5 +274,81 @@ describe("VaultPopover (component)", () => {
     await waitFor(() =>
       expect(assignSpy).toHaveBeenCalledWith("http://localhost:1939/oauth/authorize?test"),
     );
+  });
+
+  // notes#143 follow-up: a refactor of the Connect handler could silently
+  // drop the InsecureContextError branch and the user would be back to the
+  // cryptic generic-error one-liner. Pin the wiring with a component-level
+  // test that doesn't depend on AddVault.
+  it("renders the InsecureContextBanner when beginOAuth throws InsecureContextError", async () => {
+    useVaultStore.setState({
+      vaults: {
+        v: makeVault({ id: "v", url: "http://localhost:1939/vault/default", name: "default" }),
+      },
+      activeVaultId: "v",
+    });
+    global.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            vaults: [
+              { name: "default", url: "http://localhost:1939/vault/default", version: "0.1.0" },
+              { name: "techne", url: "http://localhost:1939/vault/techne", version: "0.1.0" },
+            ],
+            services: [],
+          }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+    vi.spyOn(oauthModule, "beginOAuth").mockRejectedValue(
+      new InsecureContextError("insecure context"),
+    );
+
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: /active vault/i }));
+    await waitFor(() => expect(screen.getByText("techne")).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Connect$/ }));
+    });
+
+    const banner = await screen.findByTestId("insecure-context-banner");
+    expect(banner).toHaveTextContent(/Insecure context/i);
+    expect(banner).toHaveTextContent(/HTTPS or accessed at/i);
+  });
+
+  it("does not render the InsecureContextBanner on a generic beginOAuth error", async () => {
+    useVaultStore.setState({
+      vaults: {
+        v: makeVault({ id: "v", url: "http://localhost:1939/vault/default", name: "default" }),
+      },
+      activeVaultId: "v",
+    });
+    global.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            vaults: [
+              { name: "default", url: "http://localhost:1939/vault/default", version: "0.1.0" },
+              { name: "techne", url: "http://localhost:1939/vault/techne", version: "0.1.0" },
+            ],
+            services: [],
+          }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+    vi.spyOn(oauthModule, "beginOAuth").mockRejectedValue(new Error("hub returned 502"));
+
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: /active vault/i }));
+    await waitFor(() => expect(screen.getByText("techne")).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Connect$/ }));
+    });
+
+    // The dedicated banner stays hidden; the generic error line surfaces instead.
+    await waitFor(() => expect(screen.getByText(/hub returned 502/i)).toBeInTheDocument());
+    expect(screen.queryByTestId("insecure-context-banner")).not.toBeInTheDocument();
   });
 });

--- a/src/components/VaultStatusBanner.test.tsx
+++ b/src/components/VaultStatusBanner.test.tsx
@@ -47,6 +47,7 @@ function renderBanner() {
 
 describe("VaultStatusBanner", () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     seedVault();
     localStorage.clear();
     useAuthHaltStore.setState({ byVault: {} });
@@ -58,6 +59,7 @@ describe("VaultStatusBanner", () => {
     localStorage.clear();
     useAuthHaltStore.setState({ byVault: {} });
     useVaultReachabilityStore.setState({ byVault: {} });
+    vi.restoreAllMocks();
   });
 
   it("renders nothing when both stores are clean", () => {

--- a/src/components/VaultStatusBanner.test.tsx
+++ b/src/components/VaultStatusBanner.test.tsx
@@ -1,9 +1,11 @@
 import { VaultStatusBanner, isLoopbackOrLocal } from "@/components/VaultStatusBanner";
 import { useAuthHaltStore } from "@/lib/vault/auth-halt-store";
+import * as oauthModule from "@/lib/vault/oauth";
+import { InsecureContextError } from "@/lib/vault/pkce";
 import { useVaultReachabilityStore } from "@/lib/vault/reachability-store";
 import { useVaultStore } from "@/lib/vault/store";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // The banner uses `useActiveVaultClient` for the Retry button. Stub it out
@@ -140,6 +142,43 @@ describe("VaultStatusBanner", () => {
     renderBanner();
     fireEvent.click(screen.getByRole("button", { name: /dismiss banner/i }));
     expect(useVaultReachabilityStore.getState().byVault.v).toBeUndefined();
+  });
+
+  // notes#143 follow-up: pin the auth-halt reconnect path's wiring to
+  // `InsecureContextBanner` at the component level so a refactor of the
+  // catch branch is caught here rather than in production.
+  it("renders the InsecureContextBanner when Reconnect's beginOAuth throws InsecureContextError", async () => {
+    useAuthHaltStore.getState().markHalted("v", "session expired");
+    vi.spyOn(oauthModule, "beginOAuth").mockRejectedValue(
+      new InsecureContextError("insecure context"),
+    );
+    renderBanner();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /reconnect to vault/i }));
+    });
+    const banner = await screen.findByTestId("insecure-context-banner");
+    expect(banner).toHaveTextContent(/Insecure context/i);
+    expect(banner).toHaveTextContent(/HTTPS or accessed at/i);
+  });
+
+  it("does not render the InsecureContextBanner on a generic Reconnect error", async () => {
+    useAuthHaltStore.getState().markHalted("v", "session expired");
+    vi.spyOn(oauthModule, "beginOAuth").mockRejectedValue(new Error("hub returned 502"));
+    renderBanner();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /reconnect to vault/i }));
+    });
+    // Generic error renders inside the auth-halt block; banner stays hidden.
+    await waitFor(() => expect(screen.getByText(/hub returned 502/i)).toBeInTheDocument());
+    expect(screen.queryByTestId("insecure-context-banner")).not.toBeInTheDocument();
+  });
+
+  it("does not render the InsecureContextBanner when there is no failure", () => {
+    useAuthHaltStore.getState().markHalted("v", "session expired");
+    renderBanner();
+    // Banner only appears after a failed reconnect attempt — initial render
+    // of the auth-halt block shouldn't include it.
+    expect(screen.queryByTestId("insecure-context-banner")).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds the deferred component-level insecure-context coverage the notes#144 reviewer asked for. The rc.2 refactor pointed `VaultPopover` and `VaultStatusBanner` at the relocated `InsecureContextBanner`, but the only insecure-context test still lived in `AddVault.test.tsx` — a future refactor of either consumer's catch-and-render wiring would silently regress.
- `VaultPopover.test.tsx` extended: spy on `beginOAuth`, reject with `InsecureContextError`, assert the dedicated banner (`data-testid="insecure-context-banner"`) renders on the Connect path; negative test that a generic `Error` surfaces the connect-error line and *not* the banner.
- `VaultStatusBanner.test.tsx` extended: same shape on the auth-halt Reconnect path, plus a guard that the banner isn't rendered before any failure attempt.
- Bumps to `0.3.16-rc.3`.

Tests: 813 → 818 (+5). Both files extended (already existed); no new files created.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 818/818 pass (was 813)
- [x] `bun run lint` (biome) clean
- [x] `bun run build` clean