### PR TITLE
refactor(notes-ui): migrate to @openparachute/app-client helpers (closes #163, folds #162 nits)

### DIFF
--- a/packages/notes-ui/CHANGELOG.md
+++ b/packages/notes-ui/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog — @openparachute/notes-ui
 
+## [0.1.3] - 2026-05-23
+
+### Changed
+- `detectMountBase()`'s canonical (meta-tag) path now delegates to
+  `@openparachute/app-client`'s `getMountBase()` instead of parsing the
+  meta tag locally. The thin wrapper preserves the legacy `/notes`
+  fallback and keeps the existing `(pathname?, doc?)` signature so
+  existing callers' shapes are unchanged. The local regex fallback
+  stays in place for pathname-passing callers (`sw-bootstrap.ts`) —
+  app-client's helper intentionally does not read
+  `window.location.pathname`, so pathname-based detection remains a
+  notes-ui concern until every host injects the meta tag (tracked at
+  parachute-app#21, partially shipped in app#25). Closes notes#163.
+
+### Fixed
+- Removed unreachable `|| undefined` branch in `App.tsx`'s
+  `<BrowserRouter basename>`. `detectMountBase()` always returns a
+  non-empty string, so the fallback was dead (notes#162 nit).
+- Strengthened the SSR/no-window test in `base-url.test.ts` from
+  `.toBeDefined()` to `.toBe("/notes")` so the assertion actually
+  proves the legacy fallback shape (notes#162 nit).
+
+### Dependencies
+- Bumps `@openparachute/app-client` from `^0.1.0-rc.3` to
+  `^0.1.0-rc.4`. app-client rc.4 added the runtime tenancy helpers
+  (`getMountBase`, `getTenantId`, `getHubOrigin`, `getVaultUrl`) this
+  release consumes (parachute-app#27).
+
 ## [0.1.2] - 2026-05-23
 
 ### Fixed

--- a/packages/notes-ui/meta.json
+++ b/packages/notes-ui/meta.json
@@ -3,7 +3,7 @@
   "name": "notes",
   "displayName": "Notes",
   "tagline": "Notes PWA backed by your vault.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "path": "/app/notes",
   "iconUrl": "icon.svg",
   "scopes_required": ["vault:*:read", "vault:*:write"],

--- a/packages/notes-ui/package.json
+++ b/packages/notes-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/notes-ui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "type": "module",
   "description": "Parachute Notes UI bundle — the SPA installed under parachute-app as the canonical first app. No daemon, no module surface; just the built dist/.",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",
-    "@openparachute/app-client": "^0.1.0-rc.3",
+    "@openparachute/app-client": "^0.1.0-rc.4",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",
     "@codemirror/state": "^6.6.0",

--- a/packages/notes-ui/src/app/App.tsx
+++ b/packages/notes-ui/src/app/App.tsx
@@ -119,7 +119,7 @@ export function App() {
           (parachute-app with a renamed install). See `src/lib/base-url.ts`
           for the detector + the design rationale.
         */}
-        <BrowserRouter basename={detectMountBase() || undefined}>
+        <BrowserRouter basename={detectMountBase()}>
           <div className="min-h-dvh overflow-x-hidden bg-bg text-fg pb-16 md:pb-0">
             <Toaster />
             <UpdateBanner />

--- a/packages/notes-ui/src/base-url.test.ts
+++ b/packages/notes-ui/src/base-url.test.ts
@@ -90,7 +90,7 @@ describe("detectMountBase", () => {
     // Tier 1 of detection: when parachute-app injects
     // `<meta name="parachute-mount" content="/app/<name>">`, notes-ui reads it
     // directly. No regex, no guessing. The host explicitly declared the mount;
-    // we believe it. Tracked at parachute-app#NN for the injection side.
+    // we believe it. Injection side: parachute-app#25 (merged).
     const stubWith = (content: string | null | undefined, name = "parachute-mount") =>
       ({
         querySelector: (selector: string) => {

--- a/packages/notes-ui/src/base-url.test.ts
+++ b/packages/notes-ui/src/base-url.test.ts
@@ -78,8 +78,11 @@ describe("detectMountBase", () => {
       // Implicit when called with no arg in a non-browser env. We can't
       // delete `window` from jsdom mid-test without breaking other tests,
       // so cover this branch via the explicit `undefined` path the function
-      // accepts.
-      expect(detectMountBase(undefined as unknown as string | undefined)).toBeDefined();
+      // accepts. jsdom's `document` has no `<meta name="parachute-mount">`
+      // injected (the test environment leaves the document bare), so the
+      // canonical tier returns null and we fall through to the legacy
+      // default.
+      expect(detectMountBase(undefined as unknown as string | undefined)).toBe("/notes");
     });
   });
 

--- a/packages/notes-ui/src/lib/base-url.ts
+++ b/packages/notes-ui/src/lib/base-url.ts
@@ -22,53 +22,42 @@
  *   The fix: Vite emits relative asset URLs (`base: ""` → `./assets/
  *   ...`) which the browser resolves against the document's URL, and
  *   the SPA reads its own mount at runtime — either from a meta tag
- *   the host injects (canonical) or, as a fallback, by regex against
- *   `window.location.pathname`. Same bundle, any mount.
+ *   the host injects (canonical, delegated to `@openparachute/app-
+ *   client`'s `getMountBase()`) or, for callers that pass an explicit
+ *   pathname (currently sw-bootstrap), via a regex fallback against
+ *   that pathname. Same bundle, any mount.
  *
  * Detection contract:
  *
  *   `detectMountBase()` returns a path WITHOUT a trailing slash, ready
  *   to feed React Router's `basename` and to prefix OAuth callback
- *   URLs. Recognised mount shapes (regex fallback):
+ *   URLs. Recognised mount shapes (regex fallback for pathname-based
+ *   callers):
  *
  *     - `/app/<slug>` — parachute-app hosts (the future-default)
  *     - `/notes`     — legacy notes-daemon host (preserved for
  *                       back-compat through notes-daemon's retirement)
  *
  *   Slug grammar matches parachute-app's `meta-schema.ts` `PATH_PATTERN`
- *   (single segment of `[a-z0-9][a-z0-9_-]*`). A pathname under a
- *   recognised mount returns the matching prefix; anything else falls
+ *   (single segment of `[a-z0-9][a-z0-9_-]*`). Anything else falls
  *   back to `/notes` so an unmounted load (operator types the bare
  *   origin) still degrades into the historical default rather than
  *   blanking the router.
  *
- *   Server/test environments without `window` return `/notes` — the
- *   legacy default — so tests that don't explicitly stub a pathname
- *   keep the pre-refactor behaviour.
+ *   Server/test environments without a `<meta name="parachute-mount">`
+ *   tag and without an explicit pathname return `/notes` — the legacy
+ *   default — so tests that don't explicitly stub a path keep the
+ *   pre-refactor behaviour.
+ *
+ *   Canonical path (meta-tag) delegates to `@openparachute/app-client`'s
+ *   `getMountBase()` so every Parachute app reads the runtime tenancy
+ *   contract through the same library. The local regex fallback stays
+ *   here for the pathname-passing callers (sw-bootstrap) — app-client's
+ *   helper does not take a pathname; it reads the global `document`
+ *   and returns `null` when no tag is present.
  */
 
-/**
- * Detect the mount path the SPA is served under at runtime.
- *
- * Two-tier strategy:
- *
- *   1. **Canonical** — read `<meta name="parachute-mount" content="/app/<name>">`
- *      injected by parachute-app's static-serve. This is the load-bearing path
- *      once parachute-app#21 ships. Apps read what the host explicitly told them;
- *      no guessing.
- *
- *   2. **Interim fallback** — regex-detect against known parachute mount
- *      patterns from `window.location.pathname`. Works without parachute-app
- *      cooperation, but assumes the bundle knows the host's mount conventions.
- *      Will phase out once tier 1 is universal.
- *
- * Returns a path-without-trailing-slash, suitable for React Router's basename
- * and as a prefix for OAuth callback URLs.
- *
- * Future: this logic will move into `@openparachute/app-client`'s
- * `getMountBase()` helper (issue parachute-app#22). Apps consume that abstraction; this file
- * exists until that lands.
- */
+import { getMountBase } from "@openparachute/app-client";
 
 /**
  * Recognised mount-prefix patterns. Order matters — most specific first.
@@ -94,33 +83,34 @@ const LEGACY_FALLBACK = "/notes" as const;
  *
  * Two-tier resolution:
  *
- *   1. Check for `<meta name="parachute-mount" content="/app/<name>">`
- *      injected by the host (canonical contract once parachute-app#21 ships).
- *   2. Fall back to regex-matching `window.location.pathname` against the
- *      known mount patterns.
+ *   1. **Canonical** — `getMountBase()` from `@openparachute/app-client`
+ *      reads `<meta name="parachute-mount" content="/app/<name>">` from
+ *      the host-supplied document. This is the load-bearing path once
+ *      parachute-app injects the meta tag (shipped in app#25).
+ *   2. **Pathname fallback** — when a `pathname` is supplied (sw-bootstrap
+ *      passes one for the SW gate), regex-match against the recognised
+ *      mount patterns. Without a pathname and without a meta tag, fall
+ *      through to the legacy `/notes` default.
  *
  * Returns a path WITHOUT a trailing slash — the shape React Router's
  * `basename` and OAuth redirect URI building both expect.
  *
- * @param pathname  Optional pathname for the regex fallback. Tests pass this
- *                  directly without monkey-patching `window.location`.
- * @param doc       Optional Document for the meta-tag check. Tests inject a
- *                  stub to exercise the canonical branch.
+ * @param pathname  Optional pathname for the regex fallback. Tests
+ *                  (and `sw-bootstrap.ts`) pass this directly without
+ *                  monkey-patching `window.location`.
+ * @param doc       Optional Document for the meta-tag check. Tests
+ *                  inject a stub to exercise the canonical branch.
  */
 export function detectMountBase(pathname?: string, doc?: Document): string {
-  // 1. Canonical contract: read the meta tag parachute-app injects on serve.
-  //    Once parachute-app#21 ships, this is the load-bearing path.
-  if (typeof document !== "undefined" || doc !== undefined) {
-    const d = doc ?? document;
-    const meta = d.querySelector<HTMLMetaElement>('meta[name="parachute-mount"]');
-    const value = meta?.content?.trim();
-    if (value && value.startsWith("/")) {
-      return value.replace(/\/$/, "");
-    }
-  }
+  // 1. Canonical contract: meta tag, via app-client. When a `doc` stub
+  //    is supplied, forward it; otherwise app-client reads the global
+  //    document. Returns `null` when no tag is present.
+  const fromMeta = getMountBase({ doc });
+  if (fromMeta) return fromMeta;
 
-  // 2. Fallback: regex-detect from window.location.pathname.
-  //    Interim until parachute-app#21 lands.
+  // 2. Pathname fallback. Preserved locally because app-client's helper
+  //    intentionally never reads `window.location.pathname` — pathname-
+  //    based detection is interim until every host injects the meta tag.
   const path = pathname ?? (typeof window === "undefined" ? null : window.location.pathname);
   if (path == null) return LEGACY_FALLBACK;
   for (const pattern of MOUNT_PATTERNS) {

--- a/packages/notes-ui/src/lib/base-url.ts
+++ b/packages/notes-ui/src/lib/base-url.ts
@@ -125,7 +125,7 @@ export function detectMountBase(pathname?: string, doc?: Document): string {
  * for building absolute URLs (e.g. PWA manifest start_url, OAuth
  * callback construction). `/app/notes` → `/app/notes/`.
  */
-export function detectMountBaseWithSlash(pathname?: string): string {
-  const base = detectMountBase(pathname);
+export function detectMountBaseWithSlash(pathname?: string, doc?: Document): string {
+  const base = detectMountBase(pathname, doc);
   return base.endsWith("/") ? base : `${base}/`;
 }


### PR DESCRIPTION
## Summary

- Delegates `detectMountBase()`'s canonical (meta-tag) path to `@openparachute/app-client`'s `getMountBase()` — notes-ui is the first canonical Parachute app, so it reads runtime tenancy through the same library the rest of the ecosystem will. Closes [#163](https://github.com/ParachuteComputer/parachute-notes/issues/163).
- Folds two polish nits from [#162](https://github.com/ParachuteComputer/parachute-notes/issues/162) while these files were open: removes the unreachable `|| undefined` in `App.tsx`'s `<BrowserRouter basename>`, and strengthens the SSR-fallback test from `.toBeDefined()` to `.toBe("/notes")`.
- Bumps `@openparachute/app-client` from `^0.1.0-rc.3` to `^0.1.0-rc.4`. Bumps notes-ui to `0.1.3` (package.json + meta.json in lockstep).

## Migration shape

The wrapper preserves the existing `(pathname?, doc?)` signature so existing callers (`App.tsx`, `oauth.ts`, `sw-bootstrap.ts`) and their tests need no signature changes. Two-tier resolution:

1. **Canonical (meta-tag)** — delegated to `getMountBase({ doc })` from app-client. This is the load-bearing path once parachute-app injects `<meta name=\"parachute-mount\">` (shipped in [parachute-app#25](https://github.com/ParachuteComputer/parachute-app/pull/25)).
2. **Pathname fallback** — preserved locally. `sw-bootstrap.ts` feeds explicit pathnames to gate SW registration, and app-client's helper intentionally doesn't read `window.location.pathname`. The regex fallback retires entirely once every host injects the meta tag (tracked at [parachute-app#21](https://github.com/ParachuteComputer/parachute-app/issues/21)).

## Publish ordering

**Aaron must publish `@openparachute/app-client@0.1.0-rc.4` to npm BEFORE this notes-ui 0.1.3 is consumable by users.** The current published `app-client@rc` is `0.1.0-rc.3`; the local rc.4 is built and bun-linked into this checkout but not yet on the registry. Local dev resolves through bun's workspace-name link; published consumers will hit `^0.1.0-rc.4` as a concrete-semver lookup (per [RELEASING.md](https://github.com/ParachuteComputer/parachute-notes/blob/main/RELEASING.md): never `workspace:` / `link:`).

## Cross-refs

- Closes [#163](https://github.com/ParachuteComputer/parachute-notes/issues/163)
- Partial-closes [#162](https://github.com/ParachuteComputer/parachute-notes/issues/162) (nits 1 + 2; nits 3-9 remain — docstring tightening, SW navigateFallback denylist trim, `buildTimeBase()` IIFE, meta.json path-vs-base comment, sw.js precache dedup, extra `buildTimeBase()` fallback tests, `getRegistrations()` global-throw test)
- Consumes [parachute-app#27](https://github.com/ParachuteComputer/parachute-app/pull/27) — the app-client release that exports `getMountBase` / `getTenantId` / `getHubOrigin` / `getVaultUrl`
- Builds on [parachute-app#25](https://github.com/ParachuteComputer/parachute-app/pull/25) — the meta-tag injection that makes the canonical contract live

## Test plan

- [x] `bun install` resolves cleanly (local: bun-link to rc.4; published: `^0.1.0-rc.4`)
- [x] `bun run typecheck` clean
- [x] `bun run build` clean — PWA precache rebuilt, 38 entries, no warnings beyond the pre-existing chunk-size note
- [x] `bun run test` — 808/808 pass (`base-url.test.ts` 25/25, `sw-bootstrap.test.ts` 14/14)
- [x] `npm pack --dry-run` shows version `0.1.3`, `meta.json` synced to `0.1.3`, dep block is concrete semver (no `workspace:` / `link:`)
- [ ] After publish: smoke that notes-ui mounted under parachute-app (`/app/notes/`) reads the meta tag through app-client and routes correctly; legacy `/notes/` daemon mount still works via the regex fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)