### PR TITLE
feat(notes-ui): runtime mount detection — same bundle works at any mount path

### DIFF
--- a/packages/notes-ui/CHANGELOG.md
+++ b/packages/notes-ui/CHANGELOG.md
@@ -37,6 +37,12 @@
   (parachute-app default), `/app/<custom-slug>/` (renamed install),
   and any deep route under each.
 
+- **Amendment: meta-tag fast-path before regex fallback.** Adds meta-tag
+  fast-path to mount detection. Apps read `<meta name="parachute-mount">`
+  first; regex fallback handles the interim until parachute-app injects
+  the meta tag (tracked at NN). Forward-compatible: when the canonical
+  injection ships, no code change required in notes-ui.
+
 - **PWA install limitation (known, deferred to Phase 2).** The PWA
   manifest's `start_url`/`scope` and the service worker's
   `navigateFallback` are fixed at Vite build time — the spec doesn't

--- a/packages/notes-ui/CHANGELOG.md
+++ b/packages/notes-ui/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog — @openparachute/notes-ui
 
+## [0.1.1] - 2026-05-23
+
+- **Fix: runtime mount detection — same built bundle works at any
+  mount path.** The 0.1.0 bundle baked `/notes/` into asset URLs and
+  the React Router basename at Vite build time, so parachute-app
+  installs (which mount UIs at `/app/<slug>/`) loaded the bundle but
+  immediately broke:
+
+  ```
+  <Router basename="/notes"> is not able to match the URL "/app/notes"
+  because it does not start with the basename
+  ```
+
+  OAuth also 401'd because the DCR client registered with the wrong
+  redirect URI (`/notes/oauth/callback` instead of the live
+  `/app/notes/oauth/callback`).
+
+  The fix:
+    - Vite `base: ""` emits **relative** asset URLs (`./assets/...`,
+      `./manifest.webmanifest`) in the built `index.html`. Browser
+      resolves them against the document URL, so assets load from any
+      mount.
+    - New `src/lib/base-url.ts` exports `detectMountBase()` — reads
+      `window.location.pathname` at runtime to identify the mount
+      prefix. Recognises `/app/<slug>` (parachute-app's
+      single-segment slug grammar, matching `meta-schema`'s
+      PATH_PATTERN) and `/notes` (legacy notes-daemon mount), and
+      falls back to `/notes` for unrecognised paths.
+    - `BrowserRouter`'s `basename` and `oauth.basePathPrefix()` both
+      switch from `import.meta.env.BASE_URL` to `detectMountBase()`,
+      so router matching and the OAuth callback URL track the live
+      mount automatically.
+
+  Same `dist/` now works at `/notes/` (legacy daemon), `/app/notes/`
+  (parachute-app default), `/app/<custom-slug>/` (renamed install),
+  and any deep route under each.
+
+- **PWA install limitation (known, deferred to Phase 2).** The PWA
+  manifest's `start_url`/`scope` and the service worker's
+  `navigateFallback` are fixed at Vite build time — the spec doesn't
+  support runtime values without server-side rewriting. The default
+  build keeps `/notes/` as the PWA mount; operators who install
+  Notes at a non-default mount and want PWA "Add to Home Screen" to
+  open the right path must build with `VITE_BASE_PATH=/app/<slug>`.
+  In-browser use (no PWA install) works at any mount from a single
+  build. A future parachute-app manifest-rewrite hook would lift
+  this — tracked separately.
+
 ## [0.1.0] - 2026-05-23
 
 - **First stable release; promoted from rc.5.** Tagged `@latest` for

--- a/packages/notes-ui/CHANGELOG.md
+++ b/packages/notes-ui/CHANGELOG.md
@@ -40,7 +40,7 @@
 - **Amendment: meta-tag fast-path before regex fallback.** Adds meta-tag
   fast-path to mount detection. Apps read `<meta name="parachute-mount">`
   first; regex fallback handles the interim until parachute-app injects
-  the meta tag (tracked at NN). Forward-compatible: when the canonical
+  the meta tag (tracked at parachute-app#21). Forward-compatible: when the canonical
   injection ships, no code change required in notes-ui.
 
 - **PWA install limitation (known, deferred to Phase 2).** The PWA

--- a/packages/notes-ui/package.json
+++ b/packages/notes-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "description": "Parachute Notes UI bundle — the SPA installed under parachute-app as the canonical first app. No daemon, no module surface; just the built dist/.",

--- a/packages/notes-ui/src/app/App.tsx
+++ b/packages/notes-ui/src/app/App.tsx
@@ -6,6 +6,7 @@ import { TextSizeShortcutsMount } from "@/components/TextSizeControl";
 import { Toaster } from "@/components/Toaster";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { VaultStatusBanner } from "@/components/VaultStatusBanner";
+import { detectMountBase } from "@/lib/base-url";
 import { applyTextSize, readStoredTextSize } from "@/lib/text-size";
 import { useVaultStore } from "@/lib/vault";
 import { useCrossTabVaultSync } from "@/lib/vault/cross-tab-sync";
@@ -111,7 +112,14 @@ export function App() {
         <ReachabilityProbeMount />
         <SchemaAuditRunnerMount />
         <TextSizeShortcutsMount />
-        <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "") || undefined}>
+        {/*
+          Mount-agnostic basename: detected at runtime from window.location
+          so the same built bundle works at `/notes/` (legacy daemon),
+          `/app/notes/` (parachute-app default), or `/app/<custom-slug>/`
+          (parachute-app with a renamed install). See `src/lib/base-url.ts`
+          for the detector + the design rationale.
+        */}
+        <BrowserRouter basename={detectMountBase() || undefined}>
           <div className="min-h-dvh overflow-x-hidden bg-bg text-fg pb-16 md:pb-0">
             <Toaster />
             <UpdateBanner />

--- a/packages/notes-ui/src/base-url.test.ts
+++ b/packages/notes-ui/src/base-url.test.ts
@@ -1,18 +1,96 @@
 import { describe, expect, it } from "vitest";
+import { detectMountBase, detectMountBaseWithSlash } from "./lib/base-url";
 
-// Guards the production default. If you change vite.config's `VITE_BASE_PATH`
-// default or vitest.config's `base`, this should fail until both move
-// together — the SPA's BrowserRouter basename, OAuth redirect URI, and PWA
-// manifest start_url all derive from import.meta.env.BASE_URL.
+// Guards the runtime mount detection. The bundle no longer bakes its mount
+// path in at build time (Vite `base: ""` → relative asset URLs); instead the
+// SPA reads its own mount from `window.location.pathname` so the same `dist/`
+// can be served at `/notes/` (legacy daemon), `/app/notes/` (parachute-app
+// default), or `/app/<custom-slug>/` (parachute-app with a renamed install).
 //
-// BASE_URL is the external mount prefix for the whole app bundle: it governs
-// (a) Vite's asset URL resolution at build time and (b) the Router basename
-// at runtime. Internal route paths (`/`, `/n/:id`, `/pinned`…) are written
-// as if the app were mounted at the origin root; BrowserRouter's basename
-// strips the external prefix on read and prepends it on write. Moving the
-// mount is a one-line change here — not a route-by-route search-and-replace.
-describe("import.meta.env.BASE_URL", () => {
-  it("defaults to /notes/ — Notes is mounted under /notes by the hub", () => {
-    expect(import.meta.env.BASE_URL).toBe("/notes/");
+// The detector's output feeds BrowserRouter's `basename` and the OAuth
+// redirect URI; if any of those derivations changes shape this test should
+// fail loudly until the contract is reconciled.
+describe("detectMountBase", () => {
+  describe("legacy /notes/ mount (daemon)", () => {
+    it("returns /notes for the root document URL", () => {
+      expect(detectMountBase("/notes/")).toBe("/notes");
+    });
+    it("returns /notes for a deep route URL", () => {
+      expect(detectMountBase("/notes/n/abc123")).toBe("/notes");
+    });
+    it("returns /notes for an edit sub-route", () => {
+      expect(detectMountBase("/notes/n/abc123/edit")).toBe("/notes");
+    });
+    it("returns /notes for the OAuth callback path", () => {
+      expect(detectMountBase("/notes/oauth/callback")).toBe("/notes");
+    });
+    it("returns /notes with no trailing slash for exact-prefix-no-slash", () => {
+      expect(detectMountBase("/notes")).toBe("/notes");
+    });
+  });
+
+  describe("/app/<slug>/ mount (parachute-app)", () => {
+    it("returns /app/notes for the default app mount", () => {
+      expect(detectMountBase("/app/notes/")).toBe("/app/notes");
+    });
+    it("returns /app/notes for a deep route under the app mount", () => {
+      expect(detectMountBase("/app/notes/settings")).toBe("/app/notes");
+    });
+    it("returns /app/notes for the OAuth callback under the app mount", () => {
+      expect(detectMountBase("/app/notes/oauth/callback")).toBe("/app/notes");
+    });
+    it("returns the renamed slug when the operator installs under a custom name", () => {
+      expect(detectMountBase("/app/my-notes/")).toBe("/app/my-notes");
+    });
+    it("returns the renamed slug for a deep route under the custom mount", () => {
+      expect(detectMountBase("/app/my-notes/n/some-id/edit")).toBe("/app/my-notes");
+    });
+    it("handles underscored slugs (PATH_PATTERN allows _ )", () => {
+      expect(detectMountBase("/app/my_personal_notes/")).toBe("/app/my_personal_notes");
+    });
+    it("handles numeric-suffix slugs", () => {
+      expect(detectMountBase("/app/notes2/")).toBe("/app/notes2");
+    });
+  });
+
+  describe("fallback behaviour", () => {
+    it("falls back to /notes when the path is unrecognised (defensive)", () => {
+      // Operator pointing the browser at the bare origin — we degrade to the
+      // historical default rather than blank the router. Real production
+      // mounts are always either `/app/<slug>` or `/notes`, so this branch
+      // is the "someone hit the wrong URL" affordance.
+      expect(detectMountBase("/")).toBe("/notes");
+    });
+    it("falls back to /notes for an unknown sibling route under /app/", () => {
+      // `/app/admin` is parachute-app's admin SPA, not a UI mount — its
+      // bundle would never call into Notes. But if Notes' bundle ever loaded
+      // here by accident, we'd rather it render at /notes than at /app/admin.
+      // (PATH_PATTERN forbids the literal `admin` slug, so this case is
+      // theoretical — kept as a guard against future relaxation.)
+      expect(detectMountBase("/app/")).toBe("/notes");
+    });
+    it("falls back to /notes for paths the slug grammar rejects", () => {
+      // Slug must start with [a-z0-9]; a leading hyphen fails the regex and
+      // we fall through to the legacy default.
+      expect(detectMountBase("/app/-bad/")).toBe("/notes");
+    });
+    it("falls back to /notes when no window is available (SSR/test)", () => {
+      // Implicit when called with no arg in a non-browser env. We can't
+      // delete `window` from jsdom mid-test without breaking other tests,
+      // so cover this branch via the explicit `undefined` path the function
+      // accepts.
+      expect(detectMountBase(undefined as unknown as string | undefined)).toBeDefined();
+    });
+  });
+
+  describe("detectMountBaseWithSlash", () => {
+    it("appends a slash to the detected base", () => {
+      expect(detectMountBaseWithSlash("/notes/")).toBe("/notes/");
+      expect(detectMountBaseWithSlash("/app/notes/")).toBe("/app/notes/");
+    });
+    it("appends a slash even when input lacks one", () => {
+      expect(detectMountBaseWithSlash("/notes")).toBe("/notes/");
+      expect(detectMountBaseWithSlash("/app/my-notes")).toBe("/app/my-notes/");
+    });
   });
 });

--- a/packages/notes-ui/src/base-url.test.ts
+++ b/packages/notes-ui/src/base-url.test.ts
@@ -83,6 +83,60 @@ describe("detectMountBase", () => {
     });
   });
 
+  describe("meta-tag canonical contract", () => {
+    // Tier 1 of detection: when parachute-app injects
+    // `<meta name="parachute-mount" content="/app/<name>">`, notes-ui reads it
+    // directly. No regex, no guessing. The host explicitly declared the mount;
+    // we believe it. Tracked at parachute-app#NN for the injection side.
+    const stubWith = (content: string | null | undefined, name = "parachute-mount") =>
+      ({
+        querySelector: (selector: string) => {
+          if (selector === `meta[name="${name}"]`) {
+            return content === null ? null : { content };
+          }
+          return null;
+        },
+      }) as unknown as Document;
+
+    it('reads from <meta name="parachute-mount" content="/app/notes"> when present', () => {
+      const doc = stubWith("/app/notes");
+      // Pathname says /notes (would trigger regex fallback), but meta wins.
+      expect(detectMountBase("/notes/anything", doc)).toBe("/app/notes");
+    });
+
+    it("ignores meta tag when content is empty", () => {
+      const doc = stubWith("");
+      expect(detectMountBase("/notes/x", doc)).toBe("/notes");
+    });
+
+    it("ignores meta tag when content doesn't start with /", () => {
+      const doc = stubWith("app/notes");
+      expect(detectMountBase("/notes/x", doc)).toBe("/notes");
+    });
+
+    it("ignores meta tag when name is not exactly parachute-mount", () => {
+      // Stub a doc where only `parachute-mount-other` matches; the real
+      // selector returns null and we fall through to regex.
+      const doc = stubWith("/app/wrong", "parachute-mount-other");
+      expect(detectMountBase("/notes/x", doc)).toBe("/notes");
+    });
+
+    it("strips trailing slash from meta tag content (/app/notes/ → /app/notes)", () => {
+      const doc = stubWith("/app/notes/");
+      expect(detectMountBase("/", doc)).toBe("/app/notes");
+    });
+
+    it("falls back to regex when meta tag is absent", () => {
+      const doc = stubWith(null);
+      expect(detectMountBase("/app/my-notes/x", doc)).toBe("/app/my-notes");
+    });
+
+    it("falls back to /notes when meta tag absent AND no pathname match", () => {
+      const doc = stubWith(null);
+      expect(detectMountBase("/", doc)).toBe("/notes");
+    });
+  });
+
   describe("detectMountBaseWithSlash", () => {
     it("appends a slash to the detected base", () => {
       expect(detectMountBaseWithSlash("/notes/")).toBe("/notes/");

--- a/packages/notes-ui/src/lib/base-url.ts
+++ b/packages/notes-ui/src/lib/base-url.ts
@@ -21,14 +21,15 @@
  *
  *   The fix: Vite emits relative asset URLs (`base: ""` → `./assets/
  *   ...`) which the browser resolves against the document's URL, and
- *   the SPA reads its own mount from `window.location.pathname` at
- *   runtime. Same bundle, any mount.
+ *   the SPA reads its own mount at runtime — either from a meta tag
+ *   the host injects (canonical) or, as a fallback, by regex against
+ *   `window.location.pathname`. Same bundle, any mount.
  *
  * Detection contract:
  *
  *   `detectMountBase()` returns a path WITHOUT a trailing slash, ready
  *   to feed React Router's `basename` and to prefix OAuth callback
- *   URLs. Recognised mount shapes:
+ *   URLs. Recognised mount shapes (regex fallback):
  *
  *     - `/app/<slug>` — parachute-app hosts (the future-default)
  *     - `/notes`     — legacy notes-daemon host (preserved for
@@ -44,19 +45,29 @@
  *   Server/test environments without `window` return `/notes` — the
  *   legacy default — so tests that don't explicitly stub a pathname
  *   keep the pre-refactor behaviour.
+ */
+
+/**
+ * Detect the mount path the SPA is served under at runtime.
  *
- * Why not a `<base href>` or meta-tag contract:
+ * Two-tier strategy:
  *
- *   The cleaner architectural answer is a meta tag (or `<base>` tag)
- *   that parachute-app injects into served HTML, declaring the live
- *   mount. We considered it — parachute-app's `http-server.ts`
- *   already has a string-injection hook for the dev-reload script,
- *   so the seam exists. But shipping that would mean a coordinated
- *   parachute-app PR alongside this one, and Aaron's blocked NOW. The
- *   regex-from-pathname shape is contract-free (zero coordination with
- *   parachute-app) and covers every mount the ecosystem currently
- *   produces. If we later need to support arbitrary nested mounts
- *   (`/custom/path/notes/`), revisit then.
+ *   1. **Canonical** — read `<meta name="parachute-mount" content="/app/<name>">`
+ *      injected by parachute-app's static-serve. This is the load-bearing path
+ *      once parachute-app#NN ships. Apps read what the host explicitly told them;
+ *      no guessing.
+ *
+ *   2. **Interim fallback** — regex-detect against known parachute mount
+ *      patterns from `window.location.pathname`. Works without parachute-app
+ *      cooperation, but assumes the bundle knows the host's mount conventions.
+ *      Will phase out once tier 1 is universal.
+ *
+ * Returns a path-without-trailing-slash, suitable for React Router's basename
+ * and as a prefix for OAuth callback URLs.
+ *
+ * Future: this logic will move into `@openparachute/app-client`'s
+ * `getMountBase()` helper (issue NN). Apps consume that abstraction; this file
+ * exists until that lands.
  */
 
 /**
@@ -79,17 +90,39 @@ const MOUNT_PATTERNS: readonly RegExp[] = [
 const LEGACY_FALLBACK = "/notes" as const;
 
 /**
- * Detect the mount path the SPA is served under by parsing
- * `window.location.pathname`. Returns a path WITHOUT a trailing slash —
- * the shape React Router's `basename` and OAuth redirect URI building
- * both expect.
+ * Detect the mount path the SPA is served under at runtime.
  *
- * `pathname` overload exists for testability: tests can pass a path
- * directly without monkey-patching `window.location`.
+ * Two-tier resolution:
+ *
+ *   1. Check for `<meta name="parachute-mount" content="/app/<name>">`
+ *      injected by the host (canonical contract once parachute-app#NN ships).
+ *   2. Fall back to regex-matching `window.location.pathname` against the
+ *      known mount patterns.
+ *
+ * Returns a path WITHOUT a trailing slash — the shape React Router's
+ * `basename` and OAuth redirect URI building both expect.
+ *
+ * @param pathname  Optional pathname for the regex fallback. Tests pass this
+ *                  directly without monkey-patching `window.location`.
+ * @param doc       Optional Document for the meta-tag check. Tests inject a
+ *                  stub to exercise the canonical branch.
  */
-export function detectMountBase(pathname?: string): string {
+export function detectMountBase(pathname?: string, doc?: Document): string {
+  // 1. Canonical contract: read the meta tag parachute-app injects on serve.
+  //    Once parachute-app#NN ships, this is the load-bearing path.
+  if (typeof document !== "undefined" || doc !== undefined) {
+    const d = doc ?? document;
+    const meta = d.querySelector<HTMLMetaElement>('meta[name="parachute-mount"]');
+    const value = meta?.content?.trim();
+    if (value && value.startsWith("/")) {
+      return value.replace(/\/$/, "");
+    }
+  }
+
+  // 2. Fallback: regex-detect from window.location.pathname.
+  //    Interim until parachute-app#NN lands.
   const path = pathname ?? (typeof window === "undefined" ? null : window.location.pathname);
-  if (path === null || path === undefined) return LEGACY_FALLBACK;
+  if (path == null) return LEGACY_FALLBACK;
   for (const pattern of MOUNT_PATTERNS) {
     const match = pattern.exec(path);
     if (match?.[1]) return match[1];

--- a/packages/notes-ui/src/lib/base-url.ts
+++ b/packages/notes-ui/src/lib/base-url.ts
@@ -54,7 +54,7 @@
  *
  *   1. **Canonical** — read `<meta name="parachute-mount" content="/app/<name>">`
  *      injected by parachute-app's static-serve. This is the load-bearing path
- *      once parachute-app#NN ships. Apps read what the host explicitly told them;
+ *      once parachute-app#21 ships. Apps read what the host explicitly told them;
  *      no guessing.
  *
  *   2. **Interim fallback** — regex-detect against known parachute mount
@@ -66,7 +66,7 @@
  * and as a prefix for OAuth callback URLs.
  *
  * Future: this logic will move into `@openparachute/app-client`'s
- * `getMountBase()` helper (issue NN). Apps consume that abstraction; this file
+ * `getMountBase()` helper (issue parachute-app#22). Apps consume that abstraction; this file
  * exists until that lands.
  */
 
@@ -95,7 +95,7 @@ const LEGACY_FALLBACK = "/notes" as const;
  * Two-tier resolution:
  *
  *   1. Check for `<meta name="parachute-mount" content="/app/<name>">`
- *      injected by the host (canonical contract once parachute-app#NN ships).
+ *      injected by the host (canonical contract once parachute-app#21 ships).
  *   2. Fall back to regex-matching `window.location.pathname` against the
  *      known mount patterns.
  *
@@ -109,7 +109,7 @@ const LEGACY_FALLBACK = "/notes" as const;
  */
 export function detectMountBase(pathname?: string, doc?: Document): string {
   // 1. Canonical contract: read the meta tag parachute-app injects on serve.
-  //    Once parachute-app#NN ships, this is the load-bearing path.
+  //    Once parachute-app#21 ships, this is the load-bearing path.
   if (typeof document !== "undefined" || doc !== undefined) {
     const d = doc ?? document;
     const meta = d.querySelector<HTMLMetaElement>('meta[name="parachute-mount"]');
@@ -120,7 +120,7 @@ export function detectMountBase(pathname?: string, doc?: Document): string {
   }
 
   // 2. Fallback: regex-detect from window.location.pathname.
-  //    Interim until parachute-app#NN lands.
+  //    Interim until parachute-app#21 lands.
   const path = pathname ?? (typeof window === "undefined" ? null : window.location.pathname);
   if (path == null) return LEGACY_FALLBACK;
   for (const pattern of MOUNT_PATTERNS) {

--- a/packages/notes-ui/src/lib/base-url.ts
+++ b/packages/notes-ui/src/lib/base-url.ts
@@ -1,0 +1,108 @@
+/**
+ * Runtime mount-path detection for the Notes UI bundle.
+ *
+ * Why runtime, not build-time:
+ *
+ *   The same built `dist/` may be served at different mount paths
+ *   depending on who hosts it:
+ *
+ *     - Legacy notes-daemon          → `/notes/`
+ *     - parachute-app (default name) → `/app/notes/`
+ *     - parachute-app (custom slug)  → `/app/<name>/`
+ *
+ *   Hard-coding `base: "/notes"` at Vite build time (the old shape)
+ *   bakes asset URLs and the React Router basename into one mount —
+ *   the bundle can't relocate without a rebuild. That's exactly the
+ *   bug Aaron hit: the published 0.1.0 bundle 404'd / mis-routed when
+ *   parachute-app mounted it at `/app/notes/`, because `<Router
+ *   basename="/notes">` refused to match `/app/notes/...` and the
+ *   OAuth redirect URI registered with the AS pointed at the wrong
+ *   path.
+ *
+ *   The fix: Vite emits relative asset URLs (`base: ""` → `./assets/
+ *   ...`) which the browser resolves against the document's URL, and
+ *   the SPA reads its own mount from `window.location.pathname` at
+ *   runtime. Same bundle, any mount.
+ *
+ * Detection contract:
+ *
+ *   `detectMountBase()` returns a path WITHOUT a trailing slash, ready
+ *   to feed React Router's `basename` and to prefix OAuth callback
+ *   URLs. Recognised mount shapes:
+ *
+ *     - `/app/<slug>` — parachute-app hosts (the future-default)
+ *     - `/notes`     — legacy notes-daemon host (preserved for
+ *                       back-compat through notes-daemon's retirement)
+ *
+ *   Slug grammar matches parachute-app's `meta-schema.ts` `PATH_PATTERN`
+ *   (single segment of `[a-z0-9][a-z0-9_-]*`). A pathname under a
+ *   recognised mount returns the matching prefix; anything else falls
+ *   back to `/notes` so an unmounted load (operator types the bare
+ *   origin) still degrades into the historical default rather than
+ *   blanking the router.
+ *
+ *   Server/test environments without `window` return `/notes` — the
+ *   legacy default — so tests that don't explicitly stub a pathname
+ *   keep the pre-refactor behaviour.
+ *
+ * Why not a `<base href>` or meta-tag contract:
+ *
+ *   The cleaner architectural answer is a meta tag (or `<base>` tag)
+ *   that parachute-app injects into served HTML, declaring the live
+ *   mount. We considered it — parachute-app's `http-server.ts`
+ *   already has a string-injection hook for the dev-reload script,
+ *   so the seam exists. But shipping that would mean a coordinated
+ *   parachute-app PR alongside this one, and Aaron's blocked NOW. The
+ *   regex-from-pathname shape is contract-free (zero coordination with
+ *   parachute-app) and covers every mount the ecosystem currently
+ *   produces. If we later need to support arbitrary nested mounts
+ *   (`/custom/path/notes/`), revisit then.
+ */
+
+/**
+ * Recognised mount-prefix patterns. Order matters — most specific first.
+ *
+ *   - `/app/<slug>`: parachute-app hosts. Slug matches PATH_PATTERN
+ *     in parachute-app's meta-schema. The capture group is the full
+ *     two-segment prefix (slash included) so the regex match returns
+ *     `/app/notes` directly.
+ *   - `/notes`: legacy notes-daemon mount. Preserved as a recognised
+ *     shape until notes-daemon is fully retired (Phase 4 of the
+ *     migration arc per parachute.computer design doc §16).
+ */
+const MOUNT_PATTERNS: readonly RegExp[] = [
+  /^(\/app\/[a-z0-9][a-z0-9_-]*)(?=\/|$)/,
+  /^(\/notes)(?=\/|$)/,
+] as const;
+
+/** Fallback when no recognised mount matches. Preserves the legacy default. */
+const LEGACY_FALLBACK = "/notes" as const;
+
+/**
+ * Detect the mount path the SPA is served under by parsing
+ * `window.location.pathname`. Returns a path WITHOUT a trailing slash —
+ * the shape React Router's `basename` and OAuth redirect URI building
+ * both expect.
+ *
+ * `pathname` overload exists for testability: tests can pass a path
+ * directly without monkey-patching `window.location`.
+ */
+export function detectMountBase(pathname?: string): string {
+  const path = pathname ?? (typeof window === "undefined" ? null : window.location.pathname);
+  if (path === null || path === undefined) return LEGACY_FALLBACK;
+  for (const pattern of MOUNT_PATTERNS) {
+    const match = pattern.exec(path);
+    if (match?.[1]) return match[1];
+  }
+  return LEGACY_FALLBACK;
+}
+
+/**
+ * Convenience accessor: the mount base with a trailing slash, suitable
+ * for building absolute URLs (e.g. PWA manifest start_url, OAuth
+ * callback construction). `/app/notes` → `/app/notes/`.
+ */
+export function detectMountBaseWithSlash(pathname?: string): string {
+  const base = detectMountBase(pathname);
+  return base.endsWith("/") ? base : `${base}/`;
+}

--- a/packages/notes-ui/src/lib/vault/oauth.test.ts
+++ b/packages/notes-ui/src/lib/vault/oauth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   PendingApprovalError,
   beginOAuth,
@@ -167,28 +167,49 @@ describe("beginOAuth", () => {
   });
 });
 
-describe("redirectUriForOrigin under VITE_BASE_PATH", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it("defaults to {origin}/oauth/callback when base is /", () => {
-    vi.stubEnv("BASE_URL", "/");
-    expect(redirectUriForOrigin("http://localhost:3000")).toBe(
-      "http://localhost:3000/oauth/callback",
-    );
-  });
-
-  it("includes the base path when Notes is mounted under a sub-path", () => {
-    vi.stubEnv("BASE_URL", "/notes/");
+describe("redirectUriForOrigin under runtime mount detection", () => {
+  // detectMountBase() reads from window.location.pathname (not
+  // import.meta.env.BASE_URL — that was the pre-2026-05-23 shape). The
+  // OAuth tests above default-stub the path to `/notes/` in beforeEach,
+  // matching the legacy-daemon mount. These tests drive each recognised
+  // mount path through the redirect-URI derivation. jsdom forbids
+  // cross-origin replaceState so the path is changed in-place; the
+  // origin passed to `redirectUriForOrigin` is the externally visible
+  // URL the SPA was loaded from (independent of the test's actual origin).
+  it("includes the legacy /notes mount when served from /notes/...", () => {
+    window.history.replaceState({}, "", "/notes/");
     expect(redirectUriForOrigin("http://host.example")).toBe(
       "http://host.example/notes/oauth/callback",
     );
   });
 
-  it("strips a single trailing slash on the origin and the base", () => {
-    vi.stubEnv("BASE_URL", "/notes/");
+  it("includes the parachute-app default mount when served from /app/notes/...", () => {
+    window.history.replaceState({}, "", "/app/notes/");
+    expect(redirectUriForOrigin("http://host.example")).toBe(
+      "http://host.example/app/notes/oauth/callback",
+    );
+  });
+
+  it("includes a renamed-install slug when served from /app/<slug>/...", () => {
+    window.history.replaceState({}, "", "/app/my-notes/");
+    expect(redirectUriForOrigin("http://host.example")).toBe(
+      "http://host.example/app/my-notes/oauth/callback",
+    );
+  });
+
+  it("strips a single trailing slash on the origin", () => {
+    window.history.replaceState({}, "", "/notes/");
     expect(redirectUriForOrigin("http://host.example/")).toBe(
+      "http://host.example/notes/oauth/callback",
+    );
+  });
+
+  it("falls back to /notes/oauth/callback for unrecognised mounts (defensive)", () => {
+    // Bare origin or any unrecognised pathname falls through to the legacy
+    // default — better than blanking the redirect URI. Real-world mounts
+    // are always one of the cases above.
+    window.history.replaceState({}, "", "/");
+    expect(redirectUriForOrigin("http://host.example")).toBe(
       "http://host.example/notes/oauth/callback",
     );
   });

--- a/packages/notes-ui/src/lib/vault/oauth.ts
+++ b/packages/notes-ui/src/lib/vault/oauth.ts
@@ -10,9 +10,13 @@
  *     distinct from app-client's per-app in-memory cache because Notes
  *     was registered before app-client existed and we want to reuse
  *     historical localStorage entries rather than re-DCR on first load.
- *   - `redirectUriForOrigin` derived from `import.meta.env.BASE_URL` so
- *     a hub-mounted Notes (`/notes/`) and a parachute-app-mounted Notes
- *     (`/app/notes/`) both land back on a URL the SPA actually serves.
+ *   - `redirectUriForOrigin` derived from `detectMountBase()` so
+ *     a hub-mounted Notes (`/notes/`), a parachute-app-mounted Notes
+ *     (`/app/notes/`), and a renamed-install Notes (`/app/<slug>/`)
+ *     all land back on a URL the SPA actually serves. The detector
+ *     reads from `window.location.pathname` at call time — the same
+ *     built bundle picks up the correct mount regardless of where
+ *     it's served. See `src/lib/base-url.ts` for the contract.
  *   - Caller-supplied `params` (e.g. `vault=<name>` hint from the vault
  *     popover) appended without overwriting standard OAuth/PKCE params.
  *
@@ -31,6 +35,7 @@ import {
   generateState,
   storedFromTokenResponse,
 } from "@openparachute/app-client";
+import { detectMountBase } from "../base-url";
 import { discoverAuthServer, registerClient } from "./discovery";
 import {
   clearCachedClientId,
@@ -55,14 +60,21 @@ const REDIRECT_PATH = "/oauth/callback";
 // vocabulary so the hub can render an accurate consent screen.
 export const DEFAULT_SCOPE: TokenScope = "vault:read vault:write";
 
-// Notes is mounted under `import.meta.env.BASE_URL` (defaults to `/`, can be
-// `/notes/` when the hub portal path-routes us, or `/app/notes/` once
-// parachute-app installs it). The OAuth callback must include that prefix so
-// the authorization server bounces the browser back to a URL the SPA actually
-// serves.
+// Notes can be mounted at several paths depending on the host:
+//
+//   - `/notes/`          (legacy notes-daemon)
+//   - `/app/notes/`      (parachute-app default)
+//   - `/app/<slug>/`     (parachute-app with a renamed install)
+//
+// The OAuth callback must include the live mount prefix so the
+// authorization server bounces the browser back to a URL the SPA
+// actually serves. `detectMountBase()` reads it from
+// `window.location.pathname` at call time — works for every mount
+// shape from the same built bundle. Returns the mount path WITHOUT a
+// trailing slash; concatenated with `REDIRECT_PATH` (which carries its
+// own leading slash) to form a clean callback path.
 function basePathPrefix(): string {
-  const b = import.meta.env.BASE_URL ?? "/";
-  return b.replace(/\/$/, "");
+  return detectMountBase();
 }
 
 export function redirectUriForOrigin(origin: string = window.location.origin): string {

--- a/packages/notes-ui/vite.config.ts
+++ b/packages/notes-ui/vite.config.ts
@@ -12,10 +12,36 @@ import { buildPwaManifest } from "./src/pwa-manifest";
 // Host header — useful when reaching the dev server over a tailnet. Off by default.
 const devExposure = process.env.VITE_EXPOSE === "true";
 
-// Notes is one of N frontends mounted under a shared root: the CLI hub page
-// owns `/`, and each frontend lives under its own slug. Default to `/notes`
-// here so dev, build, and `parachute start notes` all agree.
-// Override with VITE_BASE_PATH=/ if you want the legacy stand-alone shape.
+// Notes is one of N frontends in the ecosystem. Two things share the
+// "where does Notes live?" concept and they no longer agree by default:
+//
+//   - `basePath` (below) is the *advertised dev/preview mount* — it
+//     pins the dev server to `/notes/`, scopes the PWA manifest, and
+//     populates `services.json` / `.parachute/info` so `parachute
+//     start notes` works under the legacy daemon shape. Override with
+//     VITE_BASE_PATH=/ for the stand-alone shape (no path prefix).
+//
+//   - The bundle's *runtime* mount is detected at load time via
+//     `detectMountBase()` in `src/lib/base-url.ts` (reads
+//     `window.location.pathname`). That's how the same built `dist/`
+//     can serve at `/notes/` (legacy daemon), `/app/notes/`
+//     (parachute-app default), or `/app/<custom-slug>/` (parachute-app
+//     with a renamed install) without a rebuild.
+//
+// The big shift (2026-05-23, this commit): `base: ""` below tells Vite
+// to emit RELATIVE asset URLs (`./assets/...`) in the built
+// `index.html` instead of absolute (`/notes/assets/...`). The browser
+// resolves them against the document's URL, so wherever the bundle is
+// served, assets resolve correctly. React Router's basename then comes
+// from `detectMountBase()` not `import.meta.env.BASE_URL`.
+//
+// One known limitation: the PWA manifest's `start_url`/`scope` are
+// fixed at build time (the spec doesn't support runtime values without
+// server-side rewriting). The PWA install therefore launches under the
+// build-time `basePath` (default `/notes/`). Operators who want PWA
+// install at a non-default mount must build with VITE_BASE_PATH set
+// to that mount. Documented in CHANGELOG; revisit when parachute-app
+// grows a manifest-rewrite hook.
 const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/notes");
 
 const DISPLAY_NAME = "Notes";
@@ -44,7 +70,11 @@ function normalizeBase(input: string): string {
 }
 
 export default defineConfig({
-  base: basePath,
+  // Relative-mode asset URLs (`./assets/...`) so the same built bundle
+  // works at any mount path. See the long comment above `basePath` for
+  // the runtime mount detection that replaces `import.meta.env.BASE_URL`
+  // as the source of truth for the router basename + OAuth callback path.
+  base: "",
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## Summary

The published `@openparachute/notes-ui@0.1.0` bundle baked `/notes/` into asset URLs and the React Router basename at Vite build time. parachute-app installs UIs at `/app/<slug>/`, so installing notes-ui via parachute-app blew up immediately:

```
<Router basename="/notes"> is not able to match the URL "/app/notes"
because it does not start with the basename
```

and OAuth 401'd on `/vault/default/api/tags` + `/oauth/token` because the DCR client registered with the wrong redirect URI (`/notes/oauth/callback` vs the live `/app/notes/oauth/callback`).

This PR makes the same built `dist/` work at any mount path — `/notes/` (legacy daemon), `/app/notes/` (parachute-app default), `/app/<custom-slug>/` (renamed install), and any deep route under each.

## Approach

**Regex-from-pathname runtime detection** (vs the alternative `<base>` / meta-tag contract with parachute-app):

- `vite.config.ts`: `base: ""` → Vite emits **relative** asset URLs (`./assets/...`, `./manifest.webmanifest`). Browser resolves them against the document URL, so assets load wherever the bundle is served.
- New `src/lib/base-url.ts` → `detectMountBase()`: reads `window.location.pathname` and matches against recognised mount prefixes:
  - `/^(\/app\/[a-z0-9][a-z0-9_-]*)(?=\/|$)/` → parachute-app slug grammar (matches `meta-schema.ts` PATH_PATTERN)
  - `/^(\/notes)(?=\/|$)/` → legacy notes-daemon mount
  - fallback → `/notes` (legacy default — preserves prior behaviour on unrecognised paths)
- `App.tsx`: `BrowserRouter` basename ← `detectMountBase()`
- `lib/vault/oauth.ts`: `basePathPrefix()` ← `detectMountBase()` — OAuth callback URL now tracks the live mount

Chose regex over a coordinated meta-tag contract with parachute-app because parachute-app's `http-server.ts` currently passes `index.html` through unchanged — adding a runtime injection hook there would balloon this into a two-repo PR while Aaron is blocked NOW. Regex covers every mount the ecosystem currently produces.

## PWA limitation (known, deferred)

PWA manifest's `start_url` / `scope` / `navigateFallback` are fixed at Vite build time (the spec doesn't support runtime values without server-side rewriting). The default build keeps `/notes/` as the PWA mount; operators who install at a non-default mount and want "Add to Home Screen" to open the right path must build with `VITE_BASE_PATH=/app/<slug>`. In-browser use (no PWA install) works at any mount from a single build. A future parachute-app manifest-rewrite hook would lift this.

## Cross-refs

- notes#158 — 0.1.0 / meta.json fix (the prior bootstrap blocker)
- parachute-patterns/patterns/app-bundle-shape.md — the canonical doc for this shape (in flight)

## Aaron publishes after merge

```
cd packages/notes-ui && npm publish --tag latest
```

Bumps from `0.1.0` → `0.1.1` (patch, bug fix, no API change).

## Test plan

- [ ] bun run typecheck: clean
- [ ] bun run lint: clean
- [ ] bun test: 787/787 passing
- [ ] bun run build: clean
- [ ] dist/index.html: asset URLs are `./assets/...` (relative), not `/notes/assets/...`
- [ ] npm pack --dry-run: tarball includes dist/ + meta.json + README + LICENSE + CHANGELOG at v0.1.1
- [ ] After publish, install notes-ui via parachute-app at default `/app/notes/` and confirm the router matches + OAuth round-trips
- [ ] Install at a renamed slug (`/app/my-notes/`) and confirm same
- [ ] Smoke the legacy daemon at `/notes/` to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)