### PR TITLE
refactor(notes-ui): subclass app-client VaultClient (drop duplicated request loop)

### DIFF
--- a/packages/notes-ui/CHANGELOG.md
+++ b/packages/notes-ui/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog — @openparachute/notes-ui
 
+## [0.1.0-rc.3] - 2026-05-22
+
+- **Refactor: `VaultClient` subclasses `@openparachute/app-client`'s
+  base class** (closes notes#153 reviewer follow-up). app-client
+  0.1.0-rc.3 lifted `request`, `requestWithRetry`, and
+  `requestCursorWithRetry` to `protected` ([parachute-app#10][app10]),
+  so Notes' VaultClient can finally subclass cleanly instead of cloning
+  the request loop. Net ~220 lines deleted from `client.ts` and ~690
+  from `client.test.ts` (base-class tests now covered by app-client's
+  own suite); the Notes-specific surface (`renameTag`, `mergeTags`,
+  `deleteTag`, `listTagsWithSchema`, `linkAttachment`,
+  `fetchAttachmentBlob`) stays on the subclass.
+
+  Notes' previous narrow-shape `updateTag` override was dropped — the
+  base class's wider `TagUpsertPayload`-shaped `updateTag` accepts the
+  same `{description, parent_names}` Notes was already passing, and
+  `schema-ensure.ts` (the only caller) ignores the return value.
+
+  Bundle delta: +3.8 kB raw / +0.9 kB gzip on the main chunk (the
+  subclass mirrors a handful of auth-callback fields on the instance
+  so `fetchAttachmentBlob` can drive its own retry loop without
+  reaching into the base's `private` state — see file header for
+  the rationale).
+
+[app10]: https://github.com/ParachuteComputer/parachute-app/pull/10
+
 ## [0.1.0-rc.2] - 2026-05-22
 
 - **Adopt `@openparachute/app-client`** (Phase 2 of the notes-migration-

--- a/packages/notes-ui/package.json
+++ b/packages/notes-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes-ui",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "private": false,
   "type": "module",
   "description": "Parachute Notes UI bundle — the SPA installed under parachute-app as the canonical first app. No daemon, no module surface; just the built dist/.",

--- a/packages/notes-ui/src/lib/vault/client.test.ts
+++ b/packages/notes-ui/src/lib/vault/client.test.ts
@@ -269,7 +269,10 @@ describe("VaultClient (Notes subclass) — fetchAttachmentBlob", () => {
       VaultAuthError,
     );
     expect(onAuthRevoked).toHaveBeenCalledTimes(1);
-    expect(onAuthRevoked).toHaveBeenCalledWith(401);
+    expect(onAuthRevoked).toHaveBeenCalledWith(401, {
+      errorType: undefined,
+      message: undefined,
+    });
   });
 
   it("calls onAuthRevoked when there is no refresh callback wired", async () => {
@@ -284,7 +287,36 @@ describe("VaultClient (Notes subclass) — fetchAttachmentBlob", () => {
     await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
       VaultAuthError,
     );
-    expect(onAuthRevoked).toHaveBeenCalledWith(401);
+    expect(onAuthRevoked).toHaveBeenCalledWith(401, {
+      errorType: undefined,
+      message: undefined,
+    });
+  });
+
+  it("forwards parsed error_type + message to onAuthRevoked when the body carries enhanced-error detail", async () => {
+    const fetchImpl = mockBlobFetch([
+      {
+        status: 403,
+        body: JSON.stringify({
+          error_type: "token_revoked",
+          message: "session ended elsewhere",
+        }),
+      },
+    ]);
+    const onAuthRevoked = vi.fn();
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_legacy",
+      fetchImpl,
+      onAuthRevoked,
+    });
+    await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
+      VaultAuthError,
+    );
+    expect(onAuthRevoked).toHaveBeenCalledWith(403, {
+      errorType: "token_revoked",
+      message: "session ended elsewhere",
+    });
   });
 
   it("does NOT call onAuthRevoked when onAuthError returned null — refresh.ts owns that halt", async () => {

--- a/packages/notes-ui/src/lib/vault/client.test.ts
+++ b/packages/notes-ui/src/lib/vault/client.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  VaultAuthError,
-  VaultClient,
-  VaultConflictError,
-  VaultNotFoundError,
-  VaultTargetExistsError,
-  VaultUploadError,
-} from "./client";
+import { VaultAuthError, VaultClient, VaultNotFoundError, VaultTargetExistsError } from "./client";
 
 function mockFetch(response: { ok?: boolean; status?: number; json?: unknown; text?: string }) {
   return vi.fn<typeof fetch>(async () => {
@@ -15,669 +8,231 @@ function mockFetch(response: { ok?: boolean; status?: number; json?: unknown; te
       status: response.status ?? 200,
       json: async () => response.json,
       text: async () => response.text ?? "",
+      blob: async () => new Blob([response.text ?? ""]),
+      headers: new Headers(),
     } as Response;
   });
 }
 
-class FakeXhrUpload {
-  onprogress: ((e: ProgressEvent) => void) | null = null;
-}
+// Tests in this file cover ONLY the Notes-specific surface on
+// `VaultClient` — the methods Notes adds on top of
+// `@openparachute/app-client`'s base class:
+//
+//   - `linkAttachment` (Notes-only alias of base `addAttachment`)
+//   - `renameTag` / `mergeTags` / `deleteTag` (tag-curation)
+//   - `listTagsWithSchema` (schema-audit runner)
+//   - `fetchAttachmentBlob` (audio/image render path)
+//
+// The shared request loop (auto-refresh on 401/403, reachability
+// signals, structured error classification) is covered by app-client's
+// own test suite (`packages/app-client/src/__tests__/vault-client.test.ts`
+// in parachute-app). Re-asserting those behaviors here would be
+// redundant and slow.
 
-class FakeXhr {
-  method = "";
-  url = "";
-  headers: Record<string, string> = {};
-  body: Document | XMLHttpRequestBodyInit | null = null;
-  status = 0;
-  responseText = "";
-  upload = new FakeXhrUpload();
-  onload: (() => void) | null = null;
-  onerror: (() => void) | null = null;
-  onabort: (() => void) | null = null;
-
-  open(method: string, url: string) {
-    this.method = method;
-    this.url = url;
-  }
-  setRequestHeader(k: string, v: string) {
-    this.headers[k] = v;
-  }
-  send(body: Document | XMLHttpRequestBodyInit | null) {
-    this.body = body;
-  }
-  abort() {
-    // Real XHRs fire onabort when abort() is called.
-    this.fireAbort();
-  }
-  fireProgress(loaded: number, total: number) {
-    this.upload.onprogress?.({ lengthComputable: true, loaded, total } as ProgressEvent);
-  }
-  resolve(status: number, body: string) {
-    this.status = status;
-    this.responseText = body;
-    this.onload?.();
-  }
-  fireAbort() {
-    this.onabort?.();
-  }
-}
-
-describe("VaultClient", () => {
-  it("sends Bearer token on every request and returns parsed JSON", async () => {
-    const fetchImpl = mockFetch({
-      json: {
-        name: "default",
-        description: "A vault",
-        stats: { noteCount: 7, tagCount: 3, linkCount: 12 },
-      },
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-
-    const info = await client.vaultInfo();
-    expect(info.stats?.noteCount).toBe(7);
-
-    const call = fetchImpl.mock.calls[0];
-    expect(call?.[0]).toBe("http://localhost:1940/api/vault?include_stats=true");
-    const init = call?.[1] as RequestInit;
-    const headers = new Headers(init.headers);
-    expect(headers.get("Authorization")).toBe("Bearer pvt_abc");
-  });
-
-  it("throws VaultAuthError on 401 so TanStack Query can skip retries", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 401 });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(client.vaultInfo()).rejects.toBeInstanceOf(VaultAuthError);
-  });
-
-  it("strips trailing slashes from the vault URL", async () => {
-    const fetchImpl = mockFetch({ json: { name: "default", description: "" } });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940/",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await client.vaultInfo(false);
-    expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/vault");
-  });
-
-  it("queryNotes passes URLSearchParams to /api/notes and parses the array", async () => {
-    const fetchImpl = mockFetch({
-      json: [{ id: "a", createdAt: "2026-04-18T00:00:00Z", tags: ["daily"] }],
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-
-    const params = new URLSearchParams({ search: "hello", sort: "desc", limit: "50" });
-    const rows = await client.queryNotes(params);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.tags).toEqual(["daily"]);
-    expect(fetchImpl.mock.calls[0]?.[0]).toBe(
-      "http://localhost:1940/api/notes?search=hello&sort=desc&limit=50",
-    );
-  });
-
-  it("queryNotes omits the querystring entirely when params are empty", async () => {
-    const fetchImpl = mockFetch({ json: [] });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await client.queryNotes(new URLSearchParams());
-    expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/notes");
-  });
-
-  it("getNote passes id, include_content, include_links, include_attachments", async () => {
-    const fetchImpl = mockFetch({
-      json: {
-        id: "abc",
-        path: "Canon/Aaron",
-        createdAt: "2026-04-16T00:00:00Z",
-        content: "# hi",
-        tags: ["canon"],
-        links: [],
-        attachments: [],
-      },
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-
-    const note = await client.getNote("Canon/Aaron", {
-      includeLinks: true,
-      includeAttachments: true,
-    });
-    expect(note?.id).toBe("abc");
-
-    const url = fetchImpl.mock.calls[0]?.[0] as string;
-    expect(url).toContain("id=Canon%2FAaron");
-    expect(url).toContain("include_content=true");
-    expect(url).toContain("include_links=true");
-    expect(url).toContain("include_attachments=true");
-  });
-
-  it("getNote unwraps an array response to a single note", async () => {
-    const fetchImpl = mockFetch({
-      json: [{ id: "a", createdAt: "2026-04-18T00:00:00Z" }],
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    const note = await client.getNote("a");
-    expect(note?.id).toBe("a");
-  });
-
-  it("getNote returns null when the vault returns an empty array", async () => {
-    const fetchImpl = mockFetch({ json: [] });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    const note = await client.getNote("missing");
-    expect(note).toBeNull();
-  });
-
-  it("updateNote sends PATCH with JSON body to /api/notes/:id", async () => {
-    const fetchImpl = mockFetch({
-      json: {
-        id: "Canon/Aaron",
-        path: "Canon/Aaron",
-        createdAt: "2026-04-16T00:00:00Z",
-        updatedAt: "2026-04-18T12:00:00Z",
-        content: "# hi",
-        tags: ["canon"],
-      },
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-
-    await client.updateNote("Canon/Aaron", {
-      content: "# new",
-      tags: { add: ["draft"], remove: [] },
-      if_updated_at: "2026-04-18T11:00:00Z",
-    });
-
-    const call = fetchImpl.mock.calls[0];
-    expect(call?.[0]).toBe("http://localhost:1940/api/notes/Canon%2FAaron");
-    const init = call?.[1] as RequestInit;
-    expect(init.method).toBe("PATCH");
-    const headers = new Headers(init.headers);
-    expect(headers.get("Content-Type")).toBe("application/json");
-    expect(headers.get("Authorization")).toBe("Bearer pvt_abc");
-    const body = JSON.parse(init.body as string);
-    expect(body).toEqual({
-      content: "# new",
-      tags: { add: ["draft"], remove: [] },
-      if_updated_at: "2026-04-18T11:00:00Z",
-    });
-  });
-
-  it("updateNote throws VaultConflictError on 409 with current/expected timestamps", async () => {
-    const fetchImpl = mockFetch({
-      ok: false,
-      status: 409,
-      json: {
-        message: "Note was modified",
-        current_updated_at: "2026-04-18T12:05:00Z",
-        expected_updated_at: "2026-04-18T11:00:00Z",
-      },
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-
-    const err = await client
-      .updateNote("a", { content: "x", if_updated_at: "2026-04-18T11:00:00Z" })
-      .catch((e) => e);
-    expect(err).toBeInstanceOf(VaultConflictError);
-    expect((err as VaultConflictError).currentUpdatedAt).toBe("2026-04-18T12:05:00Z");
-    expect((err as VaultConflictError).expectedUpdatedAt).toBe("2026-04-18T11:00:00Z");
-  });
-
-  it("updateNote propagates 401 as VaultAuthError", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 401 });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(client.updateNote("a", { content: "x" })).rejects.toBeInstanceOf(VaultAuthError);
-  });
-
-  it("createNote POSTs JSON to /api/notes and returns the created note", async () => {
-    const fetchImpl = mockFetch({
-      status: 201,
-      json: {
-        id: "new-id",
-        path: "Projects/README",
-        createdAt: "2026-04-18T12:00:00Z",
-        content: "# hello",
-        tags: ["docs"],
-      },
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-
-    const note = await client.createNote({
-      content: "# hello",
-      path: "Projects/README",
-      tags: ["docs"],
-      metadata: { summary: "A readme" },
-    });
-
-    expect(note.id).toBe("new-id");
-    const call = fetchImpl.mock.calls[0];
-    expect(call?.[0]).toBe("http://localhost:1940/api/notes");
-    const init = call?.[1] as RequestInit;
-    expect(init.method).toBe("POST");
-    expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
-    const body = JSON.parse(init.body as string);
-    expect(body).toEqual({
-      content: "# hello",
-      path: "Projects/README",
-      tags: ["docs"],
-      metadata: { summary: "A readme" },
-    });
-  });
-
-  it("createNote surfaces a generic failure so callers can hint at duplicate paths", async () => {
-    const fetchImpl = mockFetch({
-      ok: false,
-      status: 500,
-      text: '{"error":"Internal server error"}',
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(client.createNote({ content: "hi", path: "dup" })).rejects.toThrow(/500/);
-  });
-
-  it("deleteNote sends DELETE to /api/notes/:id and resolves void", async () => {
-    const fetchImpl = mockFetch({ json: { deleted: true, id: "abc" } });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(client.deleteNote("abc-123")).resolves.toBeUndefined();
-    const call = fetchImpl.mock.calls[0];
-    expect(call?.[0]).toBe("http://localhost:1940/api/notes/abc-123");
-    expect((call?.[1] as RequestInit).method).toBe("DELETE");
-  });
-
-  it("deleteNote propagates 401 as VaultAuthError", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 401 });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(client.deleteNote("abc")).rejects.toBeInstanceOf(VaultAuthError);
-  });
-
-  it("uploadStorageFile POSTs multipart to /api/storage/upload with Bearer + progress", async () => {
-    const xhrs: FakeXhr[] = [];
-    const factory = () => {
-      const x = new FakeXhr();
-      xhrs.push(x);
-      return x as unknown as XMLHttpRequest;
-    };
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl: vi.fn(),
-      xhrFactory: factory,
-    });
-
-    const file = new File([new Uint8Array([1, 2, 3, 4])], "shot.png", { type: "image/png" });
-    const progressSeen: number[] = [];
-    const promise = client.uploadStorageFile(file, {
-      onProgress: (p) => progressSeen.push(p.loaded),
-    });
-
-    const xhr = xhrs[0]!;
-    expect(xhr.method).toBe("POST");
-    expect(xhr.url).toBe("http://localhost:1940/api/storage/upload");
-    expect(xhr.headers.Authorization).toBe("Bearer pvt_abc");
-    expect(xhr.body).toBeInstanceOf(FormData);
-    expect((xhr.body as FormData).get("file")).toBeInstanceOf(File);
-
-    xhr.fireProgress(2, 4);
-    xhr.fireProgress(4, 4);
-    xhr.resolve(
-      201,
-      JSON.stringify({ path: "2026-04-18/abc.png", size: 4, mimeType: "image/png" }),
-    );
-
-    const result = await promise;
-    expect(result).toEqual({ path: "2026-04-18/abc.png", size: 4, mimeType: "image/png" });
-    expect(progressSeen).toEqual([2, 4]);
-  });
-
-  it("uploadStorageFile throws VaultAuthError on 401", async () => {
-    const xhrs: FakeXhr[] = [];
-    const factory = () => {
-      const x = new FakeXhr();
-      xhrs.push(x);
-      return x as unknown as XMLHttpRequest;
-    };
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl: vi.fn(),
-      xhrFactory: factory,
-    });
-    const file = new File([new Uint8Array([1])], "x.png", { type: "image/png" });
-    const p = client.uploadStorageFile(file);
-    xhrs[0]!.resolve(401, '{"error":"unauthorized"}');
-    await expect(p).rejects.toBeInstanceOf(VaultAuthError);
-  });
-
-  it("uploadStorageFile surfaces 413 with VaultUploadError carrying status", async () => {
-    const xhrs: FakeXhr[] = [];
-    const factory = () => {
-      const x = new FakeXhr();
-      xhrs.push(x);
-      return x as unknown as XMLHttpRequest;
-    };
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl: vi.fn(),
-      xhrFactory: factory,
-    });
-    const file = new File([new Uint8Array([1])], "x.png", { type: "image/png" });
-    const p = client.uploadStorageFile(file);
-    xhrs[0]!.resolve(413, '{"error":"File too large (200MB). Max: 100MB"}');
-    const err = await p.catch((e) => e);
-    expect(err).toBeInstanceOf(VaultUploadError);
-    expect((err as VaultUploadError).status).toBe(413);
-    expect((err as Error).message).toMatch(/too large/i);
-  });
-
-  it("uploadStorageFile aborts when signal is aborted", async () => {
-    const xhrs: FakeXhr[] = [];
-    const factory = () => {
-      const x = new FakeXhr();
-      xhrs.push(x);
-      return x as unknown as XMLHttpRequest;
-    };
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl: vi.fn(),
-      xhrFactory: factory,
-    });
-    const file = new File([new Uint8Array([1])], "x.png", { type: "image/png" });
-    const controller = new AbortController();
-    const p = client.uploadStorageFile(file, { signal: controller.signal });
-    controller.abort();
-    xhrs[0]!.fireAbort();
-    const err = await p.catch((e) => e);
-    expect(err).toBeInstanceOf(DOMException);
-    expect((err as DOMException).name).toBe("AbortError");
-  });
-
-  it("linkAttachment POSTs JSON to /api/notes/:id/attachments and returns the attachment", async () => {
-    const fetchImpl = mockFetch({
-      status: 201,
-      json: {
-        id: "att-1",
-        noteId: "note-a",
+describe("VaultClient (Notes subclass) — Notes-only endpoints", () => {
+  describe("linkAttachment", () => {
+    it("POSTs JSON to /api/notes/:id/attachments and returns the attachment", async () => {
+      const fetchImpl = mockFetch({
+        status: 201,
+        json: {
+          id: "att-1",
+          noteId: "note-a",
+          path: "2026-04-18/abc.png",
+          mimeType: "image/png",
+          createdAt: "2026-04-18T12:00:00Z",
+        },
+      });
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+        fetchImpl,
+      });
+      const att = await client.linkAttachment("note-a", {
         path: "2026-04-18/abc.png",
         mimeType: "image/png",
-        createdAt: "2026-04-18T12:00:00Z",
-      },
+      });
+      expect(att.id).toBe("att-1");
+      const call = fetchImpl.mock.calls[0];
+      expect(call?.[0]).toBe("http://localhost:1940/api/notes/note-a/attachments");
+      const init = call?.[1] as RequestInit;
+      expect(init.method).toBe("POST");
+      expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
+      expect(JSON.parse(init.body as string)).toEqual({
+        path: "2026-04-18/abc.png",
+        mimeType: "image/png",
+      });
     });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    const att = await client.linkAttachment("note-a", {
-      path: "2026-04-18/abc.png",
-      mimeType: "image/png",
-    });
-    expect(att.id).toBe("att-1");
-    const call = fetchImpl.mock.calls[0];
-    expect(call?.[0]).toBe("http://localhost:1940/api/notes/note-a/attachments");
-    const init = call?.[1] as RequestInit;
-    expect(init.method).toBe("POST");
-    expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
-    expect(JSON.parse(init.body as string)).toEqual({
-      path: "2026-04-18/abc.png",
-      mimeType: "image/png",
+
+    it("propagates 401 as VaultAuthError", async () => {
+      const fetchImpl = mockFetch({ ok: false, status: 401 });
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+        fetchImpl,
+      });
+      await expect(
+        client.linkAttachment("note-a", { path: "x", mimeType: "image/png" }),
+      ).rejects.toBeInstanceOf(VaultAuthError);
     });
   });
 
-  it("linkAttachment propagates 401 as VaultAuthError", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 401 });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
+  describe("renameTag", () => {
+    it("POSTs new_name to /api/tags/:name/rename and returns the count", async () => {
+      const fetchImpl = mockFetch({ json: { renamed: 3 } });
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+        fetchImpl,
+      });
+      await expect(client.renameTag("work", "projects")).resolves.toEqual({ renamed: 3 });
+      const call = fetchImpl.mock.calls[0];
+      expect(call?.[0]).toBe("http://localhost:1940/api/tags/work/rename");
+      const init = call?.[1] as RequestInit;
+      expect(init.method).toBe("POST");
+      expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
+      expect(JSON.parse(init.body as string)).toEqual({ new_name: "projects" });
     });
-    await expect(
-      client.linkAttachment("note-a", { path: "x", mimeType: "image/png" }),
-    ).rejects.toBeInstanceOf(VaultAuthError);
-  });
 
-  it("deleteAttachment sends DELETE to /api/notes/:id/attachments/:attId and resolves void", async () => {
-    const fetchImpl = mockFetch({ status: 204 });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
+    it("encodes the source name so slashes and symbols survive", async () => {
+      const fetchImpl = mockFetch({ json: { renamed: 0 } });
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+        fetchImpl,
+      });
+      await client.renameTag("a/b c", "d");
+      expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/tags/a%2Fb%20c/rename");
     });
-    await expect(client.deleteAttachment("note-a", "att-1")).resolves.toBeUndefined();
-    const call = fetchImpl.mock.calls[0];
-    expect(call?.[0]).toBe("http://localhost:1940/api/notes/note-a/attachments/att-1");
-    expect((call?.[1] as RequestInit).method).toBe("DELETE");
-  });
 
-  it("deleteAttachment throws VaultNotFoundError on 404 so callers can treat it as already-removed", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 404 });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
+    it("throws VaultTargetExistsError on 409 target_exists so callers can offer merge", async () => {
+      const fetchImpl = mockFetch({
+        ok: false,
+        status: 409,
+        json: { error: "target_exists", target: "projects", message: "already exists" },
+      });
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+        fetchImpl,
+      });
+      const err = await client.renameTag("work", "projects").catch((e) => e);
+      expect(err).toBeInstanceOf(VaultTargetExistsError);
+      expect((err as VaultTargetExistsError).target).toBe("projects");
     });
-    await expect(client.deleteAttachment("note-a", "att-1")).rejects.toBeInstanceOf(
-      VaultNotFoundError,
-    );
-  });
 
-  it("deleteAttachment propagates 401 as VaultAuthError", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 401 });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(client.deleteAttachment("note-a", "att-1")).rejects.toBeInstanceOf(VaultAuthError);
-  });
-
-  it("renameTag POSTs new_name to /api/tags/:name/rename and returns the count", async () => {
-    const fetchImpl = mockFetch({ json: { renamed: 3 } });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(client.renameTag("work", "projects")).resolves.toEqual({ renamed: 3 });
-    const call = fetchImpl.mock.calls[0];
-    expect(call?.[0]).toBe("http://localhost:1940/api/tags/work/rename");
-    const init = call?.[1] as RequestInit;
-    expect(init.method).toBe("POST");
-    expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
-    expect(JSON.parse(init.body as string)).toEqual({ new_name: "projects" });
-  });
-
-  it("renameTag encodes the source name so slashes and symbols survive", async () => {
-    const fetchImpl = mockFetch({ json: { renamed: 0 } });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await client.renameTag("a/b c", "d");
-    expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/tags/a%2Fb%20c/rename");
-  });
-
-  it("renameTag throws VaultTargetExistsError on 409 target_exists so callers can offer merge", async () => {
-    const fetchImpl = mockFetch({
-      ok: false,
-      status: 409,
-      json: { error: "target_exists", target: "projects", message: "already exists" },
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    const err = await client.renameTag("work", "projects").catch((e) => e);
-    expect(err).toBeInstanceOf(VaultTargetExistsError);
-    expect((err as VaultTargetExistsError).target).toBe("projects");
-  });
-
-  it("renameTag propagates 404 as VaultNotFoundError", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 404, json: { error: "not_found" } });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(client.renameTag("gone", "still-gone")).rejects.toBeInstanceOf(VaultNotFoundError);
-  });
-
-  it("renameTag propagates 401 as VaultAuthError", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 401 });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(client.renameTag("a", "b")).rejects.toBeInstanceOf(VaultAuthError);
-  });
-
-  it("updateNote still throws VaultConflictError on a note-style 409 (not target_exists)", async () => {
-    // Guard: the 409-body sniff for target_exists must not steal note-concurrency conflicts.
-    const fetchImpl = mockFetch({
-      ok: false,
-      status: 409,
-      json: {
-        current_updated_at: "2026-04-18T12:05:00Z",
-        expected_updated_at: "2026-04-18T11:00:00Z",
-      },
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    await expect(
-      client.updateNote("a", { content: "x", if_updated_at: "2026-04-18T11:00:00Z" }),
-    ).rejects.toBeInstanceOf(VaultConflictError);
-  });
-
-  it("mergeTags POSTs sources + target to /api/tags/merge", async () => {
-    const fetchImpl = mockFetch({
-      json: { merged: { alpha: 3, beta: 2 }, target: "projects" },
-    });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-    });
-    const res = await client.mergeTags(["alpha", "beta"], "projects");
-    expect(res.target).toBe("projects");
-    expect(res.merged).toEqual({ alpha: 3, beta: 2 });
-    const call = fetchImpl.mock.calls[0];
-    expect(call?.[0]).toBe("http://localhost:1940/api/tags/merge");
-    const init = call?.[1] as RequestInit;
-    expect(init.method).toBe("POST");
-    expect(JSON.parse(init.body as string)).toEqual({
-      sources: ["alpha", "beta"],
-      target: "projects",
+    it("propagates 404 as VaultNotFoundError", async () => {
+      const fetchImpl = mockFetch({ ok: false, status: 404, json: { error: "not_found" } });
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+        fetchImpl,
+      });
+      await expect(client.renameTag("gone", "still-gone")).rejects.toBeInstanceOf(
+        VaultNotFoundError,
+      );
     });
   });
 
-  it("mergeTags propagates 401 as VaultAuthError", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 401 });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
+  describe("mergeTags", () => {
+    it("POSTs sources + target to /api/tags/merge", async () => {
+      const fetchImpl = mockFetch({
+        json: { merged: { alpha: 3, beta: 2 }, target: "projects" },
+      });
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+        fetchImpl,
+      });
+      const res = await client.mergeTags(["alpha", "beta"], "projects");
+      expect(res.target).toBe("projects");
+      expect(res.merged).toEqual({ alpha: 3, beta: 2 });
+      const call = fetchImpl.mock.calls[0];
+      expect(call?.[0]).toBe("http://localhost:1940/api/tags/merge");
+      const init = call?.[1] as RequestInit;
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual({
+        sources: ["alpha", "beta"],
+        target: "projects",
+      });
     });
-    await expect(client.mergeTags(["a"], "b")).rejects.toBeInstanceOf(VaultAuthError);
   });
 
-  it("listTags hits /api/tags and returns the summary array", async () => {
-    const fetchImpl = mockFetch({
-      json: [
-        { name: "daily", count: 42 },
-        { name: "work", count: 7 },
-      ],
+  describe("deleteTag", () => {
+    it("sends DELETE to /api/tags/:name", async () => {
+      const fetchImpl = mockFetch({ status: 204 });
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+        fetchImpl,
+      });
+      await expect(client.deleteTag("work")).resolves.toBeUndefined();
+      const call = fetchImpl.mock.calls[0];
+      expect(call?.[0]).toBe("http://localhost:1940/api/tags/work");
+      expect((call?.[1] as RequestInit).method).toBe("DELETE");
     });
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
+  });
+
+  describe("listTagsWithSchema", () => {
+    it("GETs /api/tags?include_schema=true and returns the rows", async () => {
+      const fetchImpl = mockFetch({
+        json: [
+          {
+            name: "voice",
+            count: 4,
+            description: "Voice captures",
+            parent_names: ["capture"],
+          },
+        ],
+      });
+      const client = new VaultClient({
+        vaultUrl: "http://localhost:1940",
+        accessToken: "pvt_abc",
+        fetchImpl,
+      });
+      const rows = await client.listTagsWithSchema();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.name).toBe("voice");
+      expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+        "http://localhost:1940/api/tags?include_schema=true",
+      );
     });
-    const tags = await client.listTags();
-    expect(tags).toHaveLength(2);
-    expect(tags[0]).toEqual({ name: "daily", count: 42 });
-    expect(fetchImpl.mock.calls[0]?.[0]).toBe("http://localhost:1940/api/tags");
   });
 });
 
-describe("VaultClient refresh-on-401", () => {
-  // Sequenced fetch mock: lets a single test simulate "401 → refresh → 200".
-  function sequencedFetch(responses: Array<{ ok?: boolean; status?: number; json?: unknown }>) {
+describe("VaultClient (Notes subclass) — fetchAttachmentBlob", () => {
+  function mockBlobFetch(responses: Array<{ status: number; body?: string }>) {
     const queue = [...responses];
     return vi.fn<typeof fetch>(async () => {
       const next = queue.shift();
       if (!next) throw new Error("unexpected fetch call");
       return {
-        ok: next.ok ?? true,
-        status: next.status ?? 200,
-        json: async () => next.json,
-        text: async () => "",
+        ok: next.status >= 200 && next.status < 300,
+        status: next.status,
+        blob: async () => new Blob([next.body ?? ""]),
+        text: async () => next.body ?? "",
+        json: async () => ({}),
+        headers: new Headers(),
       } as Response;
     });
   }
 
-  it("retries once with the rotated token when onAuthError yields a fresh access token", async () => {
-    const fetchImpl = sequencedFetch([
-      { ok: false, status: 401 },
-      { json: { name: "default", description: "" } },
-    ]);
+  it("GETs the absolute target with Bearer auth and returns a Blob", async () => {
+    const fetchImpl = mockBlobFetch([{ status: 200, body: "audio-bytes" }]);
+    const client = new VaultClient({
+      vaultUrl: "http://localhost:1940",
+      accessToken: "pvt_abc",
+      fetchImpl,
+    });
+    const blob = await client.fetchAttachmentBlob("/api/storage/foo.mp3");
+    expect(blob).toBeInstanceOf(Blob);
+    const call = fetchImpl.mock.calls[0];
+    expect(call?.[0]).toBe("http://localhost:1940/api/storage/foo.mp3");
+    const headers = (call?.[1] as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer pvt_abc");
+  });
+
+  it("retries once with the rotated token on 401 + onAuthError", async () => {
+    const fetchImpl = mockBlobFetch([{ status: 401 }, { status: 200, body: "bytes" }]);
     const onAuthError = vi.fn(async () => "eyJ.new");
     const client = new VaultClient({
       vaultUrl: "http://localhost:1940",
@@ -685,58 +240,22 @@ describe("VaultClient refresh-on-401", () => {
       fetchImpl,
       onAuthError,
     });
-
-    const info = await client.vaultInfo(false);
-    expect(info.name).toBe("default");
+    await client.fetchAttachmentBlob("/api/storage/foo.mp3");
     expect(onAuthError).toHaveBeenCalledTimes(1);
-
-    // First call carried the stale token, second call carried the fresh one.
-    const firstHeaders = new Headers((fetchImpl.mock.calls[0]?.[1] as RequestInit).headers);
-    const secondHeaders = new Headers((fetchImpl.mock.calls[1]?.[1] as RequestInit).headers);
-    expect(firstHeaders.get("Authorization")).toBe("Bearer eyJ.stale");
-    expect(secondHeaders.get("Authorization")).toBe("Bearer eyJ.new");
-  });
-
-  it("throws VaultAuthError without retrying when onAuthError returns null", async () => {
-    const fetchImpl = sequencedFetch([{ ok: false, status: 401 }]);
-    const onAuthError = vi.fn(async () => null);
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "eyJ.stale",
-      fetchImpl,
-      onAuthError,
-    });
-
-    await expect(client.vaultInfo(false)).rejects.toBeInstanceOf(VaultAuthError);
-    expect(onAuthError).toHaveBeenCalledTimes(1);
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not loop on a second 401 — caps at one retry", async () => {
-    // If the refresh-issued token is also rejected (e.g. vault hasn't picked up
-    // the new key yet), we surface VaultAuthError instead of looping forever.
-    const fetchImpl = sequencedFetch([
-      { ok: false, status: 401 },
-      { ok: false, status: 401 },
-    ]);
-    const onAuthError = vi.fn(async () => "eyJ.also-stale");
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "eyJ.stale",
-      fetchImpl,
-      onAuthError,
-    });
-
-    await expect(client.vaultInfo(false)).rejects.toBeInstanceOf(VaultAuthError);
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(onAuthError).toHaveBeenCalledTimes(1);
+    const headers0 = (fetchImpl.mock.calls[0]?.[1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    const headers1 = (fetchImpl.mock.calls[1]?.[1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(headers0.Authorization).toBe("Bearer eyJ.stale");
+    expect(headers1.Authorization).toBe("Bearer eyJ.new");
   });
 
   it("calls onAuthRevoked when the post-refresh retry also returns 401", async () => {
-    const fetchImpl = sequencedFetch([
-      { ok: false, status: 401 },
-      { ok: false, status: 401 },
-    ]);
+    const fetchImpl = mockBlobFetch([{ status: 401 }, { status: 401 }]);
     const onAuthError = vi.fn(async () => "eyJ.also-stale");
     const onAuthRevoked = vi.fn();
     const client = new VaultClient({
@@ -746,17 +265,15 @@ describe("VaultClient refresh-on-401", () => {
       onAuthError,
       onAuthRevoked,
     });
-
-    await expect(client.vaultInfo(false)).rejects.toBeInstanceOf(VaultAuthError);
+    await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
+      VaultAuthError,
+    );
     expect(onAuthRevoked).toHaveBeenCalledTimes(1);
     expect(onAuthRevoked).toHaveBeenCalledWith(401);
   });
 
   it("calls onAuthRevoked when there is no refresh callback wired", async () => {
-    // Legacy `pvt_*` token path — VaultClient was constructed without
-    // `onAuthError`, so the first 401 is definitive. Surface the halt so the
-    // banner still appears.
-    const fetchImpl = mockFetch({ ok: false, status: 401 });
+    const fetchImpl = mockBlobFetch([{ status: 401 }]);
     const onAuthRevoked = vi.fn();
     const client = new VaultClient({
       vaultUrl: "http://localhost:1940",
@@ -764,35 +281,14 @@ describe("VaultClient refresh-on-401", () => {
       fetchImpl,
       onAuthRevoked,
     });
-
-    await expect(client.vaultInfo(false)).rejects.toBeInstanceOf(VaultAuthError);
+    await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
+      VaultAuthError,
+    );
     expect(onAuthRevoked).toHaveBeenCalledWith(401);
-  });
-
-  it("does NOT call onAuthRevoked when refresh succeeds (banner stays hidden on transient 401)", async () => {
-    const fetchImpl = sequencedFetch([
-      { ok: false, status: 401 },
-      { json: { name: "default", description: "" } },
-    ]);
-    const onAuthError = vi.fn(async () => "eyJ.new");
-    const onAuthRevoked = vi.fn();
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "eyJ.stale",
-      fetchImpl,
-      onAuthError,
-      onAuthRevoked,
-    });
-
-    await client.vaultInfo(false);
-    expect(onAuthRevoked).not.toHaveBeenCalled();
   });
 
   it("does NOT call onAuthRevoked when onAuthError returned null — refresh.ts owns that halt", async () => {
-    // refresh.ts is responsible for marking halted with a specific reason
-    // when it sees an HTTP error from the token endpoint. Avoid double-marking
-    // (which would clobber the better message with a generic "(401)").
-    const fetchImpl = sequencedFetch([{ ok: false, status: 401 }]);
+    const fetchImpl = mockBlobFetch([{ status: 401 }]);
     const onAuthError = vi.fn(async () => null);
     const onAuthRevoked = vi.fn();
     const client = new VaultClient({
@@ -802,196 +298,9 @@ describe("VaultClient refresh-on-401", () => {
       onAuthError,
       onAuthRevoked,
     });
-
-    await expect(client.vaultInfo(false)).rejects.toBeInstanceOf(VaultAuthError);
-    expect(onAuthRevoked).not.toHaveBeenCalled();
-  });
-
-  // Regression: the blob path (audio/image attachment loads) used to short-circuit
-  // before `onAuthRevoked` was invented, so it never fired. A user whose
-  // attachment loads start 401-ing after token revocation would get silent
-  // VaultAuthError throws with no banner. These mirror the requestWithRetry
-  // tests above against `fetchAttachmentBlob`.
-
-  it("blob path: calls onAuthRevoked when the post-refresh retry also returns 401", async () => {
-    const fetchImpl = sequencedFetch([
-      { ok: false, status: 401 },
-      { ok: false, status: 401 },
-    ]);
-    const onAuthError = vi.fn(async () => "eyJ.also-stale");
-    const onAuthRevoked = vi.fn();
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "eyJ.stale",
-      fetchImpl,
-      onAuthError,
-      onAuthRevoked,
-    });
-
-    await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
-      VaultAuthError,
-    );
-    expect(onAuthRevoked).toHaveBeenCalledTimes(1);
-    expect(onAuthRevoked).toHaveBeenCalledWith(401);
-  });
-
-  it("blob path: calls onAuthRevoked when there is no refresh callback wired", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 401 });
-    const onAuthRevoked = vi.fn();
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_legacy",
-      fetchImpl,
-      onAuthRevoked,
-    });
-
-    await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
-      VaultAuthError,
-    );
-    expect(onAuthRevoked).toHaveBeenCalledWith(401);
-  });
-
-  it("blob path: does NOT call onAuthRevoked when onAuthError returned null", async () => {
-    const fetchImpl = sequencedFetch([{ ok: false, status: 401 }]);
-    const onAuthError = vi.fn(async () => null);
-    const onAuthRevoked = vi.fn();
-    const client = new VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "eyJ.stale",
-      fetchImpl,
-      onAuthError,
-      onAuthRevoked,
-    });
-
     await expect(client.fetchAttachmentBlob("/api/storage/foo.mp3")).rejects.toBeInstanceOf(
       VaultAuthError,
     );
     expect(onAuthRevoked).not.toHaveBeenCalled();
-  });
-});
-
-describe("VaultClient default fetch binding", () => {
-  // Regression for "TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation".
-  // Browser's native `fetch` requires its `this` receiver to be the global (Window).
-  // Storing `fetch` as a bare reference on an instance field loses that binding; at
-  // call-time `this` becomes the VaultClient instance and the browser throws.
-  // jsdom's fetch is permissive and doesn't enforce this invariant, so we install a
-  // this-aware shim here that mimics the browser check. This test exists to catch
-  // regressions in the default-path binding only — don't add one per endpoint.
-  it("does not throw 'Illegal invocation' when no fetchImpl is provided", async () => {
-    const shim = vi.fn(function (this: unknown, _url: string, _init?: RequestInit) {
-      if (this !== globalThis) {
-        throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation");
-      }
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: async () => ({ name: "default", description: "" }),
-        text: async () => "",
-      } as Response);
-    });
-    vi.stubGlobal("fetch", shim);
-    try {
-      const client = new VaultClient({
-        vaultUrl: "http://localhost:1940",
-        accessToken: "pvt_abc",
-      });
-      await expect(client.vaultInfo(false)).resolves.toBeDefined();
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-});
-
-describe("VaultClient reachability", () => {
-  it("throws VaultUnreachableError on 502 and reports unreachable", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 502, text: "Bad Gateway" });
-    const onReachability = vi.fn();
-    const client = new (await import("./client")).VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-      onReachability,
-    });
-    await expect(client.vaultInfo()).rejects.toMatchObject({
-      name: "VaultUnreachableError",
-      status: 502,
-    });
-    expect(onReachability).toHaveBeenCalledWith("unreachable", "HTTP 502");
-  });
-
-  it("throws VaultUnreachableError on 503 and reports unreachable", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 503 });
-    const onReachability = vi.fn();
-    const client = new (await import("./client")).VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-      onReachability,
-    });
-    await expect(client.vaultInfo()).rejects.toMatchObject({
-      name: "VaultUnreachableError",
-      status: 503,
-    });
-    expect(onReachability).toHaveBeenCalledWith("unreachable", "HTTP 503");
-  });
-
-  it("throws VaultUnreachableError on network-level failure (TypeError)", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () => {
-      throw new TypeError("Failed to fetch");
-    });
-    const onReachability = vi.fn();
-    const client = new (await import("./client")).VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-      onReachability,
-    });
-    await expect(client.vaultInfo()).rejects.toMatchObject({
-      name: "VaultUnreachableError",
-      status: 0,
-    });
-    expect(onReachability).toHaveBeenCalledWith("unreachable", "Failed to fetch");
-  });
-
-  it("does not swallow AbortError from the caller", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () => {
-      throw new DOMException("aborted", "AbortError");
-    });
-    const onReachability = vi.fn();
-    const client = new (await import("./client")).VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-      onReachability,
-    });
-    await expect(client.vaultInfo()).rejects.toMatchObject({ name: "AbortError" });
-    expect(onReachability).not.toHaveBeenCalled();
-  });
-
-  it("reports healthy on a 200 response", async () => {
-    const fetchImpl = mockFetch({ json: { name: "default", description: "" } });
-    const onReachability = vi.fn();
-    const client = new (await import("./client")).VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-      onReachability,
-    });
-    await client.vaultInfo(false);
-    expect(onReachability).toHaveBeenCalledWith("healthy");
-  });
-
-  it("reports healthy on a 4xx response — the vault is answering", async () => {
-    const fetchImpl = mockFetch({ ok: false, status: 404 });
-    const onReachability = vi.fn();
-    const client = new (await import("./client")).VaultClient({
-      vaultUrl: "http://localhost:1940",
-      accessToken: "pvt_abc",
-      fetchImpl,
-      onReachability,
-    });
-    await expect(client.vaultInfo()).rejects.toMatchObject({ name: "VaultNotFoundError" });
-    expect(onReachability).toHaveBeenCalledWith("healthy");
   });
 });

--- a/packages/notes-ui/src/lib/vault/client.ts
+++ b/packages/notes-ui/src/lib/vault/client.ts
@@ -190,15 +190,16 @@ export class VaultClient extends BaseVaultClient {
    * the `linkAttachment` name; preserving the alias avoids a sweeping
    * rename and keeps the semantic distinction (link an already-uploaded
    * blob to a note, vs. "add" which the base names generically).
+   *
+   * Thin delegation to `addAttachment` so any future wire-shape change
+   * on the base (extra fields, header additions) carries through
+   * automatically rather than drifting between the two implementations.
    */
   async linkAttachment(
     noteIdOrPath: string,
     body: { path: string; mimeType: string; transcribe?: boolean },
   ): Promise<NoteAttachment> {
-    return this.request<NoteAttachment>(
-      `/api/notes/${encodeURIComponent(noteIdOrPath)}/attachments`,
-      { method: "POST", body: JSON.stringify(body) },
-    );
+    return this.addAttachment(noteIdOrPath, body);
   }
 
   /**
@@ -242,6 +243,22 @@ export class VaultClient extends BaseVaultClient {
     }
     this.currentOnReachability?.("healthy");
     if (res.status === 401 || res.status === 403) {
+      // Mirror the base's requestWithRetry: parse the body BEFORE the
+      // refresh-and-retry branch so the detail attached to
+      // `onAuthRevoked` matches notes#150's enhanced-error shape
+      // (`error_type` + `message`).
+      const bodyText = await res.text().catch(() => "");
+      let errorType: string | undefined;
+      let serverMessage: string | undefined;
+      if (bodyText) {
+        try {
+          const parsed = JSON.parse(bodyText) as { error_type?: unknown; message?: unknown };
+          if (typeof parsed.error_type === "string") errorType = parsed.error_type;
+          if (typeof parsed.message === "string") serverMessage = parsed.message;
+        } catch {
+          // Non-JSON body — leave detail undefined.
+        }
+      }
       if (allowRetry && this.currentOnAuthError) {
         const fresh = await this.currentOnAuthError();
         if (fresh) {
@@ -254,8 +271,9 @@ export class VaultClient extends BaseVaultClient {
         // onAuthError returned null — refresh.ts owns the halt path.
       } else {
         // No refresh path, or post-refresh retry still 401/403. Mirror
-        // requestWithRetry so attachment loads also surface the banner.
-        this.currentOnAuthRevoked?.(res.status);
+        // requestWithRetry so attachment loads also surface the banner
+        // with the same `{ errorType, message }` detail shape.
+        this.currentOnAuthRevoked?.(res.status, { errorType, message: serverMessage });
       }
       throw new VaultAuthError(`Vault rejected the token (${res.status})`, res.status);
     }

--- a/packages/notes-ui/src/lib/vault/client.ts
+++ b/packages/notes-ui/src/lib/vault/client.ts
@@ -4,35 +4,34 @@
  * Phase 2 of the notes-migration-to-app arc (parachute-app#6, design doc
  * section 16) moved the canonical `VaultClient` (with structured errors,
  * auto-refresh on 401/403, cursor pagination, reachability signals) into
- * `@openparachute/app-client`. The error classes + payload types are
- * re-exported below so existing import sites (`import { VaultAuthError,
- * VaultClient, ... } from "@/lib/vault/client"`) keep working without
- * per-file churn.
+ * `@openparachute/app-client`. notes#153 adopted those re-exports but
+ * kept a near-clone of the request loop here because app-client's
+ * `request*` methods were still `private`.
  *
- * Notes' subclass adds the methods app-client's surface doesn't carry
- * because Notes is the only consumer today:
+ * app-client 0.1.0-rc.3 lifted `request`, `requestWithRetry`, and
+ * `requestCursorWithRetry` to `protected` (parachute-app#10). This file
+ * now subclasses cleanly. Notes' subclass only adds the methods app-
+ * client's surface doesn't carry because Notes is the only consumer
+ * today:
  *
- *   - `renameTag` / `mergeTags` / `deleteTag` / `updateTag` —
- *     tag-curation endpoints (`/api/tags/:name/rename`,
- *     `/api/tags/merge`, `DELETE /api/tags/:name`, `PUT /api/tags/:name`
- *     with the legacy two-key body shape).
+ *   - `renameTag` / `mergeTags` / `deleteTag` — tag-curation endpoints
+ *     (`/api/tags/:name/rename`, `/api/tags/merge`, `DELETE
+ *     /api/tags/:name`). Not in app-client's surface; Notes' Tags page
+ *     is the only caller.
  *   - `listTagsWithSchema` — `/api/tags?include_schema=true`, used by
  *     the schema-audit runner (notes#129) to diff vault state against
  *     `NOTES_REQUIRED_SCHEMA`.
- *   - `linkAttachment` — Notes-only method that POSTs to the vault's
- *     attachments endpoint. Not part of app-client's surface (Notes-specific
- *     to its capture flow); once VaultClient.request lifts to `protected`
- *     in app-client, this can subclass cleanly.
+ *   - `linkAttachment` — Notes-only alias of base `addAttachment` (same
+ *     wire shape: POST `/api/notes/:id/attachments`). Kept because
+ *     callers throughout Notes use the `linkAttachment` name + semantic.
  *   - `fetchAttachmentBlob` — retry-aware GET of an attachment blob URL
- *     (for audio/image render), with the same `onAuthError`/`onReachability`
- *     plumbing as the JSON path.
- *
- * The shared request loop (auto-refresh on 401/403, reachability
- * signals, structured 4xx → typed errors) is intentionally still in this
- * file rather than reused via subclassing — app-client's `request` is
- * `private`, not `protected`. A follow-up (parachute-app/app-client) can
- * lift those methods to `protected` so this subclass shrinks to the
- * Notes-only extensions; tracked as a follow-up in the Phase 2 PR.
+ *     (audio/image render). The base class's `request*` loop parses
+ *     JSON; this method needs the raw Blob, so it carries its own thin
+ *     retry loop. The auth callbacks (`onAuthError` / `onAuthRevoked` /
+ *     `onReachability`) and token rotation are mirrored on the subclass
+ *     during construction so the blob path can drive them without
+ *     reaching into the base's private fields. The shared JSON request
+ *     loop on the base class is no longer duplicated.
  */
 
 import {
@@ -42,17 +41,16 @@ import {
   VaultTargetExistsError as AppClientVaultTargetExistsError,
   VaultUnreachableError as AppClientVaultUnreachableError,
   VaultUploadError as AppClientVaultUploadError,
+  VaultClient as BaseVaultClient,
+  type VaultClientOptions as BaseVaultClientOptions,
 } from "@openparachute/app-client";
 import type {
   CreateNotePayload,
-  Note,
   NoteAttachment,
   ReachabilitySignal,
   StorageUploadResult,
-  TagSummary,
   UpdateNotePayload,
   UploadProgress,
-  VaultInfo,
 } from "./types";
 
 // Error classes + payload types are re-exports from app-client — Phase 2
@@ -91,210 +89,63 @@ export const STORAGE_ALLOWED_EXTENSIONS = new Set([
   "webp",
 ]);
 
-export interface VaultClientOptions {
-  vaultUrl: string;
-  accessToken: string;
-  fetchImpl?: typeof fetch;
-  xhrFactory?: () => XMLHttpRequest;
-  // Invoked when the vault returns 401/403. Should attempt a refresh-token
-  // exchange and return the fresh access token, or `null` if refresh is not
-  // possible (legacy `pvt_*` token, no refresh token, or refresh failed).
-  // Without this, the first 401 throws immediately — same behaviour as before
-  // hub-as-issuer landed.
-  onAuthError?: () => Promise<string | null>;
-  // Invoked when a 401/403 ultimately can't be recovered: either there was no
-  // refresh callback, or the post-refresh retry also got a 401/403 (the new
-  // token is dead too). Lets callers mark the vault as needing reconnect —
-  // distinct from `onAuthError`'s job, which is to attempt refresh. Skipped
-  // when `onAuthError` returned null because that path is expected to record
-  // its own halt with a more specific reason (see refresh.ts).
-  onAuthRevoked?: (status: number) => void;
-  // Fires on every fetch outcome with a coarse reachability signal so an
-  // owner store (reachability-store.ts) can run its `healthy → retrying → down`
-  // state machine in one place. Receives "healthy" on any 2xx/4xx response
-  // (the vault answered — auth/conflict/not-found are still reachable),
-  // "unreachable" on 5xx + network failures (gone / mid-restart / proxy down).
-  // Side-effect free here; all hysteresis, backoff, and UI promotion lives in
-  // the store.
-  onReachability?: (signal: ReachabilitySignal, reason?: string) => void;
-}
+export type VaultClientOptions = BaseVaultClientOptions;
 
-export class VaultClient {
-  private readonly baseUrl: string;
-  // Mutable so a successful refresh-on-401 retry can rotate the in-memory
-  // token without requiring callers to rebuild the client.
-  private token: string;
-  private readonly fetchImpl: typeof fetch;
-  private readonly xhrFactory: () => XMLHttpRequest;
-  private readonly onAuthError?: () => Promise<string | null>;
-  private readonly onAuthRevoked?: (status: number) => void;
-  private readonly onReachability?: (signal: ReachabilitySignal, reason?: string) => void;
+/**
+ * Notes' VaultClient — subclasses app-client's canonical implementation
+ * and adds the handful of Notes-only endpoints (tag curation,
+ * `linkAttachment`, blob fetch).
+ *
+ * Every method on the base class (`vaultInfo`, `queryNotes`, `getNote`,
+ * `createNote`, `updateNote`, `deleteNote`, `listTags`, `addAttachment`,
+ * `listAttachments`, `deleteAttachment`, `uploadStorageFile`,
+ * `storageUrl`, `setAccessToken`, `vaultBaseUrl`) is inherited unchanged
+ * — no per-method re-declaration here.
+ */
+export class VaultClient extends BaseVaultClient {
+  // Mirror of the base class's private blob-loop dependencies. The base
+  // exposes `request*` as protected so JSON paths inherit cleanly, but
+  // the underlying `token` / `fetchImpl` / `onAuth*` / `onReachability`
+  // remain private — the blob path can't reach them. We capture the
+  // same fields on the subclass at construction so `fetchAttachmentBlob`
+  // can run its own retry loop without re-exposing private base state.
+  //
+  // `currentToken` shadows the base's token. The base rotates its own
+  // copy on a refresh, and `setAccessToken` (inherited) rotates the
+  // base; we override `setAccessToken` to keep both in sync. The blob
+  // path's own 401 handler also rotates this field directly.
+  private currentToken: string;
+  private readonly currentFetchImpl: typeof fetch;
+  private readonly currentOnAuthError?: () => Promise<string | null>;
+  private readonly currentOnAuthRevoked?: (
+    status: number,
+    detail?: { errorType?: string; message?: string },
+  ) => void;
+  private readonly currentOnReachability?: (signal: ReachabilitySignal, reason?: string) => void;
 
   constructor(opts: VaultClientOptions) {
-    this.baseUrl = opts.vaultUrl.replace(/\/$/, "");
-    this.token = opts.accessToken;
-    this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
-    this.xhrFactory = opts.xhrFactory ?? (() => new XMLHttpRequest());
-    this.onAuthError = opts.onAuthError;
-    this.onAuthRevoked = opts.onAuthRevoked;
-    this.onReachability = opts.onReachability;
+    super(opts);
+    this.currentToken = opts.accessToken;
+    this.currentFetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
+    if (opts.onAuthError !== undefined) this.currentOnAuthError = opts.onAuthError;
+    if (opts.onAuthRevoked !== undefined) this.currentOnAuthRevoked = opts.onAuthRevoked;
+    if (opts.onReachability !== undefined) this.currentOnReachability = opts.onReachability;
   }
 
-  get vaultBaseUrl(): string {
-    return this.baseUrl;
+  /**
+   * Keep the subclass's shadow token in sync with the base's so the
+   * blob path uses the latest credential on the next call. Inherited
+   * `setAccessToken` already rotates the base's copy; we override to
+   * also rotate ours.
+   */
+  override setAccessToken(token: string): void {
+    super.setAccessToken(token);
+    this.currentToken = token;
   }
 
-  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
-    return this.requestWithRetry<T>(path, init, true);
-  }
+  // ---------- Notes-only tag-curation endpoints ----------
 
-  private async requestWithRetry<T>(
-    path: string,
-    init: RequestInit,
-    allowRetry: boolean,
-  ): Promise<T> {
-    const headers = new Headers(init.headers);
-    headers.set("Authorization", `Bearer ${this.token}`);
-    headers.set("Accept", "application/json");
-    if (init.body && !headers.has("Content-Type")) {
-      headers.set("Content-Type", "application/json");
-    }
-
-    let res: Response;
-    try {
-      res = await this.fetchImpl(`${this.baseUrl}${path}`, { ...init, headers });
-    } catch (err) {
-      // Network-level failure: ECONNREFUSED, DNS failure, fetch TypeError,
-      // CORS pre-flight reject. The vault is unreachable from the browser's
-      // perspective; surface it as such and let the reachability store decide
-      // when to promote to "down". Don't swallow AbortError — that's a caller
-      // (offline-fallback timer, useEffect cleanup) deliberately cancelling.
-      if (err instanceof DOMException && err.name === "AbortError") throw err;
-      const message = err instanceof Error ? err.message : String(err);
-      this.onReachability?.("unreachable", message);
-      throw new VaultUnreachableError(`${init.method ?? "GET"} ${path} failed: ${message}`, 0);
-    }
-
-    // 5xx = the server (or the hub fronting it) responded with a failure that
-    // isn't auth or our request shape — usually "vault not running" /
-    // "mid-restart" / "proxy upstream timeout". Treat as unreachable;
-    // VaultUnreachableError so React Query can skip retries once the store
-    // crosses its threshold.
-    if (res.status >= 500) {
-      this.onReachability?.("unreachable", `HTTP ${res.status}`);
-      throw new VaultUnreachableError(
-        `${init.method ?? "GET"} ${path} → ${res.status}`,
-        res.status,
-      );
-    }
-
-    // Any non-5xx response means the vault is talking to us — even auth
-    // failures or 404s — so reset the reachability counter.
-    this.onReachability?.("healthy");
-
-    if (res.status === 401 || res.status === 403) {
-      if (allowRetry && this.onAuthError) {
-        const fresh = await this.onAuthError();
-        if (fresh) {
-          this.token = fresh;
-          return this.requestWithRetry<T>(path, init, false);
-        }
-        // onAuthError returned null — refresh.ts will already have recorded
-        // its own halt with a specific reason if appropriate; don't double-mark.
-      } else {
-        // No refresh path, or we're on the post-refresh retry and the new
-        // token also failed. Either way, the credentials we have are dead.
-        this.onAuthRevoked?.(res.status);
-      }
-      throw new VaultAuthError(`Vault rejected the token (${res.status})`, res.status);
-    }
-    if (res.status === 404) {
-      throw new VaultNotFoundError(`${init.method ?? "GET"} ${path} → 404`);
-    }
-    if (res.status === 409 || res.status === 428) {
-      // 409 = baseline mismatch (sent stale `if_updated_at`); 428 = baseline
-      // missing (didn't send `if_updated_at` and `force` wasn't set). Both
-      // recover the same way — refetch the note for a fresh baseline and
-      // retry — so we collapse them into one error class.
-      const body = (await res.json().catch(() => ({}))) as {
-        error?: string;
-        target?: string;
-        message?: string;
-        current_updated_at?: string | null;
-        expected_updated_at?: string | null;
-      };
-      // The vault's tag-rename endpoint returns `{error:"target_exists",...}`
-      // for name-collision; the note PATCH endpoint returns the
-      // current_updated_at/expected_updated_at shape. Different failure modes,
-      // same HTTP status — distinguish by body shape.
-      if (body.error === "target_exists" && typeof body.target === "string") {
-        throw new VaultTargetExistsError(body.target, body.message);
-      }
-      throw new VaultConflictError(body);
-    }
-    if (!res.ok) {
-      const text = await res.text();
-      throw new Error(`${init.method ?? "GET"} ${path} failed (${res.status}): ${text}`);
-    }
-    if (res.status === 204) return undefined as T;
-    return (await res.json()) as T;
-  }
-
-  async vaultInfo(includeStats = true): Promise<VaultInfo> {
-    const query = includeStats ? "?include_stats=true" : "";
-    return this.request<VaultInfo>(`/api/vault${query}`);
-  }
-
-  async queryNotes(params: URLSearchParams): Promise<Note[]> {
-    const qs = params.toString();
-    return this.request<Note[]>(`/api/notes${qs ? `?${qs}` : ""}`);
-  }
-
-  async getNote(
-    id: string,
-    opts: { includeLinks?: boolean; includeAttachments?: boolean } = {},
-  ): Promise<Note | null> {
-    const params = new URLSearchParams({ id, include_content: "true" });
-    if (opts.includeLinks) params.set("include_links", "true");
-    if (opts.includeAttachments) params.set("include_attachments", "true");
-    const rows = await this.request<Note[] | Note>(`/api/notes?${params.toString()}`);
-    // The vault may return either a single note (when id is passed) or an array.
-    if (Array.isArray(rows)) return rows[0] ?? null;
-    return rows ?? null;
-  }
-
-  async updateNote(
-    id: string,
-    payload: UpdateNotePayload,
-    opts: { signal?: AbortSignal } = {},
-  ): Promise<Note> {
-    return this.request<Note>(`/api/notes/${encodeURIComponent(id)}`, {
-      method: "PATCH",
-      body: JSON.stringify(payload),
-      signal: opts.signal,
-    });
-  }
-
-  async createNote(payload: CreateNotePayload, opts: { signal?: AbortSignal } = {}): Promise<Note> {
-    return this.request<Note>("/api/notes", {
-      method: "POST",
-      body: JSON.stringify(payload),
-      signal: opts.signal,
-    });
-  }
-
-  async deleteNote(id: string, opts: { signal?: AbortSignal } = {}): Promise<void> {
-    await this.request<{ deleted: boolean; id: string } | undefined>(
-      `/api/notes/${encodeURIComponent(id)}`,
-      { method: "DELETE", signal: opts.signal },
-    );
-  }
-
-  async listTags(): Promise<TagSummary[]> {
-    return this.request<TagSummary[]>("/api/tags");
-  }
-
-  // Same as listTags but with the full tag-identity record per row
+  // `listTags` but with the full tag-identity record per row
   // (description, parent_names, etc). Used by the schema-audit path
   // (notes#129) to diff vault state against `NOTES_REQUIRED_SCHEMA`.
   async listTagsWithSchema(): Promise<
@@ -311,24 +162,6 @@ export class VaultClient {
   async deleteTag(name: string): Promise<void> {
     await this.request<undefined>(`/api/tags/${encodeURIComponent(name)}`, {
       method: "DELETE",
-    });
-  }
-
-  // Upsert a tag-identity row. `description`, `parent_names`, `fields`,
-  // `relationships` are all field-merged on the vault side — omitted keys
-  // preserve prior values, explicit `null` clears them. Idempotent: calling
-  // with the same payload as-stored is a no-op write. Used by the surface
-  // schema-ensure path (lib/vault/schema.ts → schema-ensure.ts).
-  async updateTag(
-    name: string,
-    body: {
-      description?: string | null;
-      parent_names?: string[] | null;
-    },
-  ): Promise<void> {
-    await this.request<undefined>(`/api/tags/${encodeURIComponent(name)}`, {
-      method: "PUT",
-      body: JSON.stringify(body),
     });
   }
 
@@ -349,64 +182,15 @@ export class VaultClient {
     });
   }
 
-  uploadStorageFile(
-    file: File,
-    opts: {
-      onProgress?: (p: UploadProgress) => void;
-      signal?: AbortSignal;
-    } = {},
-  ): Promise<StorageUploadResult> {
-    return new Promise((resolve, reject) => {
-      const xhr = this.xhrFactory();
-      const form = new FormData();
-      form.append("file", file);
+  // ---------- Notes-only attachment helpers ----------
 
-      xhr.open("POST", `${this.baseUrl}/api/storage/upload`);
-      xhr.setRequestHeader("Authorization", `Bearer ${this.token}`);
-      xhr.setRequestHeader("Accept", "application/json");
-
-      if (opts.onProgress && xhr.upload) {
-        xhr.upload.onprogress = (e) => {
-          if (e.lengthComputable) opts.onProgress?.({ loaded: e.loaded, total: e.total });
-        };
-      }
-
-      xhr.onload = () => {
-        if (xhr.status === 401 || xhr.status === 403) {
-          reject(new VaultAuthError(`Vault rejected the token (${xhr.status})`, xhr.status));
-          return;
-        }
-        if (xhr.status < 200 || xhr.status >= 300) {
-          let message = `Upload failed (${xhr.status})`;
-          try {
-            const body = JSON.parse(xhr.responseText) as { error?: string };
-            if (body.error) message = body.error;
-          } catch {}
-          reject(new VaultUploadError(message, xhr.status));
-          return;
-        }
-        try {
-          resolve(JSON.parse(xhr.responseText) as StorageUploadResult);
-        } catch (e) {
-          reject(e instanceof Error ? e : new Error("Invalid upload response"));
-        }
-      };
-
-      xhr.onerror = () => reject(new VaultUploadError("Network error during upload", 0));
-      xhr.onabort = () => reject(new DOMException("Upload aborted", "AbortError"));
-
-      if (opts.signal) {
-        if (opts.signal.aborted) {
-          xhr.abort();
-          return;
-        }
-        opts.signal.addEventListener("abort", () => xhr.abort(), { once: true });
-      }
-
-      xhr.send(form);
-    });
-  }
-
+  /**
+   * Notes-only alias of the base's `addAttachment` (same wire shape:
+   * POST `/api/notes/:id/attachments`). Callers throughout Notes use
+   * the `linkAttachment` name; preserving the alias avoids a sweeping
+   * rename and keeps the semantic distinction (link an already-uploaded
+   * blob to a note, vs. "add" which the base names generically).
+   */
   async linkAttachment(
     noteIdOrPath: string,
     body: { path: string; mimeType: string; transcribe?: boolean },
@@ -417,28 +201,22 @@ export class VaultClient {
     );
   }
 
-  async listAttachments(noteIdOrPath: string): Promise<NoteAttachment[]> {
-    return this.request<NoteAttachment[]>(
-      `/api/notes/${encodeURIComponent(noteIdOrPath)}/attachments`,
-    );
-  }
-
-  async deleteAttachment(noteIdOrPath: string, attachmentId: string): Promise<void> {
-    await this.request<undefined>(
-      `/api/notes/${encodeURIComponent(noteIdOrPath)}/attachments/${encodeURIComponent(attachmentId)}`,
-      { method: "DELETE" },
-    );
-  }
-
-  storageUrl(path: string): string {
-    const trimmed = path.startsWith("/") ? path.slice(1) : path;
-    return `${this.baseUrl}/api/storage/${trimmed}`;
-  }
-
+  /**
+   * Retry-aware GET of an attachment blob URL — used by audio/image
+   * render paths (NoteView, VaultImage). Mirrors the base class's
+   * refresh-on-401 behavior on the blob path: a 401/403 triggers
+   * `onAuthError` once, and the retry uses the rotated token.
+   *
+   * Carries its own retry loop because the base's `request*` always
+   * `res.json()`s the body — which would corrupt an audio/image Blob.
+   * The shape is identical to `requestWithRetry`'s auth/reachability
+   * branches; the auth callbacks and token state are captured on the
+   * subclass at construction (see field declarations above).
+   */
   async fetchAttachmentBlob(url: string): Promise<Blob> {
     const target = url.startsWith("http")
       ? url
-      : `${this.baseUrl}${url.startsWith("/") ? "" : "/"}${url}`;
+      : `${this.vaultBaseUrl}${url.startsWith("/") ? "" : "/"}${url}`;
     return this.fetchBlobWithRetry(target, url, true);
   }
 
@@ -449,32 +227,35 @@ export class VaultClient {
   ): Promise<Blob> {
     let res: Response;
     try {
-      res = await this.fetchImpl(target, {
-        headers: { Authorization: `Bearer ${this.token}` },
+      res = await this.currentFetchImpl(target, {
+        headers: { Authorization: `Bearer ${this.currentToken}` },
       });
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") throw err;
       const message = err instanceof Error ? err.message : String(err);
-      this.onReachability?.("unreachable", message);
+      this.currentOnReachability?.("unreachable", message);
       throw new VaultUnreachableError(`GET ${originalUrl} failed: ${message}`, 0);
     }
     if (res.status >= 500) {
-      this.onReachability?.("unreachable", `HTTP ${res.status}`);
+      this.currentOnReachability?.("unreachable", `HTTP ${res.status}`);
       throw new VaultUnreachableError(`GET ${originalUrl} → ${res.status}`, res.status);
     }
-    this.onReachability?.("healthy");
+    this.currentOnReachability?.("healthy");
     if (res.status === 401 || res.status === 403) {
-      if (allowRetry && this.onAuthError) {
-        const fresh = await this.onAuthError();
+      if (allowRetry && this.currentOnAuthError) {
+        const fresh = await this.currentOnAuthError();
         if (fresh) {
-          this.token = fresh;
+          this.currentToken = fresh;
+          // Keep the base's token in sync so subsequent inherited JSON
+          // calls also see the rotated token.
+          super.setAccessToken(fresh);
           return this.fetchBlobWithRetry(target, originalUrl, false);
         }
         // onAuthError returned null — refresh.ts owns the halt path.
       } else {
         // No refresh path, or post-refresh retry still 401/403. Mirror
         // requestWithRetry so attachment loads also surface the banner.
-        this.onAuthRevoked?.(res.status);
+        this.currentOnAuthRevoked?.(res.status);
       }
       throw new VaultAuthError(`Vault rejected the token (${res.status})`, res.status);
     }


### PR DESCRIPTION
## Summary

app-client 0.1.0-rc.3 lifted `request` / `requestWithRetry` /
`requestCursorWithRetry` to `protected` ([parachute-app#10][app10]),
closing the loop from notes#153's reviewer follow-up. Notes' VaultClient
now subclasses `@openparachute/app-client`'s base class instead of
cloning the request loop.

- **219 lines deleted** from `packages/notes-ui/src/lib/vault/client.ts`
  (486 → 267).
- **691 lines deleted** from `packages/notes-ui/src/lib/vault/client.test.ts`
  (997 → 306). Base-class behaviors are covered by app-client's own
  suite; 14 Notes-specific tests retained.

### Notes-specific surface retained on the subclass

| Method | Why retained |
|---|---|
| `renameTag` / `mergeTags` / `deleteTag` | Tag-curation endpoints not in app-client's surface |
| `listTagsWithSchema` | `/api/tags?include_schema=true` for schema-audit runner (notes#129) |
| `linkAttachment` | Alias of base `addAttachment` — preserves Notes' caller-facing name + avoids a sweeping rename |
| `fetchAttachmentBlob` | Audio/image render path; carries its own retry loop because the base's `request*` always parses JSON |

### Behaviour change worth flagging

Notes' previous narrow `updateTag` override was dropped. The base
class's `updateTag` accepts a wider `TagUpsertPayload` and returns a
`TagRecord`; the existing call sites (`schema-ensure.ts` → 2 calls)
pass `{description, parent_names}` (a subset of `TagUpsertPayload`) and
`await` without consuming the return — so the surface is
backward-compatible at the call site.

### Bundle delta

Main chunk: **415.90 → 419.70 kB** (+3.8 kB raw, +0.9 kB gzip). The
subclass mirrors a handful of auth-callback fields on the instance so
the blob path can drive its own retry loop without reaching into the
base's `private` state — see file header for the rationale.

### Cross-refs

- Initial Phase 2 adoption: notes#153 (`f5b70cb`)
- `request*` → `protected` in app-client: [parachute-app#10][app10] (rc.3)

[app10]: https://github.com/ParachuteComputer/parachute-app/pull/10

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` — 767/767 pass (90 files)
- [x] `bun run build` — clean
- [ ] Manual smoke: install notes-ui under `parachute-app`, verify
      vaultInfo / queryNotes / createNote / linkAttachment /
      fetchAttachmentBlob (audio playback) / renameTag all still work
- [ ] Auth-revoke smoke: confirm the blob path still fires
      `onAuthRevoked` when the post-refresh retry also 401s

🤖 Generated with [Claude Code](https://claude.com/claude-code)