### PR TITLE
fix(notes-ui): gate SW registration on mount-match + auto-unregister stale SWs

### DIFF
--- a/packages/notes-ui/CHANGELOG.md
+++ b/packages/notes-ui/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog — @openparachute/notes-ui
 
+## [0.1.2] - 2026-05-23
+
+### Fixed
+- Service-worker registration now gates on the runtime mount matching
+  the build-time vite base. Resolves the OAuth-callback breakage and
+  MIME errors that hit operators running notes-ui under parachute-app
+  at the canonical `/app/notes/` mount. The previous build auto-
+  registered the SW unconditionally at the page's current scope; the
+  precache table was built for `/notes/` so workbox served HTML for
+  what should have been JS modules and JSON manifests:
+
+  ```
+  Uncaught (in promise) non-precached-url: non-precached-url ::
+      [{"url":"/notes/index.html"}]
+  Failed to load module script: Expected JavaScript-or-Wasm module,
+      got "text/html"
+  Manifest: Line: 1, column: 1, Syntax error.
+  ```
+
+  The fix:
+    - New `src/lib/sw-bootstrap.ts` exports `shouldRegisterServiceWorker()`
+      and `cleanupStaleServiceWorker()`. The gate compares the
+      build-time vite base (`import.meta.env.BASE_URL` / `VITE_BASE_PATH`)
+      against `detectMountBase()` and only registers when they match.
+    - `UpdateBanner` splits the `useRegisterSW` call into an inner
+      component that only renders when the gate is open — React hooks
+      can't be conditional within a single component, but conditional
+      *rendering* is fine.
+    - `main.tsx` fires `cleanupStaleServiceWorker()` on boot to
+      unregister any `/notes/`-scoped SW left over from a pre-0.1.2
+      install when the bundle is now being served at a different mount.
+      Operators auto-recover on first page load — no DevTools manual
+      cleanup needed.
+    - `vite.config.ts` declares `injectRegister: false` explicitly,
+      documenting that app code is the only registration path (defensive
+      — vite-plugin-pwa v1's default already skips auto-inject when
+      `useRegisterSW` is used, but the explicit declaration makes the
+      contract grep-able).
+- `meta.json`'s `version` field synced to the package version (was
+  stuck at `0.1.0` through 0.1.1). Cosmetic — `meta.json`'s `version`
+  is informational; parachute-app reads `package.json` for install
+  resolution — but worth keeping accurate.
+
+### Known limitations
+- PWA "Add to Home Screen" install still requires a custom build with
+  `VITE_BASE_PATH=/app/<name>` when running under parachute-app at a
+  non-default mount. The default bundle targets the daemon-era
+  `/notes/` scope for back-compat; in-browser use works at any mount
+  from the default bundle (just no installable PWA). A future
+  parachute-app manifest-rewrite hook will lift this — tracked
+  separately (see 0.1.1 entry below for the original limitation note).
+
 ## [0.1.1] - 2026-05-23
 
 - **Fix: runtime mount detection — same built bundle works at any

--- a/packages/notes-ui/meta.json
+++ b/packages/notes-ui/meta.json
@@ -3,7 +3,7 @@
   "name": "notes",
   "displayName": "Notes",
   "tagline": "Notes PWA backed by your vault.",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "path": "/app/notes",
   "iconUrl": "icon.svg",
   "scopes_required": ["vault:*:read", "vault:*:write"],

--- a/packages/notes-ui/package.json
+++ b/packages/notes-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "type": "module",
   "description": "Parachute Notes UI bundle — the SPA installed under parachute-app as the canonical first app. No daemon, no module surface; just the built dist/.",

--- a/packages/notes-ui/src/components/UpdateBanner.tsx
+++ b/packages/notes-ui/src/components/UpdateBanner.tsx
@@ -1,7 +1,16 @@
 import { useRegisterSW } from "virtual:pwa-register/react";
 import { reloadAfterServiceWorkerUpdate } from "@/lib/pwa";
+import { shouldRegisterServiceWorker } from "@/lib/sw-bootstrap";
 
-export function UpdateBanner() {
+/**
+ * Inner banner that actually drives `useRegisterSW`. Split out from the
+ * exported `UpdateBanner` shim so the hook only runs when the runtime
+ * mount matches the build-time vite base — calling `useRegisterSW` at a
+ * mismatched mount would register the SW with the wrong scope (the bug
+ * Aaron hit 2026-05-23). React hooks can't be conditional within a single
+ * component, but conditional *rendering* of the child component is fine.
+ */
+function UpdateBannerInner() {
   const {
     needRefresh: [needRefresh, setNeedRefresh],
     updateServiceWorker,
@@ -53,4 +62,23 @@ export function UpdateBanner() {
       </div>
     </output>
   );
+}
+
+/**
+ * Mount-gated SW registration. The PWA service worker and manifest are
+ * baked at Vite build time with a fixed scope (default `/notes/`); when
+ * the bundle is served at a different mount (e.g. `/app/notes/` under
+ * parachute-app), registering the SW there interferes with every fetch
+ * — workbox can't find precached entries for the runtime mount and ends
+ * up returning HTML for what should be JS modules / JSON manifests.
+ *
+ * We render the inner banner (and let it call `useRegisterSW`) only when
+ * the runtime mount matches the build-time base. Otherwise we render
+ * nothing — no SW registration, no update banner. The CHANGELOG documents
+ * this as a known limitation: PWA install requires a custom build with
+ * `VITE_BASE_PATH=<runtime-mount>` for non-default mounts.
+ */
+export function UpdateBanner() {
+  if (!shouldRegisterServiceWorker()) return null;
+  return <UpdateBannerInner />;
 }

--- a/packages/notes-ui/src/lib/sw-bootstrap.test.ts
+++ b/packages/notes-ui/src/lib/sw-bootstrap.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BUILD_TIME_BASE,
+  cleanupStaleServiceWorker,
+  shouldRegisterServiceWorker,
+} from "./sw-bootstrap";
+
+// Guards the service-worker registration gate.
+//
+// The contract: notes-ui builds with a fixed mount baked into the PWA
+// manifest + service-worker precache (default `/notes/`). When the same
+// `dist/` is served at a different runtime mount (e.g. `/app/notes/`
+// under parachute-app), we must NOT register the SW — its scope would
+// straddle a precache table built for the wrong path, breaking every
+// navigation. And we must also unregister any stale SW left behind by a
+// pre-0.1.2 install that auto-registered before this gate existed.
+//
+// The vitest config sets vite's `base` to `/notes/`, so
+// `import.meta.env.BASE_URL` resolves to `/notes/` and
+// `BUILD_TIME_BASE` evaluates to `/notes`. Tests below assume that.
+
+describe("BUILD_TIME_BASE", () => {
+  it("trims the trailing slash from vite's BASE_URL", () => {
+    expect(BUILD_TIME_BASE).toBe("/notes");
+  });
+});
+
+describe("shouldRegisterServiceWorker", () => {
+  it("returns true when the runtime mount matches the build-time base (default daemon mount)", () => {
+    expect(shouldRegisterServiceWorker("/notes/")).toBe(true);
+  });
+
+  it("returns true for a deep route under the matching mount", () => {
+    expect(shouldRegisterServiceWorker("/notes/n/abc123")).toBe(true);
+  });
+
+  it("returns false when the runtime mount is parachute-app's /app/notes/", () => {
+    // The bug: bundle built for /notes/, served at /app/notes/.
+    expect(shouldRegisterServiceWorker("/app/notes/")).toBe(false);
+  });
+
+  it("returns false for a custom-slug app mount", () => {
+    expect(shouldRegisterServiceWorker("/app/my-notes/")).toBe(false);
+  });
+
+  it("returns false for an OAuth callback under a mismatched mount (the exact scenario Aaron hit)", () => {
+    expect(shouldRegisterServiceWorker("/app/notes/oauth/callback")).toBe(false);
+  });
+});
+
+describe("cleanupStaleServiceWorker", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function fakeRegistration(scope: string, unregister = vi.fn().mockResolvedValue(true)) {
+    return { scope, unregister } as unknown as ServiceWorkerRegistration & {
+      unregister: ReturnType<typeof vi.fn>;
+    };
+  }
+
+  function fakeNavigator(registrations: ServiceWorkerRegistration[]): Navigator {
+    return {
+      serviceWorker: {
+        getRegistrations: vi.fn().mockResolvedValue(registrations),
+      },
+    } as unknown as Navigator;
+  }
+
+  it("unregisters a stale /notes/-scoped SW when running under /app/notes/", async () => {
+    const stale = fakeRegistration("https://hub.example.com/notes/");
+    const nav = fakeNavigator([stale]);
+    const count = await cleanupStaleServiceWorker(nav, "/app/notes/");
+    expect(count).toBe(1);
+    expect(stale.unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the SW alone when its scope matches the runtime mount", async () => {
+    const matching = fakeRegistration("https://hub.example.com/notes/");
+    const nav = fakeNavigator([matching]);
+    const count = await cleanupStaleServiceWorker(nav, "/notes/");
+    expect(count).toBe(0);
+    expect(matching.unregister).not.toHaveBeenCalled();
+  });
+
+  it("unregisters a stale /app/old-notes/ SW when the runtime mount is /app/notes/", async () => {
+    // Operator renamed their app install — the previous slug's SW is now stale.
+    const stale = fakeRegistration("https://hub.example.com/app/old-notes/");
+    const nav = fakeNavigator([stale]);
+    const count = await cleanupStaleServiceWorker(nav, "/app/notes/");
+    expect(count).toBe(1);
+    expect(stale.unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch SWs whose scope doesn't look like a parachute mount", async () => {
+    // Defensive: don't clobber unrelated SWs on the same origin.
+    const unrelated = fakeRegistration("https://hub.example.com/some-other-app/");
+    const nav = fakeNavigator([unrelated]);
+    const count = await cleanupStaleServiceWorker(nav, "/app/notes/");
+    expect(count).toBe(0);
+    expect(unrelated.unregister).not.toHaveBeenCalled();
+  });
+
+  it("handles environments without navigator.serviceWorker gracefully", async () => {
+    const nav = {} as unknown as Navigator;
+    const count = await cleanupStaleServiceWorker(nav, "/notes/");
+    expect(count).toBe(0);
+  });
+
+  it("handles undefined navigator (SSR-style) gracefully", async () => {
+    const count = await cleanupStaleServiceWorker(undefined, "/notes/");
+    expect(count).toBe(0);
+  });
+
+  it("continues past a single unregister failure and reports the count of successes", async () => {
+    const failing = fakeRegistration(
+      "https://hub.example.com/notes/",
+      vi.fn().mockRejectedValue(new Error("boom")),
+    );
+    const succeeding = fakeRegistration("https://hub.example.com/app/old-notes/");
+    const nav = fakeNavigator([failing, succeeding]);
+    const count = await cleanupStaleServiceWorker(nav, "/app/notes/");
+    // Only the second one succeeds; the first throws inside the loop's
+    // try/catch and bumps no counter.
+    expect(count).toBe(1);
+    expect(succeeding.unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it("unregisters multiple stale SWs in one pass", async () => {
+    const a = fakeRegistration("https://hub.example.com/notes/");
+    const b = fakeRegistration("https://hub.example.com/app/other-notes/");
+    const nav = fakeNavigator([a, b]);
+    const count = await cleanupStaleServiceWorker(nav, "/app/notes/");
+    expect(count).toBe(2);
+    expect(a.unregister).toHaveBeenCalledTimes(1);
+    expect(b.unregister).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/notes-ui/src/lib/sw-bootstrap.ts
+++ b/packages/notes-ui/src/lib/sw-bootstrap.ts
@@ -1,0 +1,160 @@
+/**
+ * Service-worker bootstrap gating for the Notes UI bundle.
+ *
+ * Why this file exists:
+ *
+ *   notes-ui 0.1.1 introduced runtime mount detection — the same built
+ *   `dist/` works at any mount path (`/notes/`, `/app/notes/`,
+ *   `/app/<custom-slug>/`). Asset URLs, the React Router basename, and
+ *   the OAuth redirect URI all rebase at runtime via `detectMountBase()`.
+ *
+ *   But the service worker and PWA manifest are baked at *build time*.
+ *   The manifest's `start_url`/`scope` and the SW's precache manifest
+ *   (every `/notes/index.html`, `/notes/assets/...` entry) are hard
+ *   `/notes/`-scoped in the default build. When the same bundle gets
+ *   mounted at `/app/notes/`, the React app loads and routes work — but
+ *   then `useRegisterSW()` registers the SW *with the page's current
+ *   scope* (`/app/notes/`), and the SW immediately starts intercepting
+ *   every fetch under that scope. The precache table doesn't contain
+ *   `/app/notes/...` entries; navigations fall through to workbox's
+ *   navigation route which serves `/notes/index.html` (HTML) for a
+ *   request that the importing browser expected to be a JS module or a
+ *   JSON manifest.
+ *
+ *   Result (Aaron's report 2026-05-23):
+ *     - workbox throws `non-precached-url :: /notes/index.html`
+ *     - browser logs `Failed to load module script: Expected
+ *       JavaScript-or-Wasm module, got "text/html"`
+ *     - manifest fetch fails JSON parse
+ *     - OAuth callback navigation breaks because the SW intercepts the
+ *       fetch and returns the wrong document
+ *
+ *   The right fix is mount-aware build-time PWA assets, but that needs
+ *   a parachute-app manifest-rewrite hook + multi-scope SW generation —
+ *   non-trivial work. The immediate fix is to gate registration: if the
+ *   runtime mount doesn't match the build-time vite base, don't
+ *   register the SW at all, and unregister any stale registration left
+ *   over from a previous version that didn't gate.
+ *
+ *   PWA "Add to Home Screen" therefore remains a build-time-pinned
+ *   feature (already acknowledged in 0.1.1's CHANGELOG). Operators who
+ *   want PWA install at a non-default mount must build with
+ *   `VITE_BASE_PATH=/app/<name>`. In-browser use works at any mount
+ *   from the default bundle, no SW interference.
+ */
+
+import { detectMountBase } from "./base-url";
+
+/**
+ * The mount path the current bundle was built for. Trimmed of trailing
+ * slash to match `detectMountBase()`'s no-trailing-slash contract.
+ *
+ * `import.meta.env.BASE_URL` reflects Vite's `base` config option at
+ * build time. The current `vite.config.ts` sets `base: ""` for relative
+ * asset URLs, in which case Vite still surfaces the canonical mount via
+ * the `VITE_BASE_PATH` env arg through the manifest's `start_url` /
+ * `scope`. We mirror that with our own env var read so the gate
+ * compares against the same path the PWA manifest baked in.
+ *
+ * Resolution order:
+ *   1. `import.meta.env.VITE_BASE_PATH` — explicit override (matches
+ *      `vite.config.ts`'s `basePath` variable).
+ *   2. `import.meta.env.BASE_URL` — Vite's own resolved base, used when
+ *      no override is provided.
+ *   3. `/notes/` — the historical daemon default.
+ */
+function buildTimeBase(): string {
+  const envOverride =
+    typeof import.meta !== "undefined" && import.meta.env
+      ? (import.meta.env.VITE_BASE_PATH as string | undefined)
+      : undefined;
+  const baseUrl =
+    typeof import.meta !== "undefined" && import.meta.env
+      ? (import.meta.env.BASE_URL as string | undefined)
+      : undefined;
+  const raw = envOverride && envOverride.length > 0 ? envOverride : baseUrl;
+  // When vite.config sets `base: ""`, BASE_URL becomes "/" — useless as a
+  // mount comparator. Fall through to the legacy default in that case.
+  const normalised = !raw || raw === "" || raw === "/" ? "/notes/" : raw;
+  return normalised.replace(/\/$/, "") || "/notes";
+}
+
+/** Frozen for downstream comparison + log lines. */
+export const BUILD_TIME_BASE = buildTimeBase();
+
+/**
+ * Predicate: should the SW be registered for the current page?
+ *
+ * Returns true iff the runtime mount (via `detectMountBase()`) matches
+ * the build-time base. When false, callers must short-circuit any
+ * `registerSW` / `useRegisterSW` invocation.
+ *
+ * @param pathname  Optional pathname passed through to `detectMountBase`
+ *                  for tests that need to assert specific mounts without
+ *                  touching `window.location`.
+ */
+export function shouldRegisterServiceWorker(pathname?: string): boolean {
+  const runtime = detectMountBase(pathname);
+  return runtime === BUILD_TIME_BASE;
+}
+
+/**
+ * Unregister any service worker whose registered scope doesn't match the
+ * current runtime mount.
+ *
+ * The shape we're cleaning up after: a user on 0.1.1 or earlier installed
+ * Notes via parachute-app at `/app/notes/`, the bundle auto-registered
+ * the SW (build-time-scoped to `/notes/` via `vite.config.ts`'s `basePath`)
+ * at `/app/notes/`, and the SW now intercepts every fetch under
+ * `/app/notes/` with a precache table built for `/notes/`. Result: HTML
+ * served for JS-module requests, MIME errors, broken OAuth callbacks.
+ *
+ * We unregister any SW whose normalised scope-pathname differs from the
+ * runtime mount AND looks like a parachute mount we recognise
+ * (`/notes` or `/app/<slug>`). The "looks like ours" guard keeps us
+ * from clobbering an unrelated SW that happens to be registered on the
+ * same origin.
+ *
+ * Operators auto-recover on next page load: the stale SW unregisters,
+ * the next reload is served fresh, and `shouldRegisterServiceWorker()`
+ * declines to re-register at the wrong mount.
+ *
+ * @returns the number of registrations unregistered (for logging + tests).
+ */
+export async function cleanupStaleServiceWorker(
+  navigatorRef: Navigator | undefined = typeof navigator === "undefined" ? undefined : navigator,
+  pathname?: string,
+): Promise<number> {
+  if (!navigatorRef || !("serviceWorker" in navigatorRef)) return 0;
+  const container = navigatorRef.serviceWorker;
+  if (!container || typeof container.getRegistrations !== "function") return 0;
+  const runtimeMount = detectMountBase(pathname);
+  const registrations = await container.getRegistrations();
+  let unregistered = 0;
+  for (const registration of registrations) {
+    try {
+      const scopeUrl = new URL(registration.scope);
+      const scopePath = scopeUrl.pathname.replace(/\/$/, "") || "/";
+      if (scopePath === runtimeMount) continue;
+      // Only touch SWs whose scope looks like a parachute mount we
+      // recognise — be conservative about clobbering unrelated SWs on
+      // the same origin.
+      const looksLikeParachuteMount =
+        /^\/notes$/.test(scopePath) || /^\/app\/[a-z0-9][a-z0-9_-]*$/.test(scopePath);
+      if (!looksLikeParachuteMount) continue;
+      await registration.unregister();
+      unregistered += 1;
+      if (typeof console !== "undefined") {
+        console.info(
+          `[notes-ui] unregistered stale service worker at scope ${registration.scope} ` +
+            `(runtime mount is ${runtimeMount})`,
+        );
+      }
+    } catch (err) {
+      if (typeof console !== "undefined") {
+        console.warn(`[notes-ui] failed to inspect/unregister SW: ${String(err)}`);
+      }
+    }
+  }
+  return unregistered;
+}

--- a/packages/notes-ui/src/main.tsx
+++ b/packages/notes-ui/src/main.tsx
@@ -1,10 +1,24 @@
 import { App } from "@/app/App";
+import { cleanupStaleServiceWorker } from "@/lib/sw-bootstrap";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "@/styles/index.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("#root element not found");
+
+// Fire-and-forget: unregister any stale `/notes/`-scoped service worker
+// left behind by a pre-0.1.2 install when the bundle is now being served
+// at a different mount (e.g. `/app/notes/`). Without this, operators
+// upgrading via parachute-app keep hitting workbox's
+// `non-precached-url :: /notes/index.html` + "Expected JavaScript-or-Wasm
+// module, got text/html" errors until they manually unregister the SW
+// from DevTools. See `lib/sw-bootstrap.ts` for the full rationale.
+cleanupStaleServiceWorker().catch(() => {
+  // Best-effort cleanup — never block app boot. The fresh registration
+  // gate in `UpdateBanner` is the load-bearing path; this is the legacy-
+  // operator recovery affordance.
+});
 
 createRoot(root).render(
   <StrictMode>

--- a/packages/notes-ui/vite.config.ts
+++ b/packages/notes-ui/vite.config.ts
@@ -88,6 +88,17 @@ export default defineConfig({
     infoEndpointPlugin({ basePath, ...serviceInfo }),
     VitePWA({
       registerType: "prompt",
+      // App code is the only registration path: `UpdateBanner` calls
+      // `useRegisterSW` (gated by `shouldRegisterServiceWorker()` which
+      // compares the runtime mount to the build-time vite base). Tell
+      // vite-plugin-pwa NOT to auto-inject a registration script into
+      // `index.html` — otherwise that script would register the SW
+      // unconditionally at the page's current scope, which is exactly
+      // the bug we just fixed for parachute-app installs (notes 0.1.2,
+      // 2026-05-23). Belt + suspenders: even though vite-plugin-pwa's
+      // default in v1 is to skip auto-inject when `useRegisterSW` is
+      // used, declaring it explicitly here documents the contract.
+      injectRegister: false,
       includeAssets: ["icon.svg", "apple-touch-icon-180x180.png", "favicon.ico"],
       manifest: buildPwaManifest(basePath),
       workbox: {


### PR DESCRIPTION
## Summary

Fixes the OAuth-callback breakage + workbox MIME errors that hit operators running notes-ui under parachute-app at `/app/notes/`. The 0.1.1 bundle's service worker registered unconditionally at the page's current scope, but its precache table was built for `/notes/`. Result:

```
Uncaught (in promise) non-precached-url: non-precached-url :: [{"url":"/notes/index.html"}]
    at workbox-b9acee4e.js
Failed to load module script: Expected JavaScript-or-Wasm module, got "text/html"
Manifest: Line: 1, column: 1, Syntax error.
```

The SW served HTML for every navigation, including JS-module fetches and the JSON manifest, so OAuth-callback and most route loads broke under parachute-app installs.

The right long-term fix is mount-aware build-time PWA assets (parachute-app manifest-rewrite hook + multi-scope SW), but that's not in this PR. This PR ships the immediate fix: gate SW registration on the runtime mount matching the build-time vite base.

## What changed

- **`src/lib/sw-bootstrap.ts` (new)** — `shouldRegisterServiceWorker()` compares `detectMountBase()` against the build-time base (`VITE_BASE_PATH` env or `import.meta.env.BASE_URL`). `cleanupStaleServiceWorker()` unregisters any parachute-shaped SW (`/notes` or `/app/<slug>` scope) whose scope doesn't match the current runtime mount — operators on 0.1.1 auto-recover on first load.
- **`src/components/UpdateBanner.tsx`** — split into an outer gate and an inner component that calls `useRegisterSW`. React hooks can't be conditional, but the parent renders the inner component only when the gate is open. Outside the gate: no SW registration, no update banner.
- **`src/main.tsx`** — fires `cleanupStaleServiceWorker()` (fire-and-forget) before the React root mounts.
- **`vite.config.ts`** — declares `injectRegister: false` explicitly so app code is the only registration path (defensive — vite-plugin-pwa v1's default already skips auto-inject when `useRegisterSW` is used, but the explicit declaration documents the contract).
- **`package.json` + `meta.json` + `CHANGELOG.md`** — version bump to `0.1.2`. Also fixes a pre-existing version skew where `meta.json` said `0.1.0` while package was `0.1.1`.

## Cross-refs

- Aaron's OAuth-callback breakage (the workbox `non-precached-url` + MIME errors he hit 2026-05-23 under parachute-app)
- notes#159 — runtime mount detection (Vite `base: ""` + `detectMountBase()`); introduced the mount-mismatch surface that this PR fixes for SWs
- The PWA install limitation documented in 0.1.1's CHANGELOG (PWA install remains build-time-pinned; documented in 0.1.2's CHANGELOG too)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 808 pass (+14 new tests in `sw-bootstrap.test.ts`)
- [x] `bun run build` — clean; `dist/index.html` has no auto-injected SW registration script; precache table confirms `/notes/index.html` is what the SW would intercept under a mismatched runtime mount (matches Aaron's error literal)
- [ ] Manual smoke: install `@openparachute/notes-ui@0.1.2` into parachute-app and confirm OAuth callback flow completes without MIME errors
- [ ] Manual smoke: confirm legacy `/notes/` daemon mount still loads + SW still registers (existing behaviour preserved)
- [ ] Manual smoke: confirm an operator with a 0.1.1-registered SW at `/app/notes/` auto-recovers (the stale-cleanup path) on next load

## Patterns check

Touches the mount-path-convention pattern surface (notes#159 introduced it). Aligns with — doesn't change — the convention: same `dist/` works at any mount in browser; PWA install requires a build-time pin. No new pattern proposed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)