### PR TITLE
docs(notes): add RELEASING.md — workspace publish workflow + private:true safety net

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,39 @@
+# Releasing
+
+The `parachute-notes` repo is a monorepo with two publishable packages:
+
+- `@openparachute/notes-ui` — the UI bundle (in `packages/notes-ui/`), installed under parachute-app as the canonical first app
+- `@openparachute/notes` — the legacy module daemon (in `packages/notes-daemon/`), **deprecated as of rc.2** in favor of installing notes-ui via parachute-app
+
+The workspace root (`@openparachute/notes-monorepo`) is intentionally `private: true` and should NEVER publish.
+
+## Publish workflow
+
+**To publish a specific package:**
+
+```bash
+# From repo root
+npm publish --workspace @openparachute/notes-ui --tag rc
+npm publish --workspace @openparachute/notes --tag rc
+
+# OR cd into the package
+cd packages/notes-ui && npm publish --tag rc
+cd packages/notes-daemon && npm publish --tag rc
+```
+
+The daemon's build copies notes-ui's `dist/` into its own, so publish `notes-ui` BEFORE the daemon if both are going out in the same session and the daemon's `dist/` needs to reflect a fresh notes-ui build.
+
+**Don't run `npm publish` from the repo root without `--workspace`** — npm would try to publish `@openparachute/notes-monorepo` (the workspace root). That's blocked by `private: true` as a safety net.
+
+## RC vs stable
+
+Pre-1.0, every code-touching publish bumps `rc.N`:
+- `npm publish --workspace @openparachute/notes-ui --tag rc` ships to `@rc`
+- `npm publish --workspace @openparachute/notes-ui --tag latest` promotes to `@latest` (only after Aaron explicitly says ready)
+
+## Verifying
+
+```bash
+npm view @openparachute/notes-ui dist-tags --json
+npm view @openparachute/notes dist-tags --json
+```


### PR DESCRIPTION
## Summary

Document the correct publish workflow for the parachute-notes monorepo so the workspace root never accidentally publishes.

- Adds `RELEASING.md` at repo root with explicit `npm publish --workspace <pkg>` flow for `@openparachute/notes-ui` and `@openparachute/notes` (deprecated)
- Calls out that the workspace root (`@openparachute/notes-monorepo`) is intentionally `private: true` and explains why (npm would target the empty root without `--workspace`)

## Context

Aaron tried `npm publish` from the repo root, hit `EPRIVATE`, flipped `private: true` → `false` to bypass — which would have published the empty workspace root as `@openparachute/notes-monorepo@0.0.0` (no prerelease tag check to catch it since version is `0.0.0`). He noticed before pushing. This PR documents the correct flow so it doesn't recur. The `private: true` on the root was already correct in `main`; only RELEASING.md is new.

## Verification

- `bun install` from root still works (no changes)
- `npm publish` from root errors with `EPRIVATE` (verified via test reproducer)
- `npm publish --workspace @openparachute/notes-ui --dry-run --tag rc` targets the right package (filename: `openparachute-notes-ui-0.1.0-rc.3.tgz`)

## Patterns check

No pattern boundary crossed. Releasing-doc convention is local to each repo for now; if it generalizes across the ecosystem we can lift it into `parachute-patterns/` later.

## Test plan

- [ ] `bun install` from root succeeds
- [ ] `bun test` from root succeeds
- [ ] `npm publish --workspace @openparachute/notes-ui --dry-run --tag rc` shows notes-ui in the dry-run output

🤖 Generated with [Claude Code](https://claude.com/claude-code)