### PR TITLE
fix(notes): capture race + draft-saved indicator staleness (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.3.16-rc.4] - 2026-05-21
+
+- **fix(notes): capture race + draft-saved indicator staleness (#135).**
+  Two small follow-ups from the #134 review on the rc.10 draft-save
+  redesign:
+
+  - *Race window in `draftSave`*: the ref was set to `{ localId,
+    hasEnqueuedCreate: false }` BEFORE awaiting the create-note
+    enqueue and flipped to `true` after. During that sub-millisecond
+    window, a manual Capture click (or unmount-flush) read
+    `hasEnqueuedCreate === false`, fell into the fresh-create branch,
+    and enqueued a SECOND `create-note` row with the same localId.
+    Fix: flip the committed flag SYNCHRONOUSLY before the await —
+    renamed to `createCommitted` for clarity. IndexedDB's
+    autoincrement `seq` orders the create's `db.add()` before any
+    racing update by call order, so FIFO drain processes
+    create-then-update correctly regardless of which await resolves
+    first. If the create enqueue itself throws, the catch block now
+    resets the ref back to null so the next attempt creates fresh
+    (update-note failures leave the ref alone — the create already
+    shipped). Three new regression tests cover (a) manual Capture
+    racing the autosave, (b) unmount racing the autosave, (c)
+    create-failure roll-back so the next autosave creates fresh.
+  - *Draft-saved indicator staleness*: the "Draft saved · just now"
+    label was computed at render time from `draftSavedAt`, but nothing
+    else in the component changed while the user idled — so the label
+    could stay at "just now" for the full 5s autosave window (and
+    longer if the user idled after a finalized draft) even though
+    wall-clock had moved on. Fix: a 15s `setInterval` bumps a tick
+    state while `draftSavedAt !== null` so `relativeTime()` keeps
+    tracking. One new test confirms the label transitions from "just
+    now" to "1m ago" after 70s without user interaction.
+
 ## [0.3.16-rc.3] - 2026-05-21
 
 - **test(notes): component-level insecure-context tests for VaultPopover

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.16-rc.3",
+  "version": "0.3.16-rc.4",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",

--- a/src/app/routes/Capture.test.tsx
+++ b/src/app/routes/Capture.test.tsx
@@ -1225,6 +1225,218 @@ describe("Capture — inactivity autosave (5s)", () => {
     }
     db.close();
   });
+
+  it("manual Capture during draftSave's in-flight create routes to update-note (notes#135 race)", async () => {
+    // notes#135 race: in rc.10 the draftSave path set
+    // `{ localId, hasEnqueuedCreate: false }` BEFORE awaiting the
+    // create-note enqueue, then flipped to `true` AFTER. During that
+    // await window, a manual Capture click read `hasEnqueuedCreate ===
+    // false` and fell into the fresh-create else branch — enqueuing a
+    // SECOND create-note row with the same localId. Fix: flip the
+    // committed-flag SYNCHRONOUSLY before the await so a racing manual
+    // save sees the post-create state and routes to update-note.
+    //
+    // We can't directly stall the real `enqueue` to widen the window
+    // (the test mock wraps the real one). Instead we drive the timer
+    // to fire `draftSave` and IMMEDIATELY (synchronously, same React
+    // batch) click Capture — both code paths run their pre-await
+    // setup in the same tick. With the bug, the queue ends up with
+    // two create-note rows (same localId). With the fix, the queue
+    // has one create-note + one update-note.
+    renderAt("/capture");
+    await waitForReady();
+    const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "racing the autosave" } });
+    });
+    // Single act() that fires the autosave timer AND clicks Capture —
+    // both code paths read draftRef before either await resolves.
+    await act(async () => {
+      vi.advanceTimersByTime(5_500);
+      fireEvent.click(screen.getByRole("button", { name: /^capture$/i }));
+    });
+
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.some((t) => t.message === "Captured.")).toBe(true);
+    });
+
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    db.close();
+    const kinds = rows.map((r) => r.mutation.kind);
+    // Exactly one create-note (from the autosave), exactly one update-note
+    // (from the racing manual Capture) — NOT two create-notes.
+    expect(kinds.filter((k) => k === "create-note").length).toBe(1);
+    expect(kinds.filter((k) => k === "update-note").length).toBe(1);
+    // The create + update share the same localId / targetId so the drain
+    // resolves them as a single note. Pre-fix: two create-notes with
+    // identical localId would either dedupe vault-side (best case) or
+    // duplicate the note (worst case).
+    const create = rows.find((r) => r.mutation.kind === "create-note")!;
+    const update = rows.find((r) => r.mutation.kind === "update-note")!;
+    if (create.mutation.kind !== "create-note" || update.mutation.kind !== "update-note") {
+      throw new Error("wrong mutation shape");
+    }
+    expect(update.mutation.targetId).toBe(create.mutation.localId);
+  });
+
+  it("unmount during draftSave's in-flight create routes to update-note (notes#135 race)", async () => {
+    // Companion race for the unmount path: in rc.10 the unmount-flush
+    // checked `draft?.hasEnqueuedCreate` and fell back to create-note
+    // when false, even though draftSave had already committed to
+    // enqueueing a create for that localId. After the fix, the
+    // committed-flag flips synchronously so the unmount-flush sees
+    // the post-create state and enqueues update-note.
+    function Toggler() {
+      const [mounted, setMounted] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setMounted(false)}>
+            unmount
+          </button>
+          {mounted ? <Capture /> : <div>unmounted</div>}
+        </>
+      );
+    }
+    render(
+      <MemoryRouter>
+        <Toggler />
+      </MemoryRouter>,
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText(/capture content/i)).toBeInTheDocument();
+    });
+    const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "racing the unmount-flush" } });
+    });
+    // Fire autosave + unmount in the same act() so both code paths
+    // read draftRef before draftSave's create-note await resolves.
+    await act(async () => {
+      vi.advanceTimersByTime(5_500);
+      fireEvent.click(screen.getByRole("button", { name: "unmount" }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("unmounted")).toBeInTheDocument();
+    });
+
+    await waitFor(async () => {
+      const db = await openLensDB();
+      const rows = await listPending(db, "dev");
+      db.close();
+      expect(rows.length).toBe(2);
+    });
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    db.close();
+    const kinds = rows.map((r) => r.mutation.kind);
+    // One create (autosave) + one update (unmount-flush) — never two creates.
+    expect(kinds.filter((k) => k === "create-note").length).toBe(1);
+    expect(kinds.filter((k) => k === "update-note").length).toBe(1);
+  });
+
+  it("failed create-note draftSave resets draft so the next autosave creates fresh (notes#135)", async () => {
+    // Race-fix companion: with the create-committed flag set
+    // synchronously, a create-note enqueue that THROWS must roll the
+    // ref back to null. Otherwise the next autosave reads `draft !==
+    // null` + `createCommitted: true` and enqueues update-note for a
+    // localId that was never actually created — orphan PATCH at the
+    // vault. The catch block now resets draftRef to null specifically
+    // on fresh-create failure (update-note failures leave the ref
+    // alone, since the create already shipped).
+    renderAt("/capture");
+    await waitForReady();
+    const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "first attempt" } });
+    });
+
+    // First autosave: simulate a failure.
+    enqueueState.failNext = true;
+    await act(async () => {
+      vi.advanceTimersByTime(5_500);
+    });
+    // Wait long enough for the failed enqueue's promise to settle.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Queue still empty — the first create-note attempt threw.
+    {
+      const db = await openLensDB();
+      const rows = await listPending(db, "dev");
+      db.close();
+      expect(rows.length).toBe(0);
+    }
+
+    // Type more — fresh keystroke restarts the 5s timer.
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "first attempt plus more" } });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(5_500);
+    });
+    await waitFor(async () => {
+      const db = await openLensDB();
+      const rows = await listPending(db, "dev");
+      db.close();
+      expect(rows.length).toBe(1);
+    });
+    const db = await openLensDB();
+    const rows = await listPending(db, "dev");
+    db.close();
+    // The second autosave must enqueue create-note (NOT update-note for
+    // the rolled-back localId).
+    expect(rows[0]?.mutation.kind).toBe("create-note");
+    if (rows[0]?.mutation.kind === "create-note") {
+      expect(rows[0].mutation.payload.content).toBe("first attempt plus more");
+    }
+  });
+
+  it("draft-saved indicator re-renders so relativeTime tracks wall-clock (notes#135)", async () => {
+    // notes#135 indicator staleness: in rc.10 the "Draft saved · just
+    // now" label was computed at render time from `draftSavedAt`, but
+    // nothing else in the component changed between autosaves — so
+    // the label could stay at "just now" for a long idle even though
+    // wall-clock had moved on. Fix: 15s setInterval bumps a tick
+    // state while a draft is in flight, forcing a re-render.
+    //
+    // Test by triggering a draft, then advancing wall-clock past the
+    // "just now" threshold (1 minute). The label must transition to
+    // "1m ago" WITHOUT any user interaction. Pre-fix the label
+    // freezes at "just now"; post-fix the interval bumps a tick that
+    // re-renders the indicator.
+    const t0 = new Date(2026, 4, 21, 12, 0, 0).getTime();
+    vi.setSystemTime(t0);
+    renderAt("/capture");
+    await waitForReady();
+    const textarea = screen.getByLabelText(/capture content/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "indicator test" } });
+    });
+    // Trigger the autosave.
+    await act(async () => {
+      vi.advanceTimersByTime(5_500);
+    });
+    await waitFor(async () => {
+      const db = await openLensDB();
+      const rows = await listPending(db, "dev");
+      db.close();
+      expect(rows.length).toBe(1);
+    });
+    // Right after the draft lands the label is "just now".
+    expect(screen.getByText(/Draft saved · just now/)).toBeInTheDocument();
+
+    // Advance wall-clock 70s WITHOUT any user interaction. The 15s
+    // tick interval should fire ~4 times in this window; the most
+    // recent tick re-renders the indicator AFTER `relativeTime()`
+    // crosses the 1-minute boundary, so the label moves from "just
+    // now" to "1m ago".
+    await act(async () => {
+      vi.advanceTimersByTime(70_000);
+    });
+    expect(screen.getByText(/Draft saved · 1m ago/)).toBeInTheDocument();
+  });
 });
 
 describe("extractHashtags", () => {

--- a/src/app/routes/Capture.tsx
+++ b/src/app/routes/Capture.tsx
@@ -116,15 +116,29 @@ export function Capture({
   // shipped) and clears the draft state on reset.
   //
   // draftRef.current === null means no draft is in flight. Once a draft
-  // exists, `hasEnqueuedCreate` toggles to true after the create-note
-  // hits the queue, so subsequent saves enqueue update-note instead.
+  // exists, `createCommitted` is set SYNCHRONOUSLY before draftSave's
+  // create-note enqueue await (notes#135 race fix) — so a parallel
+  // save() or unmount-flush in the same tick sees the post-create state
+  // and routes to update-note. IndexedDB's autoincrement `seq` orders
+  // the create before any racing update by call order, so FIFO drain
+  // sees create-then-update regardless of which await resolves first.
+  // If the create enqueue itself throws, draftSave's catch block
+  // resets the ref back to null so the next attempt creates fresh.
   const draftRef = useRef<{
     localId: string;
-    hasEnqueuedCreate: boolean;
+    createCommitted: boolean;
   } | null>(null);
   // Wall-clock ms of the most recent successful background draft save.
   // Drives the "Draft saved · just now" indicator next to the textarea.
   const [draftSavedAt, setDraftSavedAt] = useState<number | null>(null);
+  // Re-render tick for the "Draft saved · just now" indicator (notes#135).
+  // `relativeTime()` is computed at render time from `draftSavedAt`, but
+  // nothing else in this component changes while the user idles after a
+  // draft has landed — so the label could stay at "just now" for the full
+  // 5s autosave window even though wall-clock has advanced. Bumping this
+  // every 15s while a draft is in flight forces a re-render so the label
+  // tracks reality without polling when there's nothing to show.
+  const [indicatorTick, setIndicatorTick] = useState(0);
 
   const recorderRef = useRef<RecorderController | null>(null);
   const previewUrlRef = useRef<string | null>(null);
@@ -364,7 +378,7 @@ export function Capture({
           },
           { vaultId: activeVault.id },
         );
-      } else if (draft?.hasEnqueuedCreate) {
+      } else if (draft?.createCommitted) {
         // Finalize an in-flight background draft (rc.10). The create-note
         // already shipped via the first autosave; enqueue an update-note
         // with the latest content + tags + path. `path` and `tags` go
@@ -476,14 +490,23 @@ export function Capture({
     const summaryValue = summary.trim();
     const metadata = summaryValue ? { summary: summaryValue } : undefined;
 
+    // Snapshot whether we're about-to-create vs already-created BEFORE the
+    // await so the catch block can roll back accurately. notes#135 race
+    // fix: the ref flips to `createCommitted: true` SYNCHRONOUSLY here
+    // (before any await) so a parallel `save()` or unmount-flush in the
+    // same tick sees the post-create state and routes to update-note. The
+    // create-note's `db.add()` will still receive a lower autoincrement
+    // `seq` than any racing update-note (IndexedDB serializes add() by
+    // call order), so FIFO drain processes create-then-update correctly
+    // regardless of which await resolves first.
+    const draftBefore = draftRef.current;
+    const isFreshCreate = !draftBefore;
+    const localId = draftBefore?.localId ?? newLocalId();
+    if (isFreshCreate) {
+      draftRef.current = { localId, createCommitted: true };
+    }
     try {
-      const draft = draftRef.current;
-      if (!draft) {
-        const localId = newLocalId();
-        // Set the ref BEFORE the await so a parallel autosave fire on the
-        // next tick (extremely unlikely, but the timer is debounced) sees
-        // the existing draft and routes to update-note.
-        draftRef.current = { localId, hasEnqueuedCreate: false };
+      if (isFreshCreate) {
         await enqueue(
           db,
           {
@@ -498,13 +521,12 @@ export function Capture({
           },
           { vaultId: activeVault.id },
         );
-        draftRef.current = { localId, hasEnqueuedCreate: true };
       } else {
         await enqueue(
           db,
           {
             kind: "update-note",
-            targetId: draft.localId,
+            targetId: localId,
             payload: {
               content,
               path: pathValue,
@@ -519,7 +541,15 @@ export function Capture({
       setDraftSavedAt(Date.now());
     } catch {
       // Draft save is best-effort — silent failure. The next tick will
-      // retry; the unmount-flush is the last-ditch safety net.
+      // retry; the unmount-flush is the last-ditch safety net. If the
+      // *create* attempt failed, roll the ref back to null so the next
+      // draftSave attempt creates fresh instead of update-noting a
+      // never-created targetId. Update-note failures don't touch the ref
+      // — the create already shipped, the next attempt should retry as
+      // an update.
+      if (isFreshCreate) {
+        draftRef.current = null;
+      }
     }
   }, [
     db,
@@ -599,7 +629,7 @@ export function Capture({
       // enqueued by the first autosave) already shipped its content; this
       // PATCH just brings the post-autosave keystrokes along.
       const draft = draftRef.current;
-      const enqueuePromise = draft?.hasEnqueuedCreate
+      const enqueuePromise = draft?.createCommitted
         ? enqueue(
             db,
             {
@@ -633,6 +663,24 @@ export function Capture({
       });
     };
   }, []);
+
+  // Indicator-tick refresh (notes#135). Re-render the "Draft saved" pill
+  // every 15s while `draftSavedAt` is set so `relativeTime()` keeps
+  // tracking wall-clock. Otherwise the label would freeze at "just now"
+  // for the full 5s autosave window (and longer, if the user idles after
+  // a finalized draft) because nothing else in the component changes.
+  // Guarded by `draftSavedAt !== null` so we don't spin a timer in the
+  // common idle-empty case. INDICATOR_TICK_MS is small enough that the
+  // label stays in step with `relativeTime()`'s minute-grain output —
+  // by the time a single minute rolls over (the first label change from
+  // "just now" to "1m ago") we've ticked four times.
+  useEffect(() => {
+    if (draftSavedAt === null) return;
+    const id = setInterval(() => {
+      setIndicatorTick((n) => n + 1);
+    }, 15_000);
+    return () => clearInterval(id);
+  }, [draftSavedAt]);
 
   // Inactivity autosave (5s) — fires `draftSave()` after the user stops
   // editing for 5 seconds. Saves a partial as a background draft (notes
@@ -690,7 +738,15 @@ export function Capture({
         />
 
         {draftSavedAt !== null ? (
-          <p className="-mt-2 text-right text-[11px] text-fg-dim" aria-live="polite">
+          <p
+            className="-mt-2 text-right text-[11px] text-fg-dim"
+            aria-live="polite"
+            // Tag the indicator element with the tick so it's a node-level
+            // read of the bumped state — keeps Biome quiet about an unused
+            // value AND re-renders the label as wall-clock advances. The
+            // attribute itself is inert; the React work is the point.
+            data-indicator-tick={indicatorTick}
+          >
             Draft saved · {relativeTime(new Date(draftSavedAt).toISOString())}
           </p>
         ) : null}


### PR DESCRIPTION
Closes #135. Two follow-ups from the #134 review on the rc.10 draft-save redesign.

## Symptoms

**Race**: In `draftSave()`, the ref was set to `{ localId, hasEnqueuedCreate: false }` BEFORE awaiting the `create-note` enqueue and flipped to `true` after. During that sub-millisecond window, a manual Capture click (or unmount-flush) read `hasEnqueuedCreate === false`, fell into the fresh-create branch, and enqueued a SECOND `create-note` row with the same localId.

**Indicator staleness**: The "Draft saved · just now" label was computed at render time from `draftSavedAt`, but nothing else in the component changed while the user idled — so the label could stay at "just now" for the full 5s autosave window even though wall-clock had moved on.

## Fix

**Race** (Capture.tsx `draftSave`):

- Flip the committed flag **synchronously** before the await. Renamed `hasEnqueuedCreate` → `createCommitted` to reflect the new semantics: "we have committed to enqueueing a create-note for this localId," not "the enqueue has resolved."
- IndexedDB's autoincrement `seq` orders the create's `db.add()` before any racing update by call order, so FIFO drain processes create-then-update correctly regardless of which `await` resolves first.
- Snapshot `isFreshCreate` from the pre-await draft state so the catch block can roll back accurately. If the *create* enqueue throws, reset `draftRef.current = null` so the next attempt creates fresh (instead of orphaning an update-note targeting a never-created localId). Update-note failures leave the ref alone — the create already shipped.

**Indicator** (Capture.tsx render + new effect):

- 15s `setInterval` bumps an `indicatorTick` state while `draftSavedAt !== null`. Guarded by the null check so we don't spin a timer in the common idle-empty case.
- Tagged the indicator `<p>` with `data-indicator-tick={indicatorTick}` so React re-renders the label as wall-clock advances (and keeps Biome quiet about an unused state value).

## Race-safety mechanism

Synchronous-flip + IndexedDB seq ordering. No `AbortController` or version counter needed — `db.add()` serializes naturally by call order, so as long as the synchronous flip happens before any other code path reads `draftRef`, FIFO drain sees `create-then-update` regardless of which Promise resolves first.

## Tests

Four new regression tests in `Capture.test.tsx`:

- Manual Capture during `draftSave`'s in-flight create routes to update-note (the race itself)
- Unmount-flush during `draftSave`'s in-flight create routes to update-note (the unmount sibling race)
- Failed `create-note` `draftSave` resets the draft so the next autosave creates fresh (catch-path roll-back)
- Draft-saved indicator re-renders so `relativeTime()` tracks wall-clock — label transitions "just now" → "1m ago" after 70s without user interaction

818 → 822 tests pass. Typecheck + lint + build clean.

## Cross-refs

- Resolves #135 (filed from the #134 review)
- Builds on #134 (autosave draft model)
- CHANGELOG entry under `[0.3.16-rc.4] - 2026-05-21`

## Test plan

- [x] `bun run test` — 822/822 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — clean
- [ ] Manual smoke: type into capture, wait ~6s for autosave, watch label freeze-then-update around the 1m mark (jsdom test covers this; the production path is the same setInterval)
- [ ] Manual smoke: type → autosave → immediately ⌘↵ — verify only one note appears in the vault (pre-fix: would sometimes be two)