### PR TITLE
docs(notes): deprecate repo — notes-ui moved to parachute-app

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,29 @@
+# parachute-notes is being archived
+
+> **Migration date: 2026-05-24**
+
+Both packages that this repo used to ship have moved or retired:
+
+## `@openparachute/notes-ui` — moved to parachute-app
+
+[`@openparachute/notes-ui`](https://www.npmjs.com/package/@openparachute/notes-ui) now ships from [`parachute-app/packages/notes-ui`](https://github.com/ParachuteComputer/parachute-app/tree/main/packages/notes-ui). The package on npm is unchanged — same name, same versioning, same Trusted Publishing flow. Only the source repo moved.
+
+Why: consolidating "host module + reference apps" in one repo. parachute-app is the host that auto-bootstraps notes-ui as the canonical first app; keeping them together mirrors what frameworks like Rails / NixOS / Next.js do with reference examples.
+
+For releases: see [`parachute-app/RELEASING.md`](https://github.com/ParachuteComputer/parachute-app/blob/main/RELEASING.md).
+
+## `@openparachute/notes` (the daemon) — deprecated
+
+[`@openparachute/notes`](https://www.npmjs.com/package/@openparachute/notes) (notes-daemon) was deprecated 2026-05-22 per [its DEPRECATED.md](./packages/notes-daemon/DEPRECATED.md). The notes-as-daemon era is over; notes is now installed via parachute-app's auto-bootstrap mechanism. Hub redirects `/notes/*` → `/app/notes/*` for backwards compat.
+
+The package stays on npm at 0.3.x — operators on legacy installs continue to work — but no new releases are planned.
+
+## What about this repo?
+
+This repo will be **archived** once the dust settles on the migration. Until then it sits read-only for historical reference. PRs and issues are closed.
+
+## If you're looking for the latest notes-ui source
+
+- npm: `bun add @openparachute/notes-ui` (no change — same package name on npm)
+- source: https://github.com/ParachuteComputer/parachute-app/tree/main/packages/notes-ui
+- changelog: https://github.com/ParachuteComputer/parachute-app/blob/main/packages/notes-ui/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,31 +1,26 @@
-# parachute-notes
+# parachute-notes — ARCHIVED
 
-Monorepo for Parachute Notes. Two npm publish targets, one shared source.
+> **This repo is being archived as of 2026-05-24.** See [DEPRECATED.md](./DEPRECATED.md) for the migration details.
 
-| Package | Publishes as | Role |
+## Where things moved
+
+| Package | Status | New location |
 |---|---|---|
-| [`packages/notes-ui`](./packages/notes-ui) | `@openparachute/notes-ui` | UI bundle only. Installed under [parachute-app](https://github.com/ParachuteComputer/parachute-app) as the canonical first app. |
-| [`packages/notes-daemon`](./packages/notes-daemon) | `@openparachute/notes` | Module-shaped wrapper that hub installs via `parachute install notes`. Ships notes-ui's `dist/` + `.parachute/module.json`. |
+| `@openparachute/notes-ui` | active, **moved** | [`parachute-app/packages/notes-ui`](https://github.com/ParachuteComputer/parachute-app/tree/main/packages/notes-ui) |
+| `@openparachute/notes` (daemon) | deprecated | [`packages/notes-daemon/DEPRECATED.md`](./packages/notes-daemon/DEPRECATED.md) |
 
-The two publish in parallel during the migration arc (see [design Section 16][s16]). Phase 1 (this layout) makes notes-ui available without disrupting the existing module. Phase 2 deprecates the module form. Phase 3 retires it.
+Both packages stay on npm; existing operators on `@openparachute/notes-ui@0.1.3` or `@openparachute/notes@0.3.x` are unaffected. Future releases of notes-ui ship from parachute-app.
+
+## Why the move
+
+Notes is the canonical first app under parachute-app's host-module pattern. After notes-daemon's deprecation arc, notes-ui was going to be the only active package in this repo — and a single-package repo is architecturally awkward when the package is conceptually a "reference app" living under the host module's purview. Consolidating in parachute-app (alongside future reference apps like calendar / tasks / etc.) keeps the layering clean.
+
+See [design Section 16][s16] for the migration arc context.
 
 [s16]: https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-apps-design.md#16-notes-migration-to-app
 
-## Working in this repo
+## For installs / development
 
-```
-bun install                # workspace install (bun's --filter is what scripts dispatch through)
-bun run dev                # vite dev for notes-ui
-bun run build              # builds notes-ui dist/, then copies it into notes-daemon/dist
-bun run test               # notes-ui vitest suite (842 tests), then notes-daemon smoke test
-bun run typecheck          # notes-ui only — daemon has no TS source
-bun run lint               # biome over notes-ui
-```
-
-The development guide, mount-path convention, tag-roles primitive, and per-vault settings doc all live in [`packages/notes-daemon/README.md`](./packages/notes-daemon/README.md) — that's where the SPA + module surface is documented end-to-end.
-
-## Release flow
-
-Pre-1.0 governance applies: every code-touching PR bumps the rc chain. Both packages bump in lockstep on a structural-restructure PR like this one; thereafter they bump independently. See [parachute-patterns/patterns/governance.md][gov] for the canonical rules.
-
-[gov]: https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md
+- `bun add @openparachute/notes-ui` works exactly as before — same npm package, same versions
+- Source / issues / PRs: https://github.com/ParachuteComputer/parachute-app
+- Build / test / dev: see [`parachute-app/RELEASING.md`](https://github.com/ParachuteComputer/parachute-app/blob/main/RELEASING.md) + the workspace conventions in `parachute-app/CLAUDE.md`


### PR DESCRIPTION
## Summary

parachute-notes is being archived. Both packages have moved or retired:

- `@openparachute/notes-ui` → moved to [parachute-app/packages/notes-ui](https://github.com/ParachuteComputer/parachute-app/tree/main/packages/notes-ui) (see [parachute-app#32](https://github.com/ParachuteComputer/parachute-app/pull/32))
- `@openparachute/notes` (daemon) → already deprecated 2026-05-22 per `packages/notes-daemon/DEPRECATED.md`

Adds top-level `DEPRECATED.md` + rewrites `README.md` to point at the new home.

The npm packages stay on the registry; existing operators are unaffected. Only the source repo is being retired.

## Test plan

- [x] Markdown only — no code changes
- [x] Doc-only PR; skips rc per governance

🤖 Generated with [Claude Code](https://claude.com/claude-code)