### PR TITLE
release(notes-ui): 0.1.0 — first stable release with meta.json (resolves bootstrap)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,8 +2,10 @@
 
 The `parachute-notes` repo is a monorepo with two publishable packages:
 
-- `@openparachute/notes-ui` — the UI bundle (in `packages/notes-ui/`), installed under parachute-app as the canonical first app
+- `@openparachute/notes-ui` — the UI bundle (in `packages/notes-ui/`), installed under parachute-app as the canonical first app. Ships `meta.json` alongside `dist/` so parachute-app's bootstrap validator accepts the tarball (added rc.5; see [meta-schema][meta-schema]).
 - `@openparachute/notes` — the legacy module daemon (in `packages/notes-daemon/`), **deprecated as of rc.2** in favor of installing notes-ui via parachute-app
+
+[meta-schema]: https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/meta-schema.ts
 
 The workspace root (`@openparachute/notes-monorepo`) is intentionally `private: true` and should NEVER publish.
 
@@ -53,9 +55,12 @@ This bit us on `@openparachute/notes-ui@0.1.0-rc.3` (and `@openparachute/app@0.2
 cd packages/notes-ui && npm pack --dry-run
 # scan the printed manifest's `dependencies` block — every entry must be a
 # concrete semver. NO `workspace:` and NO `link:` strings.
+#
+# Also confirm `meta.json` appears in the file list — parachute-app's
+# bootstrap validator rejects tarballs without it.
 ```
 
-If the dry-run shows `workspace:` or `link:`, fix the package.json before publishing.
+If the dry-run shows `workspace:` or `link:`, fix the package.json before publishing. If `meta.json` is missing, ensure it's listed in the `files` array of `packages/notes-ui/package.json`.
 
 ## RC vs stable
 

--- a/packages/notes-ui/CHANGELOG.md
+++ b/packages/notes-ui/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog — @openparachute/notes-ui
 
+## [0.1.0-rc.5] - 2026-05-23
+
+- **Fix: ship `meta.json` so parachute-app bootstrap can install.**
+  parachute-app's auto-bootstrap path validates `@openparachute/notes-
+  ui`'s tarball against its [meta-schema][meta-schema] and requires
+  `name` + `displayName` + `path`. Tarballs through rc.4 included only
+  `dist/`, `LICENSE`, `README.md`, `package.json`, and `CHANGELOG.md`
+  — no `meta.json`, so bootstrap failed with:
+
+  ```
+  [app] bootstrap: failed to install @openparachute/notes-ui: meta.json:
+  name: is required (string); displayName: is required (non-empty
+  string); path: is required (string)
+  ```
+
+  This release adds `packages/notes-ui/meta.json` and includes it in
+  the `files` list. The file declares `name: "notes"`, `displayName:
+  "Notes"`, `path: "/app/notes"`, `scopes_required: ["vault:*:read",
+  "vault:*:write"]` (vault-agnostic — Notes' in-app vault picker
+  narrows per OAuth flow), `pwa: true` + `pwa_service_worker: "sw.js"`
+  (Notes is the canonical PWA-mode example per [design §18][s18]),
+  `iconUrl: "icon.svg"`, and the `required_schema.tags` declaration
+  for `capture` / `capture/text` / `capture/voice` mirroring
+  `NOTES_REQUIRED_SCHEMA` in `src/lib/vault/schema.ts` (patterns#57 —
+  Phase 2.0 validates the shape; Phase 2.1+ auto-provisions).
+
+  Canonical reference for the shape: [design doc §5][s5].
+
+[meta-schema]: https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/meta-schema.ts
+[s5]: https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-apps-design.md#5-per-ui-metadata-schema--metajson-draft-07
+[s18]: https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-apps-design.md#18-caching--reload-strategy
+
 ## [0.1.0-rc.4] - 2026-05-22
 
 - **Fix: resolve `link:` dep in published manifest** (`link:` →

--- a/packages/notes-ui/CHANGELOG.md
+++ b/packages/notes-ui/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog — @openparachute/notes-ui
 
-## [0.1.0-rc.5] - 2026-05-23
+## [0.1.0] - 2026-05-23
 
+- **First stable release; promoted from rc.5.** Tagged `@latest` for
+  parachute-app bootstrap's bare-spec resolution.
 - **Fix: ship `meta.json` so parachute-app bootstrap can install.**
   parachute-app's auto-bootstrap path validates `@openparachute/notes-
   ui`'s tarball against its [meta-schema][meta-schema] and requires

--- a/packages/notes-ui/meta.json
+++ b/packages/notes-ui/meta.json
@@ -3,7 +3,7 @@
   "name": "notes",
   "displayName": "Notes",
   "tagline": "Notes PWA backed by your vault.",
-  "version": "0.1.0-rc.5",
+  "version": "0.1.0",
   "path": "/app/notes",
   "iconUrl": "icon.svg",
   "scopes_required": ["vault:*:read", "vault:*:write"],

--- a/packages/notes-ui/meta.json
+++ b/packages/notes-ui/meta.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://parachute.computer/schemas/app-ui-meta.json",
+  "name": "notes",
+  "displayName": "Notes",
+  "tagline": "Notes PWA backed by your vault.",
+  "path": "/app/notes",
+  "iconUrl": "icon.svg",
+  "scopes_required": ["vault:*:read", "vault:*:write"],
+  "pwa": true,
+  "pwa_service_worker": "sw.js",
+  "required_schema": {
+    "tags": [
+      {
+        "name": "capture",
+        "description": "Notes captured directly by the user (text or voice)."
+      },
+      {
+        "name": "capture/text",
+        "description": "Text capture."
+      },
+      {
+        "name": "capture/voice",
+        "description": "Voice capture."
+      }
+    ]
+  }
+}

--- a/packages/notes-ui/meta.json
+++ b/packages/notes-ui/meta.json
@@ -3,6 +3,7 @@
   "name": "notes",
   "displayName": "Notes",
   "tagline": "Notes PWA backed by your vault.",
+  "version": "0.1.0-rc.5",
   "path": "/app/notes",
   "iconUrl": "icon.svg",
   "scopes_required": ["vault:*:read", "vault:*:write"],

--- a/packages/notes-ui/package.json
+++ b/packages/notes-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes-ui",
-  "version": "0.1.0-rc.5",
+  "version": "0.1.0",
   "private": false,
   "type": "module",
   "description": "Parachute Notes UI bundle — the SPA installed under parachute-app as the canonical first app. No daemon, no module surface; just the built dist/.",

--- a/packages/notes-ui/package.json
+++ b/packages/notes-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes-ui",
-  "version": "0.1.0-rc.4",
+  "version": "0.1.0-rc.5",
   "private": false,
   "type": "module",
   "description": "Parachute Notes UI bundle — the SPA installed under parachute-app as the canonical first app. No daemon, no module surface; just the built dist/.",
@@ -10,7 +10,7 @@
     "url": "https://github.com/ParachuteComputer/parachute-notes.git",
     "directory": "packages/notes-ui"
   },
-  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
+  "files": ["dist", "meta.json", "README.md", "LICENSE", "CHANGELOG.md"],
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary

Ships `@openparachute/notes-ui@0.1.0` — the first stable release — bundling the `meta.json` fix that resolves Aaron's `parachute-app` auto-bootstrap loop. Without the bundled `meta.json` the bootstrap path fails with:

```
[app] bootstrap: failed to install @openparachute/notes-ui: meta.json: name: is required (string); displayName: is required (non-empty string); path: is required (string)
```

Per [governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md): *"When Aaron explicitly says ready-for-release: drop the `-rc` suffix, ship the same `0.X.Y` stable, `npm publish --tag latest`."* Aaron's calling stable promotion, so the rc chain (rc.1 → rc.5) ends here and `0.1.0` lands as the first `@latest`-tagged release. Folding the bump into this PR avoids a redundant rc.5 merge.

This also unblocks parachute-app's default bootstrap spec — the bare `@openparachute/notes-ui` resolves via the `@latest` dist-tag, which previously had nothing pointing at it. The orphaned `0.1.0-rc.5` tag on npm (published mid-iteration) becomes harmless leftover; `@latest` is now canonical for notes-ui.

## What changed

- `packages/notes-ui/package.json` — `0.1.0-rc.4` → `0.1.0`. Added `"meta.json"` to `files` so npm tarballs include it.
- `packages/notes-ui/meta.json` — new file. See **Schema** below. `version` field carries `0.1.0`.
- `packages/notes-ui/CHANGELOG.md` — `[0.1.0]` entry with promotion note + the meta.json fix.
- `RELEASING.md` — one-liner that the package ships `meta.json` + a verify step in the dry-run section.

## Schema (the new meta.json)

```json
{
  "$schema": "https://parachute.computer/schemas/app-ui-meta.json",
  "name": "notes",
  "displayName": "Notes",
  "tagline": "Notes PWA backed by your vault.",
  "version": "0.1.0",
  "path": "/app/notes",
  "iconUrl": "icon.svg",
  "scopes_required": ["vault:*:read", "vault:*:write"],
  "pwa": true,
  "pwa_service_worker": "sw.js",
  "required_schema": {
    "tags": [
      { "name": "capture",       "description": "Notes captured directly by the user (text or voice)." },
      { "name": "capture/text",  "description": "Text capture." },
      { "name": "capture/voice", "description": "Voice capture." }
    ]
  }
}
```

### Field derivation

- **`name` / `path`** — `notes` / `/app/notes` (the canonical mount point per design §16).
- **`displayName` / `tagline`** — mirrored from the legacy notes-daemon's `services.json` (`"Notes"` / `"Notes PWA backed by your vault."`).
- **`scopes_required: ["vault:*:read", "vault:*:write"]`** — Notes is vault-agnostic (in-app `VaultPopover` picks per session). [Design §5](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-apps-design.md#5-per-ui-metadata-schema--metajson-draft-07) line 191: *"Vault-agnostic (multi-vault) UIs declare wildcards: `[\"vault:*:read\", \"vault:*:write\"]`. The UI handles vault selection in-app (Notes-style — see notes' VaultPopover component)."* The runtime two-segment `vault:read vault:write` form in `src/lib/vault/oauth.ts:56` (`DEFAULT_SCOPE`) is what OAuth requests at runtime — the meta.json declares the **shape** (wildcards), the runtime narrows.
- **`pwa: true` + `pwa_service_worker: "sw.js"`** — Notes is the canonical PWA-mode example per [design §18](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-apps-design.md#18-caching--reload-strategy) line 634: *"For UIs that genuinely need offline-first behavior (Notes is the canonical example...)"*. `vite-plugin-pwa` emits `dist/sw.js` via the build.
- **`iconUrl: "icon.svg"`** — already shipped in `dist/icon.svg`.
- **`required_schema.tags`** — mirrors `NOTES_REQUIRED_SCHEMA` in `packages/notes-ui/src/lib/vault/schema.ts` (the existing `ensureNotesSchema()` declaration). patterns#57 — Phase 2.0 validates the shape and surfaces it in the admin SPA; Phase 2.1+ auto-provisions missing rows in vault at install time. The vault-side `parent_names` hierarchy isn't part of the meta-schema yet (the validator's `TagSchemaDeclaration` accepts `{name, description?, fields?}`); Notes' runtime `ensureNotesSchema()` still owns the hierarchy.
- **Not included**:
  - `vault_default` — would pin Notes to one vault. Notes is vault-agnostic by design.
  - `dev_*` fields — installed-bundle context, not dev mode.

## Validation

`bun run` against the live `parseMeta()` in `parachute-app/packages/app-host/src/meta-schema.ts` accepts the file cleanly. `npm pack --dry-run` shows the `0.1.0` tarball with `meta.json` in the file list:

```
npm notice 686B meta.json
npm notice version: 0.1.0
npm notice filename: openparachute-notes-ui-0.1.0.tgz
npm notice total files: 38
```

`bun run typecheck` and `bun run build` both clean. The `dist/` + `meta.json` bundle is byte-identical to rc.5's content — only the version string changed.

## After merge — publish

Aaron will run from his own shell (per npm-publish governance):

```
cd packages/notes-ui && npm publish --tag latest
```

Note `--tag latest` (NOT `--tag rc`). This is the first stable, so `@latest` becomes canonical and parachute-app's bare-spec bootstrap resolves cleanly.

## Cross-refs

- Aaron's bootstrap error reproducer (see Summary).
- [`parachute-app/packages/app-host/src/meta-schema.ts`](https://github.com/ParachuteComputer/parachute-app/blob/main/packages/app-host/src/meta-schema.ts) — the validator.
- [design §5](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-apps-design.md#5-per-ui-metadata-schema--metajson-draft-07) — canonical meta.json schema.
- [design §16](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-apps-design.md#16-notes-migration-to-app) — Notes-as-app migration arc.
- [governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md) — stable promotion shape.

## Test plan

- [x] `bun run build` — clean, fresh `dist/sw.js` emitted by vite-plugin-pwa
- [x] `bun run typecheck` — clean
- [x] `npm pack --dry-run` confirms `openparachute-notes-ui-0.1.0.tgz` with `meta.json` (686B) in the tarball
- [x] Live `parseMeta()` from the parachute-app meta-schema accepts the file with `scopes_required`, `pwa`, `pwa_service_worker`, `iconUrl`, `tagline`, `required_schema.tags` all decoding as declared
- [ ] After publish: `npm pack @openparachute/notes-ui@0.1.0 && tar tzf openparachute-notes-ui-0.1.0.tgz | grep meta.json` — confirms registry-served tarball carries it
- [ ] `npm view @openparachute/notes-ui dist-tags` confirms `latest: 0.1.0`
- [ ] parachute-app's bare-spec bootstrap (`@openparachute/notes-ui`) resolves cleanly via `@latest`

Generated with [Claude Code](https://claude.com/claude-code)