### PR TITLE
fix(notes-ui): resolve link: dep in published manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ This is the monorepo-level changelog. Per-package changelogs live at:
 - `packages/notes-daemon/CHANGELOG.md` — `@openparachute/notes`
 - `packages/notes-ui/CHANGELOG.md` — `@openparachute/notes-ui`
 
+## 2026-05-22 — notes-ui 0.1.0-rc.4 fix-publish
+
+`@openparachute/notes-ui@0.1.0-rc.3`'s tarball declared
+`"@openparachute/app-client": "link:@openparachute/app-client"` —
+the local-dev `link:` protocol set up during the notes#153 work
+when app-client wasn't yet published. Installing rc.3 from npm
+failed at resolve. rc.4 switches to a concrete `^0.1.0-rc.3` and
+the repo's `RELEASING.md` grows a "Workspace dependencies" rule
+to prevent recurrence. See
+`packages/notes-ui/CHANGELOG.md` for the full entry.
+
 ## 2026-05-22 — notes-daemon deprecated (Phase 2)
 
 `@openparachute/notes` (the daemon at `packages/notes-daemon/`) entered the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,6 +25,38 @@ The daemon's build copies notes-ui's `dist/` into its own, so publish `notes-ui`
 
 **Don't run `npm publish` from the repo root without `--workspace`** — npm would try to publish `@openparachute/notes-monorepo` (the workspace root). That's blocked by `private: true` as a safety net.
 
+## Workspace dependencies must be concrete in the published manifest
+
+If a publishable package (notes-ui, notes-daemon) depends on a sibling workspace package or any sibling-published package (e.g. `@openparachute/app-client` from the parachute-app repo), the dependency in its `package.json` MUST be a concrete semver (e.g. `"^0.1.0-rc.3"`) — NEVER `workspace:*` or `link:...`.
+
+**Reason**: `npm publish` does NOT rewrite the `workspace:` protocol at publish time. (Bun's `bun publish` does, but we can't bind the publish workflow to a single tool.) `link:` is a local-dev-only protocol that always serializes as an unresolvable string in a published tarball. Either form leaks into the npm-served manifest and breaks every install:
+
+```
+error: Workspace dependency "@openparachute/app-client" not found
+```
+
+This bit us on `@openparachute/notes-ui@0.1.0-rc.3` (and `@openparachute/app@0.2.0-rc.3` next door) — both required emergency rc.4 republishes 2026-05-22.
+
+**To bump a sibling dep** (e.g. when app-client publishes a new rc):
+
+1. Update the consumer's `package.json` to the new concrete version (e.g. `"^0.1.0-rc.4"`).
+2. `bun install` to refresh the lockfile.
+3. Run typecheck + tests locally.
+4. Bump the consumer's own version + CHANGELOG entry referencing the dep bump.
+5. Publish the consumer.
+
+**Local dev still works** with concrete semver — Bun's resolver matches sibling packages by name regardless of the version string, falling back to the registry only when no sibling matches.
+
+**Verify before publishing**:
+
+```bash
+cd packages/notes-ui && npm pack --dry-run
+# scan the printed manifest's `dependencies` block — every entry must be a
+# concrete semver. NO `workspace:` and NO `link:` strings.
+```
+
+If the dry-run shows `workspace:` or `link:`, fix the package.json before publishing.
+
 ## RC vs stable
 
 Pre-1.0, every code-touching publish bumps `rc.N`:

--- a/bun.lock
+++ b/bun.lock
@@ -7,14 +7,14 @@
     },
     "packages/notes-daemon": {
       "name": "@openparachute/notes",
-      "version": "0.3.17-rc.1",
+      "version": "0.3.17-rc.2",
       "devDependencies": {
         "@openparachute/notes-ui": "workspace:*",
       },
     },
     "packages/notes-ui": {
       "name": "@openparachute/notes-ui",
-      "version": "0.1.0-rc.2",
+      "version": "0.1.0-rc.4",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",
@@ -22,7 +22,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.41.1",
         "@lezer/highlight": "^1.2.3",
-        "@openparachute/app-client": "link:@openparachute/app-client",
+        "@openparachute/app-client": "^0.1.0-rc.3",
         "@tanstack/react-query": "^5",
         "highlight.js": "^11.11.1",
         "idb": "^8.0.3",
@@ -426,7 +426,7 @@
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
-    "@openparachute/app-client": ["@openparachute/app-client@link:@openparachute/app-client", {}],
+    "@openparachute/app-client": ["@openparachute/app-client@0.1.0-rc.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-hnXHm7N1SCVLYkdQ7Bu7O0vcQrxYSbAnLXdORIZ0B130/Blyv+vdjXPCAx75o1e0fGnmsgvab7C5rGbRiTNThw=="],
 
     "@openparachute/notes": ["@openparachute/notes@workspace:packages/notes-daemon"],
 

--- a/packages/notes-ui/CHANGELOG.md
+++ b/packages/notes-ui/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog — @openparachute/notes-ui
 
+## [0.1.0-rc.4] - 2026-05-22
+
+- **Fix: resolve `link:` dep in published manifest** (`link:` →
+  `^0.1.0-rc.3`). The published tarball for `0.1.0-rc.3` carried
+  `"@openparachute/app-client": "link:@openparachute/app-client"` —
+  a local-dev-only protocol set up in notes#153 when app-client
+  wasn't yet on npm. Installing `@openparachute/notes-ui@0.1.0-rc.3`
+  failed at resolve:
+
+  ```
+  error: Workspace dependency "@openparachute/app-client" not found
+  ```
+
+  `@openparachute/app-client@0.1.0-rc.3` is now published, so we
+  switch to a concrete semver. Local dev still resolves the sibling
+  through Bun's workspace resolver (it matches by name regardless
+  of the version string), and the published tarball declares a
+  real, registry-resolvable dependency.
+
+  The repo's `RELEASING.md` grows a "Workspace dependencies" section
+  documenting the rule so this can't recur.
+
 ## [0.1.0-rc.3] - 2026-05-22
 
 - **Refactor: `VaultClient` subclasses `@openparachute/app-client`'s

--- a/packages/notes-ui/package.json
+++ b/packages/notes-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes-ui",
-  "version": "0.1.0-rc.3",
+  "version": "0.1.0-rc.4",
   "private": false,
   "type": "module",
   "description": "Parachute Notes UI bundle — the SPA installed under parachute-app as the canonical first app. No daemon, no module surface; just the built dist/.",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",
-    "@openparachute/app-client": "link:@openparachute/app-client",
+    "@openparachute/app-client": "^0.1.0-rc.3",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",
     "@codemirror/state": "^6.6.0",


### PR DESCRIPTION
## Summary

`@openparachute/notes-ui@0.1.0-rc.3`'s published tarball carries `"@openparachute/app-client": "link:@openparachute/app-client"` — the local-dev `link:` protocol set up in #153 when app-client wasn't yet published. `link:` is local-dev-only and always serializes as an unresolvable string in a published tarball:

```
error: Workspace dependency "@openparachute/app-client" not found
```

`@openparachute/app-client@0.1.0-rc.3` is now published, so this PR ships `0.1.0-rc.4` with a concrete `^0.1.0-rc.3` semver. Local dev still resolves the sibling through Bun's workspace resolver (matches by name regardless of version string), and the published tarball declares a real, registry-resolvable dependency.

`RELEASING.md` grows a new "Workspace dependencies" section explaining the gotcha + the rule (concrete semver in any package.json that gets published; never `workspace:*` or `link:`) so this can't recur.

Tracked next door at parachute-app#TBD (same fix for `@openparachute/app@0.2.0-rc.3` which leaked `workspace:*` for the same reason).

## Test plan

- [x] `bun install` — succeeds, lockfile updates cleanly
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 768 pass / 0 fail (notes-ui) + daemon smoke tests pass
- [x] `npm pack --dry-run` from `packages/notes-ui/` — manifest `dependencies` block contains only concrete semver, no `workspace:` / `link:` strings
- [x] Extracted tarball `package.json` shows `"@openparachute/app-client": "^0.1.0-rc.3"`
- [x] Standalone `bun add ./openparachute-notes-ui-0.1.0-rc.4.tgz` in a fresh temp dir — `@openparachute/app-client` resolves from the registry

After merge, Aaron publishes:
```
cd packages/notes-ui && npm publish --tag rc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)