### PR TITLE
chore(notes-daemon): deprecate (Notes migration Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog — parachute-notes workspace
+
+This is the monorepo-level changelog. Per-package changelogs live at:
+
+- `packages/notes-daemon/CHANGELOG.md` — `@openparachute/notes`
+- `packages/notes-ui/CHANGELOG.md` — `@openparachute/notes-ui`
+
+## 2026-05-22 — notes-daemon deprecated (Phase 2)
+
+`@openparachute/notes` (the daemon at `packages/notes-daemon/`) entered the
+deprecation phase of the notes-as-app migration arc (design Section 16). The
+daemon continues to ship and serve, but operators are directed to migrate to
+`parachute-app` + `@openparachute/notes-ui`. Hub PR #316 adds a transparent
+`/notes/*` → `/app/notes/*` redirect so existing bookmarks keep working.
+
+See `packages/notes-daemon/DEPRECATED.md` for the migration path and the
+full phase timeline (Phase 3 retirement is targeted for ~Q3 2026).
+
+## 2026-05-21 — Phase 1: monorepo restructure + dual-publish
+
+The repo became a bun workspace with two publish targets — the existing
+`@openparachute/notes` daemon and a new `@openparachute/notes-ui` UI bundle
+shipped for installation under `parachute-app`. No functional changes; both
+packages ship byte-identical bundles. See
+`packages/notes-daemon/CHANGELOG.md` entry `0.3.17-rc.1` for the full
+restructure mechanics.

--- a/packages/notes-daemon/CHANGELOG.md
+++ b/packages/notes-daemon/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.17-rc.2] - 2026-05-22 — DEPRECATION RELEASE
+
+This is the deprecation release. notes-daemon is no longer the recommended way to ship Notes.
+
+- **DEPRECATED**: see [DEPRECATED.md](./DEPRECATED.md) for migration to parachute-app + @openparachute/notes-ui
+- **No functional changes**: this release ships the same dist/ as 0.3.17-rc.1, just with the deprecation banner + DEPRECATED.md
+- **Hub redirect**: hub#316 adds `/notes/*` → `/app/notes/*` redirect for transparent migration
+
+Migrate at your own pace. notes-daemon will continue to serve until Phase 3 retirement (~Q3 2026).
+
 ## [0.3.17-rc.1] - 2026-05-21
 
 - **feat(notes): Phase 1 migration — monorepo restructure, dual-publish

--- a/packages/notes-daemon/DEPRECATED.md
+++ b/packages/notes-daemon/DEPRECATED.md
@@ -1,0 +1,35 @@
+# parachute-notes daemon — DEPRECATED
+
+**Status**: Deprecated as of 2026-05-22 — see migration below.
+
+The `@openparachute/notes` daemon is deprecated. Notes now ships as a UI bundle (`@openparachute/notes-ui`) consumed by [parachute-app](https://github.com/ParachuteComputer/parachute-app).
+
+## Migration
+
+If you have notes-daemon installed today:
+
+1. Install parachute-app: `parachute install app`
+2. Apps auto-bootstraps Notes on fresh installs; if you have an existing apps install, add it manually:
+   `parachute-app add @openparachute/notes-ui --name notes --path /app/notes`
+3. Your existing bookmarks/links to `/notes/*` continue working — hub redirects to `/app/notes/*` automatically (Phase 2 redirect window)
+4. Optional: uninstall the old daemon: `parachute uninstall notes` (keeps your vault notes intact — they live in vault, not the daemon)
+
+## Why the change
+
+- Notes is conceptually an "app" that consumes a vault — not its own backend service
+- parachute-app is the host module for custom UIs (Gitcoin Brain, Unforced Brain, etc.); Notes joins them as the first canonical app
+- Reduces ecosystem surface (4 committed-core modules → 3 + 1 host module)
+- New UIs can ship as bundles without each becoming a full npm-published module
+
+Full migration arc: https://parachute.computer/design/2026-05-21-parachute-apps-design — Section 16.
+
+## Timeline
+
+- **Phase 1** (done): @openparachute/notes-ui published. notes-daemon continues alongside.
+- **Phase 2** (this release): notes-daemon deprecated. Hub redirects /notes/* → /app/notes/*. Operators can migrate at their own pace.
+- **Phase 3** (TBD, ~Q3 2026): notes-daemon retires. Port 1942 reclaimed.
+- **Phase 4** (cleanup): notes-daemon package archived. Source moves to UI-only.
+
+## Questions / Issues
+
+File at https://github.com/ParachuteComputer/parachute-notes/issues

--- a/packages/notes-daemon/README.md
+++ b/packages/notes-daemon/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **DEPRECATED** — this daemon is deprecated as of 2026-05-22.
+> Notes ships as a UI bundle (`@openparachute/notes-ui`) hosted by [parachute-app](https://github.com/ParachuteComputer/parachute-app).
+> See [DEPRECATED.md](./DEPRECATED.md) for the migration path.
+
 # Parachute Notes (`@openparachute/notes`)
 
 The default frontend for [Parachute](https://parachute.computer). Browse, edit, and capture in any [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault).

--- a/packages/notes-daemon/package.json
+++ b/packages/notes-daemon/package.json
@@ -1,16 +1,17 @@
 {
   "name": "@openparachute/notes",
-  "version": "0.3.17-rc.1",
+  "version": "0.3.17-rc.2",
   "private": false,
   "type": "module",
   "description": "Parachute Notes — the default frontend for Parachute. Browse, edit, and capture in any Parachute Vault.",
   "license": "AGPL-3.0-only",
+  "deprecated": "@openparachute/notes is deprecated. Use @openparachute/app + @openparachute/notes-ui via parachute-app. See https://github.com/ParachuteComputer/parachute-notes/blob/main/packages/notes-daemon/DEPRECATED.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-notes.git",
     "directory": "packages/notes-daemon"
   },
-  "files": ["dist", ".parachute/module.json", "README.md", "LICENSE", "CHANGELOG.md"],
+  "files": ["dist", ".parachute/module.json", "README.md", "LICENSE", "CHANGELOG.md", "DEPRECATED.md"],
   "scripts": {
     "build": "node scripts/build.mjs",
     "test": "node scripts/build.test.mjs",


### PR DESCRIPTION
## Summary

Phase 2 of the [notes-as-app migration arc](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-apps-design.md#16-notes-migration-to-app) — `@openparachute/notes` (the daemon at `packages/notes-daemon/`) is marked deprecated. This is purely a docs + manifest change; no code is touched and the daemon continues to install and serve.

Phase 1 (done): `@openparachute/notes-ui` published alongside.
Phase 2 (this PR): notes-daemon deprecated; hub#316 adds `/notes/*` -> `/app/notes/*` redirect.
Phase 3 (~Q3 2026): notes-daemon retires.
Phase 4: package archived.

## Changes

- **New** `packages/notes-daemon/DEPRECATED.md` — migration steps + full phase timeline, modeled on [`parachute-agent/DEPRECATED.md`](https://github.com/ParachuteComputer/parachute-agent/blob/main/DEPRECATED.md) (2026-05-20 precedent)
- **Banner** at top of `packages/notes-daemon/README.md` pointing operators to `DEPRECATED.md`
- **`package.json`** — added the npm `deprecated` field so `npm install` / `bun install` surface the warning to operators; added `DEPRECATED.md` to the published `files` array
- **Version bump** `@openparachute/notes` `0.3.17-rc.1` -> `0.3.17-rc.2`
- **`packages/notes-daemon/CHANGELOG.md`** — DEPRECATION RELEASE entry
- **Workspace `CHANGELOG.md`** — new file noting the Phase 2 event + Phase 1 context

## Companion PRs

- hub#316 — adds `/notes/*` -> `/app/notes/*` redirect so existing bookmarks continue working transparently

## Why no functional changes

The `dist/` shipped by this rc is byte-identical to `0.3.17-rc.1`. Deprecation is a signaling event for operators — the daemon stays functional through Phase 3 so people can migrate at their own pace.

## Test plan

- [x] `bun install` from root — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 803 ui tests + 10 daemon smoke tests all pass
- [x] `npm pack --dry-run` in `packages/notes-daemon/` — verified `DEPRECATED.md` (1.9kB) ships in the tarball alongside `CHANGELOG.md`, `README.md`, `LICENSE`, `.parachute/module.json`
- [ ] Reviewer-subagent check: deprecation message in `package.json` is under reasonable length for the npm warning surface; cross-refs to hub#316 + design Section 16 are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)